### PR TITLE
Add external links popup to OSM / Google Maps

### DIFF
--- a/webclient/src/variables.scss
+++ b/webclient/src/variables.scss
@@ -79,9 +79,9 @@ $bg-color: #f7f8f9;
 
     $image-loading-bg: #444;
     $container-loading-bg: #2a2b2f;
-    
+
     $roomfinder-selected-bg: #282c35;
-    
+
     $search-border: #353535;
     $search-border-hover: #444;
 

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -3,6 +3,7 @@ view_view:
     details_for: {de: "Details für", en: "Details for"}
   header:
     copy_link: {de: "Link kopieren", en: "Copy link"}
+    external_link: {de: "Externe Links", en: "External links"}
     feedback:
       de: "Problem melden oder Änderung vorschlagen"
       en: "Report issue or suggest changes"

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -3,7 +3,13 @@ view_view:
     details_for: {de: "Details für", en: "Details for"}
   header:
     copy_link: {de: "Link kopieren", en: "Copy link"}
-    external_link: {de: "Externe Links", en: "External links"}
+    external_link:
+      tooltip: {de: "Externe Links", en: "External links"}
+      open_in: {de: "Öffnen in", en: "Open in"}
+      other_app: {de: "Andere App ...", en: "Other app ..."}
+      share: {de: "Teilen", en: "Share"}
+      share_link: {de: "Teilen mit ...", en: "Share with ..."}
+      copied: {de: "Kopiert", en: "Copied"}
     feedback:
       de: "Problem melden oder Änderung vorschlagen"
       en: "Report issue or suggest changes"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -72,16 +72,26 @@
       </div>
       <div class="column col-auto col-ml-auto">
         <button class="btn btn-link btn-action btn-sm"
-                title="${{ _.view_view.header.external_link }}$" >
+                title="${{ _.view_view.header.external_link.tooltip }}$" >
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 3.704 3.704" fill="none" stroke="#0065bd" stroke-width=".529" stroke-linecap="round">
             <path d="M2.912 2.179v1.26H.267V.794h1.197" stroke-linejoin="round"/><path d="M1.407 2.297l2.03-2.03"/><path d="M2.352.268h1.085v1.085" stroke-linejoin="round"/>
           </svg>
         </button>
         <div class="link-popover">
+          <strong>${{ _.view_view.header.external_link.open_in }}$</strong>
           <a class="btn" target="_blank"
              :href="'https://www.openstreetmap.org/?mlat=' + view_data.coords.lat + '&mlon=' + view_data.coords.lon + '#map=17/' + view_data.coords.lat + '/' + view_data.coords.lon + '&layers=T'">OpenStreetMap</a><br>
           <a class="btn" target="_blank"
              :href="'https://www.google.com/maps/search/?api=1&query=' + view_data.coords.lat + '%2C'+ view_data.coords.lon">Google Maps</a>
+          <a class="btn"
+             :href="'geo:' + view_data.coords.lat + ','+ view_data.coords.lon">${{ _.view_view.header.external_link.other_app }}$</a>
+          <strong>${{ _.view_view.header.external_link.share }}$</strong>
+          <button class="btn" @click="share_link" v-if="browser_supports_share">
+            ${{ _.view_view.header.external_link.share_link }}$
+          </button>
+          <button class="btn" @click="copy_link"
+                  v-html="copied ? '${{ _.view_view.header.external_link.copied }}$' : '${{ _.view_view.header.copy_link }}$'">
+          </button>
         </div>
         <button class="btn btn-link btn-action btn-sm"
                 title="${{ _.view_view.header.feedback }}$"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -72,6 +72,18 @@
       </div>
       <div class="column col-auto col-ml-auto">
         <button class="btn btn-link btn-action btn-sm"
