### PR TITLE
Made the webclient accept the Accept_language header

### DIFF
--- a/webclient/nginx.conf
+++ b/webclient/nginx.conf
@@ -14,6 +14,40 @@ http {
   access_log  /var/log/nginx/access.log  main;
   sendfile        on;
   keepalive_timeout  65;
+
+  # theme detection
+  map $cookie_theme $THEME {
+    default "light";
+
+    "dark" "dark";
+    "light" "light";
+  }
+
+  # language detection. The accept_language header sucks.
+  # This map will only be used if $cookie_lang is unset
+  map $http_accept_language $ACCEPT_LANG {
+    default "de";
+
+    "~*.*de;.*en.*" "de";
+    "~*.*en;.*de.*" "en";
+    "~*.*de,.*en.*" "de";
+    "~*.*en,.*de.*" "en";
+    "~*.*de-.*en.*" "de";
+    "~*.*en-.*de.*" "en";
+    "~*.*de;.*" "de";
+    "~*.*en;.*" "en";
+    "~*.*de,.*" "de";
+    "~*.*en,.*" "en";
+    "~*.*de.*" "de";
+    "~*.*en.*" "en";
+  }
+
+  map $cookie_lang $LANG {
+    default "${ACCEPT_LANG}";
+    "en" "en";
+    "de" "de";
+  }
+
   server {
     listen       80;
 
@@ -31,14 +65,6 @@ http {
       return 200 'healthy';
     }
 
-    set $THEME "light";
-    if ($cookie_theme = "dark") {
-      set $THEME "dark";
-    }
-    set $LANG "de";
-    if ($cookie_lang = "en") {
-      set $LANG "en";
-    }
     location / {
       index /index-view-main-$THEME-$LANG.html;
       try_files $uri $uri/ /index-view-main-$THEME-$LANG.html;

--- a/webclient/nginx.conf
+++ b/webclient/nginx.conf
@@ -28,18 +28,10 @@ http {
   map $http_accept_language $ACCEPT_LANG {
     default "de";
 
-    "~*.*de;.*en.*" "de";
-    "~*.*en;.*de.*" "en";
-    "~*.*de,.*en.*" "de";
-    "~*.*en,.*de.*" "en";
-    "~*.*de-.*en.*" "de";
-    "~*.*en-.*de.*" "en";
-    "~*.*de;.*" "de";
-    "~*.*en;.*" "en";
-    "~*.*de,.*" "de";
-    "~*.*en,.*" "en";
-    "~*.*de.*" "de";
-    "~*.*en.*" "en";
+    "~.*de.*en.*" "de";
+    "~.*en.*de.*" "en";
+    "~.*de.*" "de";
+    "~.*en.*" "en";
   }
 
   map $cookie_lang $LANG {


### PR DESCRIPTION
I am sorry this seems to be the "prettyest" way to get this done. There is a module to do this, but it essentially also does regexes (but a bit more efficiently since it can actually parse the content). The plugin however seems to be abandoned and installing it is not documented in a working way.

We might want to clean up the regex used for the`$ACCEPT_LANG` detection. Not from a performance but from a readability standpoint. This would make us less compliant to the standard, but this would imo still be acceptable.
resolves #47