### PR TITLE
Coordinate picker (UX flow)

### DIFF
--- a/webclient/src/core.js
+++ b/webclient/src/core.js
@@ -235,6 +235,11 @@ var navigatum = (function () {
                 expiry: now.getTime() + ttl * 3.6e+6,
             };
             localStorage.setItem(key, JSON.stringify(item));
+
+            // "storage" usually fires only across tabs, this way we
+            // force it to fire in this window as well
+            var e = new Event("storage");
+            window.dispatchEvent(e);
         },
         getLocalStorageWithExpiry: function(key, default_value=null) {
             const itemStr = localStorage.getItem(key);
@@ -248,6 +253,11 @@ var navigatum = (function () {
                 return default_value;
             }
             return item.value;
+        },
+        removeLocalStorage: function(key) {
+            localStorage.removeItem(key);
+            var e = new Event("storage");
+            window.dispatchEvent(e);
         },
         putData: function(id, data) {
             

--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -96,7 +96,7 @@ var feedback = (function() {
         const feedback_helptext = document.getElementById('feedback-helptext');
         feedback_helptext.innerText = helptextLUT[category];
 
-        const coordinate_picker=document.getElementById('feedback-coodinate-picker');
+        const coordinate_picker=document.getElementById('feedback-coordinate-picker');
         if (category === 'entry'
             && coordinate_picker.classList.contains('activate-coordinatepicker')) {
             coordinate_picker.classList.remove("d-none");
@@ -106,10 +106,10 @@ var feedback = (function() {
     }
 
     function close_form() {
-        const coordintePicker = document.getElementById("feedback-coodinate-picker");
+        const coordintePicker = document.getElementById("feedback-coordinate-picker");
         coordintePicker.classList.add("d-none");
         coordintePicker.classList.remove("activate-coordinatepicker");
-        document.getElementById("feedback-coodinate-picker-helptext").classList.add("d-none");
+        document.getElementById("feedback-coordinate-picker-helptext").classList.add("d-none");
 
         document.getElementById("feedback-modal").classList.remove("active");
         document.getElementById("feedback-success-modal").classList.remove("active");

--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -174,6 +174,8 @@ var feedback = (function() {
                     localStorage.removeItem("coordinate-feedback");
                     token = null;
                     localStorage.removeItem("feedback-token");
+                    var e = new Event("storage");
+                    window.dispatchEvent(e);
                     show_success(r.responseText);
                 } else if (r.status === 500) {
                     show_error("${{_.feedback.error.server_error}}$ (" + r.responseText + ")", false);

--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -210,5 +210,6 @@ var feedback = (function() {
     return {
         open_form: open_form,
         close_form: close_form,
+        update_feedback_form: update_feedback_form,
     }
 })();

--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -49,6 +49,7 @@ var feedback = (function() {
         show_loading(false);
 
         document.getElementById("feedback-modal").classList.add("active");
+        document.body.classList.add("no-scroll");
 
         // Token are renewed after 6 hours here to be sure, even though they may be valid
         // for longer on the server side.
@@ -113,6 +114,8 @@ var feedback = (function() {
 
         document.getElementById("feedback-modal").classList.remove("active");
         document.getElementById("feedback-success-modal").classList.remove("active");
+
+        document.body.classList.remove("no-scroll");
     }
 
     function may_close_form() {
@@ -195,6 +198,9 @@ var feedback = (function() {
     document.getElementById("feedback-cancel").addEventListener('click', close_form, false);
     document.getElementById("feedback-close").addEventListener('click', close_form, false);
     document.getElementById("feedback-overlay").addEventListener('click', may_close_form, false);
+
+    document.getElementById("feedback-close-2").addEventListener('click', close_form, false);
+    document.getElementById("feedback-overlay-2").addEventListener('click', close_form, false);
 
     document.getElementById("feedback-category").addEventListener('change', function(e) {
         update_feedback_form(e.value);

--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -98,8 +98,7 @@ var feedback = (function() {
         feedback_helptext.innerText = helptextLUT[category];
 
         const coordinate_picker=document.getElementById('feedback-coordinate-picker');
-        if (category === 'entry'
-            && coordinate_picker.classList.contains('activate-coordinatepicker')) {
+        if (category === 'entry') {
             coordinate_picker.classList.remove("d-none");
         } else {
             coordinate_picker.classList.add("d-none");
@@ -107,9 +106,7 @@ var feedback = (function() {
     }
 
     function close_form() {
-        const coordintePicker = document.getElementById("feedback-coordinate-picker");
-        coordintePicker.classList.add("d-none");
-        coordintePicker.classList.remove("activate-coordinatepicker");
+        document.getElementById("feedback-coordinate-picker").classList.add("d-none");
         document.getElementById("feedback-coordinate-picker-helptext").classList.add("d-none");
 
         document.getElementById("feedback-modal").classList.remove("active");

--- a/webclient/src/i18n.yaml
+++ b/webclient/src/i18n.yaml
@@ -57,19 +57,19 @@ feedback:
   mail: {de: "E-Mail (optional)", en: "E-Mail (optional)"}
   helptext:
     general:
-      de: "Generelles Feedback über diese website"
+      de: "Generelles Feedback über diese Website"
       en: "General Feedback about this website"
     bug:
-      de: "Welchen Fehler hast du gefunden? Wo hast du ihn gefunden? Bitte gib eine genaue Beschreibung an"
-      en: "Which bug did you find? Where did you find it? Please provide a detailed description"
+      de: "Welchen Fehler hast du gefunden? Wo hast du ihn gefunden? Bitte gib eine genaue Beschreibung an."
+      en: "Which bug did you find? Where did you find it? Please provide a detailed description."
     features:
       de: "Features, die du gerne auf dieser Website haben würdest"
-      en: "Features, you would like to see on this website"
+      en: "Features you would like to see on this website"
     search:
       de: "Feedback zur Suche. Was war dein Suchbegriff? Was hättest du als Ergebnis erwartet?"
       en: "Feedback about the search. What was your search query? What did you expect to see?"
     entry:
-      de: "Feedback zu einem Eintrag. Wir können Räume/Gebäude/Standorte hinzufügen und alle Daten, die du siehst (Namen, Coordinaten, Adressen, ...) anpassen. Was können wir verbessern?"
+      de: "Feedback zu einem Eintrag. Wir können Räume/Gebäude/Standorte hinzufügen und alle Daten, die du siehst (Namen, Koordinaten, Adressen, ...) anpassen. Was können wir verbessern?"
       en: "Feedback about an entry. We can add rooms/buildings/locations and adjust all data you see (names, coordinates, addresses, ...). What can we improve?"
   coordinatepicker:
     helptext:

--- a/webclient/src/i18n.yaml
+++ b/webclient/src/i18n.yaml
@@ -83,14 +83,14 @@ feedback:
       de: "Koordinaten bearbeiten"
       en: "Edit coordinates"
     edit_multiple_coordinates:
-      de: "Hallo, ich möchte diese Koordinaten beim Roomfinder editieren"
-      en: "Hello, I would like to edit these coordinates in the roomfinder"
+      de: "Hallo, ich möchte diese Koordinaten beim Roomfinder editieren:"
+      en: "Hello, I would like to edit these coordinates in the roomfinder:"
     add_coordinate:
-      de: "Hallo, ich möchte diese Koordinate zum Roomfinder hinzufügen"
-      en: "Hello, I would like to add this coordinate to the roomfinder"
+      de: "Hallo, ich möchte diese Koordinate zum Roomfinder hinzufügen:"
+      en: "Hello, I would like to add this coordinate to the roomfinder:"
     correct_coordinate:
-      de: "Hallo, ich möchte diese Koordinate im Roomfinder korrigieren"
-      en: "Hello, I would like to correct this coordinate in the roomfinder"
+      de: "Hallo, ich möchte diese Koordinate im Roomfinder korrigieren:"
+      en: "Hello, I would like to correct this coordinate in the roomfinder:"
   message: {de: "Nachricht", en: "Message"}
   public:
     de: "Meine Feedback Daten dürfen anonym, aber öffentlich zugänglich auf der <a href='https://github.com/TUM-Dev/navigatum/issues' target='_blank'>GitHub Projektseite</a> gespeichert werden. Mit der Nutzung dieses Feedbackformulars stimmst du explizit den <a href='https://docs.github.com/en/github/site-policy' target='_blank'>Nutzungsbedingungen und Datenschutzbestimmungen von GitHub</a> sowie einer möglichen Übertragung der Daten außerhalb der Europäischen Union zu. Falls du dies ablehnst, schreibe uns bitte über app@tum.de, oder einem der anderen in unserem  <a href='/about/impressum' target='_blank'>Impressum</a> gelisteten Kontaktmöglichkeiten."

--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -345,17 +345,27 @@
             </div>
 
             <div class="form-group">
-              <label class="form-label" for="feedback-body">${{_.feedback.message}}$</label>
+              <div>
+                <label class="form-label" for="feedback-body">${{_.feedback.message}}$</label>
+                <button id="feedback-coordinate-picker" class="btn btn-sm btn-link d-none">
+                  ${{_.feedback.coordinatepicker.title}}$
+                </button>
+              </div>
               <textarea class="form-input"
                         id="feedback-body"
                         placeholder="${{_.feedback.message}}$"
-                        rows="4">
+                        rows="6">
               </textarea>
               <p id="feedback-helptext" class="text-gray text-tiny"></p>
             </div>
 
-            <!-- only visible if called through a view, because then the context of the calling building is availible -->
-            <button id="feedback-coordinate-picker" class="d-none btn">${{_.feedback.coordinatepicker.title}}$</button>
+            <!-- only visible if called through a view, because then the context
+                 of the calling building is availible -->
+            <div id="feedback-coordinate-picker-container">
+              <button id="feedback-coordinate-picker" class="btn btn-sm d-none">
+                ${{_.feedback.coordinatepicker.title}}$
+              </button>
+            </div>
 
             <div class="form-group">
               <label class="form-checkbox" id="feedback-privacy-label">
@@ -377,10 +387,10 @@
       </div>
     </div>
     <div class="modal" id="feedback-success-modal">
-      <div id="feedback-overlay" class="modal-overlay"></div>
+      <div id="feedback-overlay-2" class="modal-overlay"></div>
       <div class="modal-container">
         <div class="modal-header">
-          <button class="btn btn-clear float-right" aria-label="Close" id="feedback-close"></button>
+          <button class="btn btn-clear float-right" aria-label="Close" id="feedback-close-2"></button>
           <div class="modal-title h5">${{_.feedback.success.title}}$</div>
         </div>
         <div class="modal-body">
@@ -388,7 +398,7 @@
             <p>${{_.feedback.success.thank_you}}$</p>
             <p>${{_.feedback.success.response_at}}$ <a id="feedback-success-url" class="btn-link" href="https://github.com/TUM-Dev/navigatum/issues">${{_.feedback.success.this_issue}}$</a></p>
             <div class="buttons">
-              <button class="btn btn-primary" id="feedback-close">${{_.feedback.success.ok}}$</button>
+              <button class="btn btn-primary" id="feedback-close-2">${{_.feedback.success.ok}}$</button>
             </div>
           </div>
         </div>

--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -325,7 +325,7 @@
           <div class="content">
             <div id="feedback-error"></div>
             <div class="form-group">
-              <div id="feedback-coodinate-picker-helptext" class="d-none toast toast-primary">${{_.feedback.coordinatepicker.helptext}}$</div>
+              <div id="feedback-coordinate-picker-helptext" class="d-none toast toast-primary">${{_.feedback.coordinatepicker.helptext}}$</div>
               <label class="form-label" for="feedback-subject">${{_.feedback.subject}}$</label>
               <div class="input-group">
                 <select class="form-select"
@@ -355,7 +355,7 @@
             </div>
 
             <!-- only visible if called through a view, because then the context of the calling building is availible -->
-            <button id="feedback-coodinate-picker" class="d-none btn">${{_.feedback.coordinatepicker.title}}$</button>
+            <button id="feedback-coordinate-picker" class="d-none btn">${{_.feedback.coordinatepicker.title}}$</button>
 
             <div class="form-group">
               <label class="form-checkbox" id="feedback-privacy-label">

--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -330,8 +330,7 @@
               <div class="input-group">
                 <select class="form-select"
                         aria-label="${{_.feedback.category}}$"
-                        id="feedback-category"
-                        onchange="updateFeedbackForm()">
+                        id="feedback-category">
                   <option value="general">${{_.feedback.type.general}}$</option>
                   <option value="bug">${{_.feedback.type.bug}}$</option>
                   <option value="features">${{_.feedback.type.features}}$</option>
@@ -396,31 +395,10 @@
       </div>
     </div>
     <script>
-        function updateFeedbackForm(category=null) {
-            if (!category) {
-                category=document.getElementById("feedback-category").value;
-            }
-            const helptextLUT = {
-                general: '${{_.feedback.helptext.general}}$',
-                bug: '${{_.feedback.helptext.bug}}$',
-                features: '${{_.feedback.helptext.features}}$',
-                search: '${{_.feedback.helptext.search}}$',
-                entry: '${{_.feedback.helptext.entry}}$',
-            };
-            const feedbackHelptext = document.getElementById('feedback-helptext');
-            feedbackHelptext.innerText = helptextLUT[category];
-
-            const coordinatePicker=document.getElementById('feedback-coodinate-picker');
-            if (category === 'entry' && coordinatePicker.classList.contains('activate-coordinatepicker')) {
-                coordinatePicker.classList.remove("d-none");
-            } else {
-                coordinatePicker.classList.add("d-none");
-            }
-        }
         function open_feedback(category, subject, body) {
             if (window.feedback) {
                 window.feedback.open_form(category, subject, body);
-                updateFeedbackForm(category);
+                window.feedback.update_feedback_form(category);
             } else {
                 window.feedback_preload = {category: category, subject: subject, body: body};
                 var s = document.createElement("script");

--- a/webclient/src/main.scss
+++ b/webclient/src/main.scss
@@ -9,6 +9,10 @@ html {
 body {
     min-height: 80%;  // optimized for desktop view, not really relevant on mobile
     position: relative;
+
+    &.no-scroll {
+        overflow-y: hidden;
+    }
 }
 
 // v-cloak is set until vue loaded

--- a/webclient/src/main.scss
+++ b/webclient/src/main.scss
@@ -239,7 +239,7 @@ body {
 }
 
 /* === Feedback === */
-#feedback-modal {
+#feedback-modal, #feedback-success-modal {
     z-index: 3000;
 
     .modal-container {
@@ -247,15 +247,16 @@ body {
         box-shadow: $feedback-box-shadow;
     }
 
-    .modal-header {
-        
+    label {
+        width: fit-content;
+        display: inline-block;
     }
 
     .buttons {
         text-align: right;
     }
 }
-#feedback-overlay {
+#feedback-overlay, #feedback-overlay-2 {
     background: $feedback-overlay-bg;
 }
 #feedback-error {
@@ -264,11 +265,22 @@ body {
 #feedback-category {
     flex: none;
 }
+#feedback-body {
+    min-width: 100%;
+}
 #feedback-privacy-label {
     font-size: 11px;
     line-height: 140%;
 }
 
+#feedback-coordinate-picker {
+    //text-align: right;
+    float: right;
+    margin-top: .5em;
+}
+#feedback-coordinate-picker-helptext {
+    font-size: 14px;
+}
 
 /* === Footer === */
 footer {

--- a/webclient/src/main.scss
+++ b/webclient/src/main.scss
@@ -70,6 +70,30 @@ body {
     border-radius: 4px;
 }
 
+// --- Toast buttons
+.toast .btn {
+    background: $toast-btn-bg;
+    color: $light-color;
+    border-color: $light-color;
+    font-weight: bold;
+
+    &:hover {
+        background: $toast-btn-bg-hover;
+        border-color: $light-color;
+    }
+
+    &:active {
+        background: $toast-btn-bg-active;
+        border-color: $light-color;
+    }
+
+    &:focus {
+        background: $toast-btn-bg;
+        border-color: $light-color;
+    }
+}
+
+
 /* === Navbar === */
 
 #navbar {
@@ -297,6 +321,13 @@ footer {
             }
         }
     }
+}
+
+
+// Animations
+@keyframes fade-in {
+    from { opacity: 0 }
+    to { opacity: 1 }
 }
 
 

--- a/webclient/src/variables.scss
+++ b/webclient/src/variables.scss
@@ -19,6 +19,9 @@ $footer-color: #fafafa;
 $footer-setting-bg-disabled: #999;
 $feedback-overlay-bg: rgba(247,248,249,.75);
 $feedback-box-shadow: 0 .2rem .5rem rgba(48,55,66,.3);
+$toast-btn-bg: #0002;
+$toast-btn-bg-hover: #0003;
+$toast-btn-bg-active: #0004;
 
 $text-gray: #aaa;
 $border-default: #e1e1e1;
@@ -42,6 +45,8 @@ $code-bg: #fcf2f2;
 $primary-color: $theme-accent;
 $body-font-color: #3b4351;
 
+$light-color: #fff;
+
 $bg-color: #f7f8f9;
 
 
@@ -58,6 +63,9 @@ $bg-color: #f7f8f9;
     $footer-setting-bg-disabled: #333;
     $feedback-overlay-bg: rgba(0, 0, 0, 0.7);
     $feedback-box-shadow: 0 .2rem .5rem rgba(0, 0, 0, 0.5);
+    $toast-btn-bg: #fff1;
+    $toast-btn-bg-hover: #fff3;
+    $toast-btn-bg-active: #0001;
 
     $text-gray: #aaa;
     $border-default: #444;

--- a/webclient/src/variables.scss
+++ b/webclient/src/variables.scss
@@ -22,6 +22,7 @@ $feedback-box-shadow: 0 .2rem .5rem rgba(48,55,66,.3);
 $toast-btn-bg: #0002;
 $toast-btn-bg-hover: #0003;
 $toast-btn-bg-active: #0004;
+$card-highlighted-bg: #f7f7f7;
 
 $text-gray: #aaa;
 $border-default: #e1e1e1;
@@ -66,6 +67,7 @@ $bg-color: #f7f8f9;
     $toast-btn-bg: #fff1;
     $toast-btn-bg-hover: #fff3;
     $toast-btn-bg-active: #0001;
+    $card-highlighted-bg: #0e0e0e;
 
     $text-gray: #aaa;
     $border-default: #444;

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -45,11 +45,22 @@ view_view:
         en: "Automatically computed based on the associated rooms or buildings"
   msg:
     correct_location:
-      de: "Um die richtige Position zu sehen, ziehe den roten Marker über die Karte. <br/> Sobald du zufrieden bist, klicke auf diese Nachricht."
-      en: "To correct the location, drag the red Marker around. <br/> Once you are satisfied, click on this toast."
+      msg:
+        de: "Um die richtige Position zu sehen, ziehe den roten Marker über die Karte."
+        en: "To correct the location, drag the red Marker around."
+      btn-done:
+        de: "Fertig"
+        en: "Done"
+      btn-cancel:
+        de: "Abbrechen"
+        en: "Cancel"
     inaccurate_only_building:
-      de: "Die angezeigte Position zeigt nur die Position des Gebäude(teils). <br/> Die genaue Lage innerhalb des Gebäudes ist uns nicht bekannt. <br/> Wenn du die genaue Position kennst, kannst du sie hinzufügen, indem du auf diesen Hinweis klickst."
-      en: "The displayed position only shows the position of the building(part). <br/> The exact position within the building is not known to us. <br/> If you know the exact position, you can add it, by clicking on this note."
+      msg:
+        de: "Die angezeigte Position zeigt nur die Position des Gebäude(teils). Die genaue Lage innerhalb des Gebäudes ist uns nicht bekannt.<br><i>Falls du sie herausfindest, kannst du die</i>"
+        en: "The displayed position only shows the position of the building(part). The exact position within the building is not known to us.<br><i>If you find it out, you can help others and</i>"
+      btn:
+        de: "Koordinate eintragen"
+        en: "Assign a coordinate"
     no_floor_overlay:
       de: "Für den angezeigten Raum gibt es leider keine Indoor Karte."
       en: "There is unfortunately no indoor map for the displayed room."

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -69,6 +69,9 @@ view_view:
         de: "Aktuell"
         en: "Currently"
       msg-2:
+        de: "ausstehende Koordinatenänderung"
+        en: "pending coordinate edit"
+      msg-2-plural:
         de: "ausstehende Koordinatenänderungen"
         en: "pending coordinate edits"
       info:

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -64,6 +64,25 @@ view_view:
     no_floor_overlay:
       de: "Für den angezeigten Raum gibt es leider keine Indoor Karte."
       en: "There is unfortunately no indoor map for the displayed room."
+    coordinate-counter:
+      msg-1:
+        de: "Aktuell"
+        en: "Currently"
+      msg-2:
+        de: "ausstehende Koordinatenänderungen"
+        en: "pending coordinate edits"
+      info:
+        de: "Änderungen werden lokal \\n für 12h gespeichert"
+        en: "Changes are stored \\n locally for 12 h"
+      delete:
+        de: "Löschen"
+        en: "Delete"
+      delete-confirm:
+        de: "Wirklich löschen?"
+        en: "Really delete?"
+      send:
+        de: "Senden"
+        en: "Send"
   slideshow:
     header:
       de: "Bilder-Showcase"

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -36,7 +36,7 @@ view_view:
         en: "(For this entry automatic patches were applied to external data)"
     coords:
       title: {de: "Koordinaten", en: "Coordinates"}
-      navigatum: {de: "NavigaTUM", en: "NavigaTUM"}
+      navigatum: {de: "NavigaTUM Mitwirkende", en: "NavigaTUM Contributors"}
       roomfinder:
         de: "Roomfinder"
         en: "Roomfinder"
@@ -46,8 +46,8 @@ view_view:
   msg:
     correct_location:
       msg:
-        de: "Um die richtige Position zu sehen, ziehe den roten Marker über die Karte."
-        en: "To correct the location, drag the red Marker around."
+        de: "Um die richtige Position zu setzen, ziehe den roten Marker über die Karte."
+        en: "To set the location, drag the red Marker around."
       btn-done:
         de: "Fertig"
         en: "Done"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -13,8 +13,13 @@
     <div class="panel-body columns">
       <div class="column col col-sm-12 msg">
         ${{_.view_view.msg.coordinate-counter.msg-1}}$
-        <em>{{ coord_counter.counter }}</em>
-        ${{_.view_view.msg.coordinate-counter.msg-2}}$
+        <em>{{ coord_counter.counter }} </em>
+        <span v-if="coord_counter.counter === 1">
+          ${{_.view_view.msg.coordinate-counter.msg-2}}$
+        </span>
+        <span v-else>
+          ${{_.view_view.msg.coordinate-counter.msg-2-plural}}$
+        </span>
         <button class="btn btn-action btn-sm btn-link tooltip tooltip-left"
                 data-tooltip=" ${{_.view_view.msg.coordinate-counter.info}}$ ">&#x1f6c8;</button>
       </div>

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -26,7 +26,7 @@
           <span class="default">${{_.view_view.msg.coordinate-counter.delete}}$</span>
           <span class="confirm">${{_.view_view.msg.coordinate-counter.delete-confirm}}$</span>
         </button>
-        <button class="btn btn-primary btn-sm" @click="entry_feedback">
+        <button class="btn btn-primary btn-sm" @click="openFeedbackForm">
           <i class="icon icon-check"></i>
           ${{_.view_view.msg.coordinate-counter.send}}$
         </button>
@@ -68,7 +68,7 @@
       <div class="column col-auto col-ml-auto">
         <button class="btn btn-link btn-action btn-sm"
                 title="${{ _.view_view.header.feedback }}$"
-                @click="entry_feedback">
+                @click="openFeedbackForm">
           <i class="icon icon-flag"></i>
         </button>
         <!--<button class="btn btn-link btn-action btn-sm"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -60,9 +60,11 @@
     <div class="column col-7 col-md-12" id="map-container">
       <div class="show-sm">
         <div class="toast toast-warning"
-             @click="entry_feedback"
              v-if="view_data.coords.accuracy && view_data.coords.accuracy === 'building'">
-          ${{_.view_view.msg.inaccurate_only_building}}$
+          ${{_.view_view.msg.inaccurate_only_building.msg}}$
+          <button class="btn btn-sm" @click="addLocationPicker">
+            ${{_.view_view.msg.inaccurate_only_building.btn}}$
+          </button>
         </div>
         <div class="toast toast-warning"
              v-if="view_data.type == 'room' && view_data.maps && view_data.maps.overlays && view_data.maps.overlays.default === null">
@@ -70,8 +72,19 @@
         </div>
       </div>
 
-      <div class="toast toast-primary mb-2" @click="confirmLocationPicker" v-if="map.interactive.marker2">
-        ${{_.view_view.msg.correct_location}}$
+      <div class="toast toast-primary mb-2 location-picker" v-if="map.interactive.marker2">
+        <div class="columns">
+          <div class="column col col-sm-12">${{_.view_view.msg.correct_location.msg}}$</div>
+          <div class="column col-auto col-sm-12 btns">
+            <button class="btn btn-sm" @click="cancelLocationPicker">
+              ${{_.view_view.msg.correct_location.btn-cancel}}$
+            </button>
+            <button class="btn btn-sm" @click="confirmLocationPicker">
+              <i class="icon icon-check"></i>
+              ${{_.view_view.msg.correct_location.btn-done}}$
+            </button>
+          </div>
+        </div>
       </div>
 
       <div id="interactive-map-container"
@@ -177,9 +190,11 @@
           </table>
           <span v-else>-</span>
           <div class="toast toast-warning"
-               @click="add"
                v-if="view_data.coords.accuracy && view_data.coords.accuracy === 'building'">
-            ${{_.view_view.msg.inaccurate_only_building}}$
+            ${{_.view_view.msg.inaccurate_only_building.msg}}$
+            <button class="btn btn-sm" @click="addLocationPicker">
+              ${{_.view_view.msg.inaccurate_only_building.btn}}$
+            </button>
           </div>
           <div class="toast toast-warning"
                v-if="view_data.type == 'room' && view_data.maps && view_data.maps.overlays && view_data.maps.overlays.default === null">

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -9,22 +9,24 @@
   </a>
 
   <!-- Pending coordinates counter (if any) -->
-  <div class="panel coord-counter">
+  <div class="panel coord-counter" v-if="coord_counter.counter">
     <div class="panel-body columns">
       <div class="column col col-sm-12 msg">
         ${{_.view_view.msg.coordinate-counter.msg-1}}$
-        <em></em>
+        <em>{{ coord_counter.counter }}</em>
         ${{_.view_view.msg.coordinate-counter.msg-2}}$
         <button class="btn btn-action btn-sm btn-link tooltip tooltip-left"
                 data-tooltip=" ${{_.view_view.msg.coordinate-counter.info}}$ ">&#x1f6c8;</button>
       </div>
       <div class="column col-auto col-sm-12 btns">
-        <button class="btn btn-link btn-sm delete">
+        <button class="btn btn-link btn-sm delete"
+                v-bind:class="{'to-confirm': coord_counter.to_confirm_delete}"
+                @click="deletePendingCoordinates">
           <i class="icon icon-cross"></i>
           <span class="default">${{_.view_view.msg.coordinate-counter.delete}}$</span>
           <span class="confirm">${{_.view_view.msg.coordinate-counter.delete-confirm}}$</span>
         </button>
-        <button class="btn btn-primary btn-sm">
+        <button class="btn btn-primary btn-sm" @click="entry_feedback">
           <i class="icon icon-check"></i>
           ${{_.view_view.msg.coordinate-counter.send}}$
         </button>

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -8,6 +8,30 @@
          class="img-responsive"/>
   </a>
 
+  <!-- Pending coordinates counter (if any) -->
+  <div class="panel coord-counter">
+    <div class="panel-body columns">
+      <div class="column col col-sm-12 msg">
+        ${{_.view_view.msg.coordinate-counter.msg-1}}$
+        <em></em>
+        ${{_.view_view.msg.coordinate-counter.msg-2}}$
+        <button class="btn btn-action btn-sm btn-link tooltip tooltip-left"
+                data-tooltip=" ${{_.view_view.msg.coordinate-counter.info}}$ ">&#x1f6c8;</button>
+      </div>
+      <div class="column col-auto col-sm-12 btns">
+        <button class="btn btn-link btn-sm delete">
+          <i class="icon icon-cross"></i>
+          <span class="default">${{_.view_view.msg.coordinate-counter.delete}}$</span>
+          <span class="confirm">${{_.view_view.msg.coordinate-counter.delete-confirm}}$</span>
+        </button>
+        <button class="btn btn-primary btn-sm">
+          <i class="icon icon-check"></i>
+          ${{_.view_view.msg.coordinate-counter.send}}$
+        </button>
+      </div>
+    </div>
+  </div>
+
   <!-- Breadcrumbs -->
   <ol class="breadcrumb"
       vocab="https://schema.org/" typeof="BreadcrumbList">

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -241,18 +241,21 @@ navigatum.registerView('view', {
                        "${{_.feedback.coordinatepicker.edit_coordinates_subject}}$";
             }
 
+            let subject_prefix = `[${this.view_data.id}]: `
+            let subject_msg = Object.keys(current_edits).length === 0
+                              ? "" : "${{_.feedback.coordinatepicker.edit_coordinate_subject}}$";
+
             // The subject backup is only loaded (and supported) when a single
             // entry is being edited
             if (this.coord_picker.suject_backup
-                && this.coord_picker.backup_id === this.view_data.id) {
+                && this.coord_picker.backup_id === this.view_data.id
+                && this.coord_picker.suject_backup !== subject_prefix) {
                 const backup = this.coord_picker.suject_backup;
                 this.coord_picker.suject_backup = null;
                 return backup;
+            } else {
+                return subject_prefix + subject_msg;
             }
-
-            let subject_msg = Object.keys(current_edits).length === 0
-                              ? "" : "${{_.feedback.coordinatepicker.edit_coordinate_subject}}$";
-            return `[${this.view_data.id}]: ${subject_msg}`;
         },
         _getFeedbackBody:function (current_edits) {
             // Look up whether there is a backup of the body and extract the section
@@ -264,7 +267,7 @@ navigatum.registerView('view', {
                 if (parts.length === 1) {
                     action_msg = parts[0];
                 } else {
-                    action_msg = parts[0] + "\n" + parts[1].split("\`\`\`").slice(1).join("\n");
+                    action_msg = parts[0] + parts[1].split("\`\`\`").slice(1).join("\n");
                 }
 
                 this.coord_picker.body_backup = null;
@@ -349,6 +352,9 @@ navigatum.registerView('view', {
             if (this.coord_counter.to_confirm_delete) {
                 navigatum.removeLocalStorage("coordinate-feedback");
                 this.coord_counter.to_confirm_delete = false;
+                this.coord_picker.body_backup = null;
+                this.coord_picker.subject_backup = null;
+                this.coord_picker.backup_id = null;
             } else {
                 this.coord_counter.to_confirm_delete = true;
             }

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -253,6 +253,10 @@ navigatum.registerView('view', {
             this.map.interactive.marker2.remove();
             this.map.interactive.marker2 = null;
         },
+        cancelLocationPicker: function() {
+            this.map.interactive.marker2.remove();
+            this.map.interactive.marker2 = null;
+        },
         loadInteractiveMap: function(from_ui) {
             var _this = this;
             var from_map = this.state.map.selected;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -113,7 +113,7 @@ navigatum.registerView('view', {
                 // the set coordinate button in the feedback form. If we didn't
                 // made a backup then, this would be lost after clicking confirm there.
                 backup_id: null,
-                suject_backup: null,
+                subject_backup: null,
                 body_backup: null,
                 force_reopen: false,
             },
@@ -214,7 +214,7 @@ navigatum.registerView('view', {
             if (window.feedback
                 && document.getElementById("feedback-modal").classList.contains("active")) {
                 this.coord_picker.backup_id = this.view_data.id;
-                this.coord_picker.suject_backup = document.getElementById("feedback-subject").value;
+                this.coord_picker.subject_backup = document.getElementById("feedback-subject").value;
                 this.coord_picker.body_backup = document.getElementById("feedback-body").value;
                 this.coord_picker.force_reopen = true;  // reopen after confirm
 
@@ -251,11 +251,11 @@ navigatum.registerView('view', {
 
             // The subject backup is only loaded (and supported) when a single
             // entry is being edited
-            if (this.coord_picker.suject_backup
+            if (this.coord_picker.subject_backup
                 && this.coord_picker.backup_id === this.view_data.id
-                && this.coord_picker.suject_backup !== subject_prefix) {
-                const backup = this.coord_picker.suject_backup;
-                this.coord_picker.suject_backup = null;
+                && this.coord_picker.subject_backup !== subject_prefix) {
+                const backup = this.coord_picker.subject_backup;
+                this.coord_picker.subject_backup = null;
                 return backup;
             } else {
                 return subject_prefix + subject_msg;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -254,7 +254,7 @@ navigatum.registerView('view', {
         },
         confirmLocationPicker: function() {
             this._openFeedbackForm(true);
-        document.getElementById("feedback-coodinate-picker-helptext").classList.remove("d-none");
+        document.getElementById("feedback-coordinate-picker-helptext").classList.remove("d-none");
             this.map.interactive.marker2.remove();
             this.map.interactive.marker2 = null;
         },
@@ -444,7 +444,7 @@ navigatum.registerView('view', {
             document.body.removeChild(textArea);
         },
         entry_feedback: function() {
-            const picker = document.getElementById("feedback-coodinate-picker");
+            const picker = document.getElementById("feedback-coordinate-picker");
             picker.onclick = this.addLocationPicker;
             picker.classList.remove("d-none");
             picker.classList.add("activate-coordinatepicker");

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -226,7 +226,11 @@ navigatum.registerView('view', {
             // Verify that there isn't already a marker (could happen if you click 'assign
             // a location' multiple times from the 'missing accurate location' toast)
             if (this.map.interactive.marker2 === null) {
-                const coords = this.view_data.coords;
+                // Coordinates are either taken from the entry, or if there are already
+                // some in the localStorage use them
+                const current_edits = navigatum.getLocalStorageWithExpiry("coordinate-feedback", {});
+
+                const coords = (current_edits[this.view_data.id] || this.view_data).coords;
                 const marker2 = new mapboxgl.Marker({
                     draggable: true,
                     color: '#ff0000',

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -96,7 +96,7 @@
                 }
 
                 .delete.to-confirm {
-                    animation: delay-btn .5s steps(1);
+                    animation: delay-btn .3s steps(1);
                     animation-fill-mode: both;
                 }
                 .delete.to-confirm .default {

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -62,6 +62,15 @@
         padding: 0 8px;
     }
 
+    .toast.location-picker {
+        animation: fade-in .1s linear .05s;
+        animation-fill-mode: both;
+
+        & .btns {
+            margin: auto 0;
+        }
+    }
+
     /* --- Interactive map display --- */
     #interactive-map-container {
         margin-bottom: 10px;

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -55,6 +55,60 @@
         }
     }
 
+    /* --- Pending coordinates counter --- */
+    .coord-counter {
+        margin: 8px 0px;
+        box-shadow: $card-shadow;
+        border: 1px solid $card-border;
+        border-radius: 4px;
+        background: $card-highlighted-bg;
+
+        & .panel-body {
+            overflow-y: visible;
+
+            & .msg {
+                margin: 15px 0;
+
+                & em {
+                    color: $theme-accent;
+                    font-style: normal;
+                    font-weight: bold;
+                }
+
+                & .btn {
+                    height: 1.3rem;
+                    width: 1.3rem;
+
+                    &::after {
+                        z-index: 2000;
+                    }
+                }
+            }
+
+            & .btns {
+                margin: auto 0 12px 0;
+
+                .delete .default {
+                    display: inline-block;
+                }
+                .delete .confirm {
+                    display: none;
+                }
+
+                .delete.to-confirm {
+                    animation: delay-btn .5s steps(1);
+                    animation-fill-mode: both;
+                }
+                .delete.to-confirm .default {
+                    display: none;
+                }
+                .delete.to-confirm .confirm {
+                    display: inline-block;
+                }
+            }
+        }
+    }
+
     /* --- Map container --- */
     #map-container {
         // This does not change anything (except using px instead of rem),
@@ -402,5 +456,17 @@
         #rooms-overview-list .panel-body {
             max-height: 275px;
         }
+    }
+}
+
+
+@keyframes delay-btn {
+    from {
+        pointer-events: none;
+        color: $text-gray;
+    }
+    to {
+        pointer-events: all;
+        color: $error-color;
     }
 }

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -114,6 +114,12 @@
         // This does not change anything (except using px instead of rem),
         // but ensures that roomfinder position calculations are predictable.
         padding: 0 8px;
+
+        // The marker2 (draggable)
+        .mapboxgl-marker + .mapboxgl-marker {
+            animation: fade-in .1s linear .05s;
+            animation-fill-mode: both;
+        }
     }
 
     .toast.location-picker {


### PR DESCRIPTION
This contains a lot of small changes, it might be easier to look at the individual commits.

Overall this PR proposes the following coordinate edit workflow:
- For each entry, you can click either the feedback button and then 'select coordinate' or the button in the 'inaccurate warning'
- After clicking 'done' in the picker, the coordinate is stored in localStorage
  - If there is only one entry in localStorage, the feedback form opens, but with the info that you can add multiple coordinates
  - If not the 'coordinate counter' at the top just increases and you can click 'send' when you're done

Screenshots:
![image](https://user-images.githubusercontent.com/7429408/169669049-c5654ba4-5d95-4b27-8f12-31afa93216aa.png)

![image](https://user-images.githubusercontent.com/7429408/169669063-bb99f1f7-b402-4122-b530-66e2074ed9f5.png)

![image](https://user-images.githubusercontent.com/7429408/169669093-34b0e68d-cd92-4f35-b476-5f78327e3aea.png)

One technical note: I sometimes change names from camelCase to under_score, because that is used in other parts of the code. I have generally used camelCase only for functions, but that is far from consistent in the codebase.