### PR TITLE
Add fullscreen button on mobile

### DIFF
--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -56,6 +56,12 @@ navigatum.registerModule("interactive-map", (function() {
             });
             const nav = new mapboxgl.NavigationControl();
             map.addControl(nav, 'top-left');
+            
+            // Fullscreen currently only on mobile
+            if (window.matchMedia &&
+                window.matchMedia("only screen and (max-width: 480px)").matches) {
+                map.addControl(new mapboxgl.FullscreenControl());
+            }
             //const location = new mapboxgl.GeolocateControl({
             //    positionOptions: {
             //    enableHighAccuracy: true


### PR DESCRIPTION
This adds a fullscreen button on the mobile page:
![image](https://user-images.githubusercontent.com/7429408/153278794-ab5419e6-8e4a-4339-a5b8-33135864107a.png)

I'm not sure whether this button makes sense on desktop, too, because it goes to fullscreen mode entirely in the browser, which is a bit uncommon.