### PR TITLE
Add hash to JS files and assets for caching

### DIFF
--- a/webclient/gulpfile.js
+++ b/webclient/gulpfile.js
@@ -459,21 +459,20 @@ gulp.task('assets', copy_assets);
 
 // --- Revisioning Pipeline ---
 function revision_assets(done) {
-    if (config.target === "release")
-        return gulp.src(['build/index-*.html', 'build/js/*.js'])
-                   .pipe(revAll.revision({
-                       // Currently .js only, because important css is inlined, and postloaded
-                       // css is deferred using preload, which revAll currently doesn't detect
-                       includeFilesInManifest: [".js"],
-                       dontRenameFile: [".html"],
-                       transformFilename: function (file, hash) {
-                           var ext = path.extname(file.path);
-                           return "cache_" + hash.substr(0, 8) + "." + path.basename(file.path, ext) + ext;
-                       },
-                   }))
-                   .pipe(gulp.dest('build'))
-    else
+    if (config.target !== "release")
         return done();
+    return gulp.src(['build/index-*.html', 'build/js/*.js'])
+               .pipe(revAll.revision({
+                   // Currently .js only, because important css is inlined, and postloaded
+                   // css is deferred using preload, which revAll currently doesn't detect
+                   includeFilesInManifest: [".js"],
+                   dontRenameFile: [".html"],
+                   transformFilename: function (file, hash) {
+                       var ext = path.extname(file.path);
+                       return "cache_" + hash.substr(0, 8) + "." + path.basename(file.path, ext) + ext;
+                   },
+               }))
+               .pipe(gulp.dest('build'))
 }
 gulp.task('revision_assets', revision_assets);
 

--- a/webclient/gulpfile.js
+++ b/webclient/gulpfile.js
@@ -461,11 +461,11 @@ gulp.task('assets', copy_assets);
 function revision_assets(done) {
     if (config.target !== "release")
         return done();
-    return gulp.src(['build/index-*.html', 'build/js/*.js'])
+    return gulp.src(['build/index-*.html', 'build/js/*.js', 'build/assets/*'])
                .pipe(revAll.revision({
                    // Currently .js only, because important css is inlined, and postloaded
                    // css is deferred using preload, which revAll currently doesn't detect
-                   includeFilesInManifest: [".js"],
+                   includeFilesInManifest: [".js", ".webp", ".svg", ".png", ".ico"],
                    dontRenameFile: [".html"],
                    transformFilename: function (file, hash) {
                        var ext = path.extname(file.path);

--- a/webclient/nginx.conf
+++ b/webclient/nginx.conf
@@ -129,6 +129,11 @@ http {
       try_files $uri /404.html;
     }
 
+    location ~ ^/js/cache_.*$ {
+      expires 30d;
+      add_header Cache-Control "public";
+    }
+
     location ~ ^/(js|css|\.well-known|pages)/.*$ {
       try_files $uri /404.html;
     }

--- a/webclient/nginx.conf
+++ b/webclient/nginx.conf
@@ -123,18 +123,12 @@ http {
       try_files /index-view-view-$THEME-$LANG.html /404.html;
     }
 
-    location ^~ /assets/ {
-      expires 1d;
-      add_header Cache-Control "public";
-      try_files $uri /404.html;
-    }
-
-    location ~ ^/js/cache_.*$ {
+    location ~ ^/(js|assets)/cache_.*$ {
       expires 30d;
       add_header Cache-Control "public";
     }
 
-    location ~ ^/(js|css|\.well-known|pages)/.*$ {
+    location ~ ^/(js|css|assets|\.well-known|pages)/.*$ {
       try_files $uri /404.html;
     }
 

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -32,6 +32,7 @@
     "gulp-preprocess": "^4.0.2",
     "gulp-purgecss": "^4.0.3",
     "gulp-rename": "^2.0.0",
+    "gulp-rev-all": "^3.0.0",
     "gulp-sass": "^5.0.0",
     "gulp-sitemap": "^8.0.0",
     "gulp-split-files": "^1.2.3",


### PR DESCRIPTION
This renames JS files in release builds e.g. from `app-core-for-view-main-de.min.js` to `cache_f52f42ee.app-core-for-view-main-de.min.js` based on the hash of the file (we might change that filename format, it's just starting with `cache_` so it looks nicer in the nginx config).

This way we can set long cache times for them without worrying about changes.