+                title="${{ _.view_view.header.external_link }}$" >
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 3.704 3.704" fill="none" stroke="#0065bd" stroke-width=".529" stroke-linecap="round">
+            <path d="M2.912 2.179v1.26H.267V.794h1.197" stroke-linejoin="round"/><path d="M1.407 2.297l2.03-2.03"/><path d="M2.352.268h1.085v1.085" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <div class="link-popover">
+          <a class="btn" target="_blank"
+             :href="'https://www.openstreetmap.org/?mlat=' + view_data.coords.lat + '&mlon=' + view_data.coords.lon + '#map=17/' + view_data.coords.lat + '/' + view_data.coords.lon + '&layers=T'">OpenStreetMap</a><br>
+          <a class="btn" target="_blank"
+             :href="'https://www.google.com/maps/search/?api=1&query=' + view_data.coords.lat + '%2C'+ view_data.coords.lon">Google Maps</a>
+        </div>
+        <button class="btn btn-link btn-action btn-sm"
                 title="${{ _.view_view.header.feedback }}$"
                 @click="openFeedbackForm">
           <i class="icon icon-flag"></i>

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -117,6 +117,7 @@ navigatum.registerView('view', {
                 body_backup: null,
                 force_reopen: false,
             },
+            browser_supports_share: "share" in navigator,
         }
     },
     beforeRouteEnter: function(to, from, next) { viewNavigateTo(to, from, next, null) },
@@ -543,6 +544,15 @@ navigatum.registerView('view', {
             }
 
             document.body.removeChild(textArea);
+        },
+        share_link: function() {
+            if (navigator.share) {
+                navigator.share({
+                    title: this.view_data.name,
+                    text: document.title,
+                    url: window.location.href,
+                });
+            }
         },
     },
     watch: {

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -48,6 +48,39 @@
             span {
                 color: $text-gray;
             }
+
+            button svg {
+                margin-top: 4px;
+                stroke: $primary-color;
+            }
+
+            .link-popover {
+                position: absolute;
+                z-index: 1000;
+                padding: 2px 10px 10px 10px;
+                width: 200px;
+                right: 24px;
+                background: $light-color;
+                box-shadow: $card-shadow-dark;
+                border-radius: 2px;
+                border: 1px solid $card-border;
+
+                visibility: hidden;
+                opacity: 0;
+                transform: translateY(-5px);
+                transition: opacity .05s, transform .05s;
+
+                & a {
+                    width: 100%;
+                    margin-top: 8px;
+                }
+            }
+
+            button:focus + .link-popover, .link-popover:hover {
+                visibility: visible;
+                opacity: 1;
+                transform: translateY(0px)
+            }
         }
 
         .divider {

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -61,7 +61,7 @@
             .link-popover {
                 position: absolute;
                 z-index: 1000;
-                padding: 2px 10px 10px 10px;
+                padding: 6px 10px;
                 width: 200px;
                 right: 36px;
                 background: $light-color;
@@ -74,9 +74,18 @@
                 transform: translateY(-5px);
                 transition: opacity .05s, transform .05s;
 
-                & a {
+                a, button {
                     width: 100%;
-                    margin-top: 8px;
+                    margin: 4px 0px;
+                }
+
+                strong {
+                    margin-top: 2px;
+                    display: block;
+
+                    & + a, & + button {
+                        margin-top: 2px;
+                    }
                 }
             }
 

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -54,12 +54,16 @@
                 stroke: $primary-color;
             }
 
+            .column:last-child {
+                position: relative;
+            }
+
             .link-popover {
                 position: absolute;
                 z-index: 1000;
                 padding: 2px 10px 10px 10px;
                 width: 200px;
-                right: 24px;
+                right: 36px;
                 background: $light-color;
                 box-shadow: $card-shadow-dark;
                 border-radius: 2px;


### PR DESCRIPTION
This adds a small popup with links to OSM and Google Maps. The Google Maps links _should_ directly open the app on Android and according to the internet also on iOS.

Currently the popup is implemented CSS only. This appeared to work, we have to see whether this causes issues.

![image](https://user-images.githubusercontent.com/7429408/172486132-7b0926a4-f72b-4850-970f-82ca6babbb65.png)

Solves #87