### PR TITLE
Minor restyling of the search results

### DIFF
--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -70,7 +70,7 @@
                          autocomplete="off">
                   <i class="form-icon icon icon-search"></i>
                   <button class="btn btn-primary input-group-btn btn-lg"
-                          @click="searchGo(true)">
+                          @click="searchGo(false)">
                     ${{_.search.action}}$
                   </button>
                 </div>

--- a/webclient/src/modules/autocomplete.js
+++ b/webclient/src/modules/autocomplete.js
@@ -124,7 +124,7 @@ navigatum.registerModule("autocomplete", (function() {
                     if (navigatum.app.search.autocomplete.highlighted !== null) {
                         navigatum.app.searchGoTo(navigatum.app.search.autocomplete.highlighted, true);
                     } else {
-                        navigatum.app.searchGo(true);
+                        navigatum.app.searchGo(false);
                     }
                     break;
             }

--- a/webclient/src/views/search/view-search.inc
+++ b/webclient/src/views/search/view-search.inc
@@ -1,6 +1,12 @@
 <div id="view-search" v-if="search_data">
 
   <h1>${{ _.view_search.search_for }}$ <i>"{{ query }}"</i></h1>
+  
+  <small class="search_meta">
+    ${{ _.view_search.runtime }}$: {{ search_data.time_ms }}ms –
+    <a onclick="open_feedback('search')" class="c-hand">${{_.view_search.give_feedback}}$</a>
+  </small>
+
   <div class="divider"></div>
   
   <template v-for="s in sections">
@@ -46,10 +52,4 @@
       </div>
     </section>
   </template>
-  
-  <small class="search_meta">
-    ${{ _.view_search.runtime }}$: {{ search_data.time_ms }}ms –
-    <a onclick="open_feedback('search')" class="c-hand">${{_.view_search.give_feedback}}$</a>
-  </small>
-
 </div>

--- a/webclient/src/views/search/view-search.inc
+++ b/webclient/src/views/search/view-search.inc
@@ -1,14 +1,9 @@
 <div id="view-search" v-if="search_data">
-
-  <h1>${{ _.view_search.search_for }}$ <i>"{{ query }}"</i></h1>
-  
   <small class="search_meta">
     ${{ _.view_search.runtime }}$: {{ search_data.time_ms }}ms –
     <a onclick="open_feedback('search')" class="c-hand">${{_.view_search.give_feedback}}$</a>
   </small>
 
-  <div class="divider"></div>
-  
   <template v-for="s in sections">
     <section>
       <div class="columns">

--- a/webclient/src/views/search/view-search.js
+++ b/webclient/src/views/search/view-search.js
@@ -39,11 +39,7 @@ navigatum.registerView('search', {
         loadSearchData: function(query, data) {
             this.search_data = data;
             this.query = query;
-            var search= document.getElementById("search")
-            if (search.value.length === 0) {
-                // /search/:querry is called from an internal url and thus the search url is not set
-                search.value = query;
-            }
+            navigatum.app.search.query = query;
             navigatum.setTitle('${{ _.view_search.search_for }}$ "' + query + '"');
             
             // Currently borrowing this functionality from autocomplete.

--- a/webclient/src/views/search/view-search.js
+++ b/webclient/src/views/search/view-search.js
@@ -39,7 +39,11 @@ navigatum.registerView('search', {
         loadSearchData: function(query, data) {
             this.search_data = data;
             this.query = query;
-            
+            var search= document.getElementById("search")
+            if (search.value.length === 0) {
+                // /search/:querry is called from an internal url and thus the search url is not set
+                search.value = query;
+            }
             navigatum.setTitle('${{ _.view_search.search_for }}$ "' + query + '"');
             
             // Currently borrowing this functionality from autocomplete.

--- a/webclient/src/views/search/view-search.scss
+++ b/webclient/src/views/search/view-search.scss
@@ -71,7 +71,6 @@
     
     small.search_meta {
         display: block;
-        margin-top: 30px;
         //color: $text-gray;
         
         a {


### PR DESCRIPTION
pushed the runtime and feedback up next to what we searched for (like…google)

Before: 
![Screenshot_20220204_220127](https://user-images.githubusercontent.com/26258709/152603075-4c83a612-def2-4fda-abf5-01a0f8780f22.png)

After:
![Screenshot_20220204_220040](https://user-images.githubusercontent.com/26258709/152603081-bb65b24c-c190-43af-ad9c-54538187729c.png)
