### PR TITLE
The `/api/source_code`-endpoint now references a specific commit instead of the base

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,3 +52,5 @@ jobs:
                   file: "${{ inputs.context }}/${{ inputs.dockerfile }}"
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  build-args: |
+                      GIT_COMMIT_SHA=${{ github.sha }}

--- a/server/Dockerfile.server
+++ b/server/Dockerfile.server
@@ -1,7 +1,10 @@
+
+
 FROM rust:1.58 AS build
 WORKDIR /navigatum-server
 COPY . .
-
+ARG GIT_COMMIT_SHA
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}
 # get api_data.json
 ADD https://roomapi.tum.sexy/cdn/api_data.json data/api_data.json
 # For local testing if roomapi is not avalible:

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,7 +5,6 @@ use std::fs;
 
 use actix_cors::Cors;
 use actix_web::{get, http, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Result};
-use serde_json::to_string;
 use structopt::StructOpt;
 
 mod feedback;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,9 +1,11 @@
 #[macro_use]
 extern crate lazy_static;
+
 use std::fs;
 
 use actix_cors::Cors;
 use actix_web::{get, http, middleware, web, App, HttpRequest, HttpResponse, HttpServer, Result};
+use serde_json::to_string;
 use structopt::StructOpt;
 
 mod feedback;
@@ -61,7 +63,14 @@ async fn search_handler(
 
 #[get("/api/source_code")]
 async fn source_code_handler() -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().body("https://github.com/TUM-Dev/navigatum-server".to_string()))
+    let gh_base = "https://github.com/TUM-Dev/navigatum".to_string();
+    let commit_hash = std::env::var("GIT_COMMIT_SHA");
+    if commit_hash.is_ok() {
+        let github_link = format!("{}{}{}", gh_base, "/tree/", commit_hash.unwrap());
+        Ok(HttpResponse::Ok().body(github_link))
+    } else {
+        Ok(HttpResponse::Ok().body(gh_base))
+    }
 }
 
 #[get("/health")]


### PR DESCRIPTION
The Commit data can be supplied via an environment variable given in the docker build.
If no variable is given the plain reposittory should be shown

resolves #25 