### PR TITLE
Improve display of results in search for searches by arch name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1204,7 +1204,7 @@ components:
               description: 'Subtext to show below the search (by default in bold and after the non-bold subtext). Usually contains the arch-id of the room, which is another common room id format, and supports highlighting.'
               type: string
             parsed_id:
-              description: 'This is an optional feature, that is only supported for some rooms. It might be displayed instead or before the name, to show that a different room id format has matched, that was probably used. See the image below for an example. Supports highlighting.'
+              description: 'This is an optional feature, that is only supported for some rooms. It might be displayed instead or before the name, to show that a different room id format has matched, that was probably used. See the image below for an example. It will be cropped to a maximum length to not take too much space in UIs. Supports highlighting.'
               type: string
     SitesBuildingsEntry:
       type: object

--- a/server/src/search.rs
+++ b/server/src/search.rs
@@ -150,11 +150,10 @@ pub async fn do_benchmarked_search(args: SearchQueryArgs) -> SearchResults {
 // size=100 seems to be about 10M
 #[cached(size = 500)]
 async fn execute_search(args: SearchQueryArgs) -> Vec<SearchResultsSection> {
-    let (q,sanitised_args) = sanitise_args(args);
+    let (q, sanitised_args) = sanitise_args(args);
     let parsed = parse_input_query(q);
     return do_geoentry_search(&parsed.tokens, sanitised_args).await;
 }
-
 
 fn sanitise_args(args: SearchQueryArgs) -> (String, SanitisedSearchQueryArgs) {
     let sanitised_args = SanitisedSearchQueryArgs {
@@ -396,8 +395,12 @@ async fn do_geoentry_search(
         }; // No duplicates
 
         // Total limit reached (does only count visible results)
-        if section_rooms.entries.len() + section_buildings.n_visible.unwrap_or_else(|| { section_buildings.entries.len() })
-            >= args.limit_all {
+        if section_rooms.entries.len()
+            + section_buildings
+                .n_visible
+                .unwrap_or_else(|| section_buildings.entries.len())
+            >= args.limit_all
+        {
             break;
         }
 
@@ -611,10 +614,7 @@ fn highlight_matches(s: &String, search_tokens: &Vec<SearchToken>) -> String {
 
 // Parse the search against some known room formats and improve the
 // results display in this case. Room formats are hardcoded for now.
-fn parse_room_formats(
-    search_tokens: &Vec<SearchToken>,
-    hit: &MSHit,
-) -> Option<String> {
+fn parse_room_formats(search_tokens: &Vec<SearchToken>, hit: &MSHit) -> Option<String> {
     // Some building specific roomcode formats are determined by their building prefix
     if search_tokens.len() == 2
         && match search_tokens[0].s.as_str() {
@@ -639,7 +639,6 @@ fn parse_room_formats(
             arch_id.get(..search_tokens[1].s.len()).unwrap(),
             arch_id.get(search_tokens[1].s.len()..).unwrap_or_default(),
         ))
-
     }
     // If it doesn't match some precise room format, but the search is clearly
     // matching the arch name and not the main name, then we highlight this arch name.
@@ -671,8 +670,8 @@ fn parse_room_formats(
                 _ => match hit.name.get(..4).unwrap_or_default() {
                     "5101" => Some("PH "),
                     "5107" => Some("PH II "),
-                    _ => None
-                }
+                    _ => None,
+                },
             };
             if prefix.is_some() {
                 (prefix, arch_id.to_string())
@@ -681,11 +680,17 @@ fn parse_room_formats(
                 // look nice. Since this building name here serves only as a
                 // hint, we'll crop it (with more from the end, because there
                 // is usually more entropy)
-                (None, format!(
-                    "{} {}…{}",
-                    arch_id,
-                    hit.parent_building[0].get(..7).unwrap(),
-                    hit.parent_building[0].get((hit.parent_building[0].len()-10)..).unwrap()))
+                (
+                    None,
+                    format!(
+                        "{} {}…{}",
+                        arch_id,
+                        hit.parent_building[0].get(..7).unwrap(),
+                        hit.parent_building[0]
+                            .get((hit.parent_building[0].len() - 10)..)
+                            .unwrap()
+                    ),
+                )
             } else {
                 (None, format!("{} {}", arch_id, hit.parent_building[0]))
             }
@@ -694,7 +699,9 @@ fn parse_room_formats(
             "{}\u{0019}{}\u{0017}{}",
             prefix.unwrap_or_default(),
             parsed_arch_id.get(..search_tokens[0].s.len()).unwrap(),
-            parsed_arch_id.get(search_tokens[0].s.len()..).unwrap_or_default(),
+            parsed_arch_id
+                .get(search_tokens[0].s.len()..)
+                .unwrap_or_default(),
         ))
     } else {
         None

--- a/server/src/search.rs
+++ b/server/src/search.rs
@@ -637,7 +637,7 @@ fn parse_room_formats(search_tokens: &Vec<SearchToken>, hit: &MSHit) -> Option<S
             "\u{0019}{} {}\u{0017}{}",
             search_tokens[0].s.to_uppercase(),
             arch_id.get(..search_tokens[1].s.len()).unwrap(),
-            arch_id.get(search_tokens[1].s.len()..).unwrap_or_default(),
+            arch_id.get(search_tokens[1].s.len()..).unwrap(),
         ))
     }
     // If it doesn't match some precise room format, but the search is clearly

--- a/server/src/search.rs
+++ b/server/src/search.rs
@@ -423,34 +423,8 @@ async fn do_geoentry_search(
             }
             "room" | "virtual_room" => {
                 if section_rooms.entries.len() < args.limit_rooms {
-                    // Test whether the query matches some common room id formats.
-                    // This is hardcoded here for now and should be changed in the future.
-                    let parsed_id = if search_tokens.len() == 2
-                        && match search_tokens[0].s.as_str() {
-                            "mi" => hit.id.starts_with("560") || hit.id.starts_with("561"),
-                            "mw" => hit.id.starts_with("550") || hit.id.starts_with("551"),
-                            "ph" => hit.id.starts_with("5101"),
-                            "ch" => hit.id.starts_with("540"),
-                            _ => false,
-                        }
-                        && !search_tokens[1].s.contains("@")
-                        && hit.arch_name.is_some()
-                        && hit
-                            .arch_name
-                            .as_ref()
-                            .unwrap()
-                            .starts_with(&search_tokens[1].s)
-                    {
-                        let arch_id = hit.arch_name.as_ref().unwrap().split("@").next().unwrap();
-                        Some(format!(
-                            "\u{0019}{} {}\u{0017}{}",
-                            search_tokens[0].s.to_uppercase(),
-                            arch_id.get(..search_tokens[1].s.len()).unwrap(),
-                            arch_id.get(search_tokens[1].s.len()..).unwrap_or_default(),
-                        ))
-                    } else {
-                        None
-                    };
+                    // Test whether the query matches some common room id formats
+                    let parsed_id = parse_room_formats(&search_tokens, &hit);
 
                     section_rooms.entries.push(ResultEntry {
                         id: hit.id.to_string(),
@@ -633,4 +607,96 @@ fn highlight_matches(s: &String, search_tokens: &Vec<SearchToken>) -> String {
     }
 
     s_highlighted.to_string()
+}
+
+// Parse the search against some known room formats and improve the
+// results display in this case. Room formats are hardcoded for now.
+fn parse_room_formats(
+    search_tokens: &Vec<SearchToken>,
+    hit: &MSHit,
+) -> Option<String> {
+    // Some building specific roomcode formats are determined by their building prefix
+    if search_tokens.len() == 2
+        && match search_tokens[0].s.as_str() {
+            "mi" => hit.id.starts_with("560") || hit.id.starts_with("561"),
+            "mw" => hit.id.starts_with("550") || hit.id.starts_with("551"),
+            "ph" => hit.id.starts_with("5101"),
+            "ch" => hit.id.starts_with("540"),
+            _ => false,
+        }
+        && !search_tokens[1].s.contains("@")
+        && hit.arch_name.is_some()
+        && hit
+            .arch_name
+            .as_ref()
+            .unwrap()
+            .starts_with(&search_tokens[1].s)
+    {
+        let arch_id = hit.arch_name.as_ref().unwrap().split("@").next().unwrap();
+        Some(format!(
+            "\u{0019}{} {}\u{0017}{}",
+            search_tokens[0].s.to_uppercase(),
+            arch_id.get(..search_tokens[1].s.len()).unwrap(),
+            arch_id.get(search_tokens[1].s.len()..).unwrap_or_default(),
+        ))
+
+    }
+    // If it doesn't match some precise room format, but the search is clearly
+    // matching the arch name and not the main name, then we highlight this arch name.
+    // This is intentionally still restrictive and considers only the first token,
+    // because we expect searches for arch names not to start with anything else.
+    else if (search_tokens.len() == 1
+             || (search_tokens.len() > 1 && search_tokens[0].s.len() >= 3))
+        //     Needs to be specific enough to be considered relevant ↑
+        && !hit.name.contains(&search_tokens[0].s) // No match in the name
+        && hit.parent_building.len() > 0 // Has parent information to show in query
+        && hit.arch_name.is_some()
+        && hit
+            .arch_name
+            .as_ref()
+            .unwrap()
+            .starts_with(&search_tokens[0].s)
+    {
+        // Exclude the part after the "@" if it's not in the query and use the
+        // building name instead, because this is probably more helpful
+        let (prefix, parsed_arch_id) = if search_tokens[0].s.contains("@") {
+            (None, hit.arch_name.as_ref().unwrap().to_string())
+        } else {
+            let arch_id = hit.arch_name.as_ref().unwrap().split("@").next().unwrap();
+            // For some well known buildings we have a prefix that we can use instead
+            let prefix = match hit.name.get(..3).unwrap_or_default() {
+                "560" | "561" => Some("MI "),
+                "550" | "551" => Some("MW "),
+                "540" => Some("CH "),
+                _ => match hit.name.get(..4).unwrap_or_default() {
+                    "5101" => Some("PH "),
+                    "5107" => Some("PH II "),
+                    _ => None
+                }
+            };
+            if prefix.is_some() {
+                (prefix, arch_id.to_string())
+            } else if hit.parent_building[0].len() > 25 {
+                // Building names can sometimes be quite long, which doesn't
+                // look nice. Since this building name here serves only as a
+                // hint, we'll crop it (with more from the end, because there
+                // is usually more entropy)
+                (None, format!(
+                    "{} {}…{}",
+                    arch_id,
+                    hit.parent_building[0].get(..7).unwrap(),
+                    hit.parent_building[0].get((hit.parent_building[0].len()-10)..).unwrap()))
+            } else {
+                (None, format!("{} {}", arch_id, hit.parent_building[0]))
+            }
+        };
+        Some(format!(
+            "{}\u{0019}{}\u{0017}{}",
+            prefix.unwrap_or_default(),
+            parsed_arch_id.get(..search_tokens[0].s.len()).unwrap(),
+            parsed_arch_id.get(search_tokens[0].s.len()..).unwrap_or_default(),
+        ))
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
This PR improves how search results are displayed, if they are mainly matched by the archname and not the TUMOnline roomcode. My hope with more prominently showing the building is that it's easier to distinguish which result is the correct one.
There's still a lot of room for improvement in terms of query-dependant search result formatting, but I think this is more usefull already.

Examples before:
![image](https://user-images.githubusercontent.com/7429408/167211601-2ffaa68b-3977-4c3c-9ec0-949735c6293f.png)
![image](https://user-images.githubusercontent.com/7429408/167212813-6bbafbbd-5a8d-4b6e-9325-171f1192303f.png)

After:
![image](https://user-images.githubusercontent.com/7429408/167211620-4a969ed3-9d26-4af1-ba73-73ff608013ab.png)
![image](https://user-images.githubusercontent.com/7429408/167212836-8ed524b7-5e7b-46db-ba70-f46320e9b30a.png)

The logic is quite complex though because there are a lot of cases. This does however only affect result formatting, not ranking etc.