### PR TITLE
restyling of the 404-page

### DIFF
--- a/webclient/src/views/404/i18n-404.yaml
+++ b/webclient/src/views/404/i18n-404.yaml
@@ -1,1 +1,13 @@
-view_404: {}
+view_404:
+  header:
+    de: "Die angeforderte Website steht nicht zur verfügung"
+    en: "The requested website could not to be found."
+  description:
+    de: "Dies könnte sein, weil wir einen Fehler gemacht haben."
+    en: "This could be because we made a mistake."
+  call_to_action:
+    de: "Falls du denkst, das dies ein fehler ist teile es uns doch hier mit"
+    en: "If you think this is a mistake, please let us know here"
+  got_here: # "\\\\n" renders to "\n"
+    de: "Ich habe diesen Fehler so gefunden:\\\\n1. ..."
+    en: "I have found the error by:\\\\n1. ..."

--- a/webclient/src/views/404/i18n-404.yaml
+++ b/webclient/src/views/404/i18n-404.yaml
@@ -1,12 +1,12 @@
 view_404:
   header:
-    de: "Die angeforderte Website steht nicht zur verfügung"
+    de: "Die angeforderte Seite wurde nicht gefunden."
     en: "The requested website could not to be found."
   description:
     de: "Dies könnte sein, weil wir einen Fehler gemacht haben."
     en: "This could be because we made a mistake."
   call_to_action:
-    de: "Falls du denkst, das dies ein fehler ist teile es uns doch hier mit"
+    de: "Falls du denkst, dass dies ein Fehler ist, teile es uns doch hier mit"
     en: "If you think this is a mistake, please let us know here"
   got_here: # "\\\\n" renders to "\n"
     de: "Ich habe diesen Fehler so gefunden:\\\\n1. ..."

--- a/webclient/src/views/404/view-404.inc
+++ b/webclient/src/views/404/view-404.inc
@@ -1,3 +1,14 @@
 <div id="view-404">
-    <h5 style="margin-top: 25px">404</h5>
+    <div class="toast toast-error">
+      ${{_.core_js.error.404}}$
+    </div>
+    <h5 style="margin-top: 25px">${{_.view_404.header}}$</h5>
+    <p>
+        ${{_.view_404.description}}$
+    </p>
+    <button onclick="open_feedback('bug', `404 on ${window.location.href}`, '${{_.view_404.got_here}}$')"
+            class="btn btn-link p-0"
+            aria-label="Open the feedback-form">
+      ${{_.view_404.call_to_action}}$
+    </button>
 </div>


### PR DESCRIPTION
made the 404-view look more like the 404 toast and included a link to the feedback-form

resolves #57 

Screenshots:
![Screenshot_20220311_001207](https://user-images.githubusercontent.com/26258709/157771299-99b2a77c-059a-47ad-aea2-eb091414827c.png)
![Screenshot_20220311_001242](https://user-images.githubusercontent.com/26258709/157771306-76e63627-0ce1-4637-a5d4-af916faa33a4.png)
![Screenshot_20220311_001320](https://user-images.githubusercontent.com/26258709/157771309-25f58659-3a68-40a4-a498-d5006175f309.png)
![Screenshot_20220311_001338](https://user-images.githubusercontent.com/26258709/157771311-9fe608d8-8a48-4570-8ff3-b0db0b74f5ff.png)