### PR TITLE
Fixed ngnix routing

### DIFF
--- a/webclient/nginx.conf
+++ b/webclient/nginx.conf
@@ -51,24 +51,47 @@ http {
     server_name  roomapi.tum.sexy localhost;
     root /app;
 
-    location /health {
+    # metadata
+    location = /robots.txt { access_log off; }
+    # These Files are intenitonally not supported
+    location = /adds.txt { log_not_found off; access_log off; }
+    location = /app-ads.txt  { log_not_found off; access_log off; }
+
+    # for the webclient-healthcheck
+    location = /health {
       access_log off;
       add_header Content-Type text/plain;
       return 200 'healthy';
     }
 
-    location / {
-      index /index-view-main-$THEME-$LANG.html;
-      try_files $uri $uri/ /index-view-main-$THEME-$LANG.html;
+    location = / {
+      alias /index-view-main-$THEME-$LANG.html;
     }
 
-    # These Fieles areintenitonally not supported
-    location = /adds.txt { log_not_found off; access_log off; }
-    location = /app-ads.txt  { log_not_found off; access_log off; }
+    location ^~ /search/ {
+      alias /index-view-search-$THEME-$LANG.html;
+    }
+
+    location ^~ /about/  {
+      alias /index-view-md-$THEME-$LANG.html;
+    }
+
+    location ~ ^/(view|campus|site|building|room)/.*$  {
+      alias /index-view-view-$THEME-$LANG.html;
+    }
+
+    location ~ ^/(assets|js|css|.well-known|pages)/.*$  {
+      try_files $uri $uri/ /404.html;
+    }
 
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
-      root   /usr/share/nginx/html;
+      root /usr/share/nginx/html;
+    }
+
+    error_page 404 /index-view-404-$THEME-$LANG.html;
+    location = /404.html {
+      return 404;
     }
   }
 }

--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+    <meta name="from-view" content="<!-- @echo view -->">
     <!-- @if view="main" -->
     <!-- For some reason currently only works with Chrome -->
     <link rel="preload" href="<!-- @echo api_prefix -->get/root" as="fetch" crossorigin>


### PR DESCRIPTION
refactors how the ngnix config is layed out
Furthermore all requests are routed to the correct file

For 404 urls, the 404-view still looks like on 

- https://roomapi.tum.sexy/building/m 
- or https://roomapi.tum.sexy/bug/m

The differing 404 views should be fixed in another PR imo, but we can put this in this PR if you like