### PR TITLE
Maximize Map on Desktop

### DIFF
--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -5,7 +5,7 @@ navigatum.registerModule("interactive-map", (function() {
 
     // Because mapboxgl might not be loaded yet, we need to postpone
     // the declaration of the FloorControl class
-    function FloorControlInit() {
+    function floorControlInit() {
         // Add Evented functionality from mapboxgl
         FloorControl.prototype = Object.create(mapboxgl.Evented.prototype);
 
@@ -163,7 +163,7 @@ navigatum.registerModule("interactive-map", (function() {
                 const el_js = document.createElement("script");
                 el_js.src = "/* @echo app_prefix */js/mapbox/* @if target='release' */.min/* @endif */.js";
                 el_js.onload = () => {
-                    FloorControlInit();
+                    floorControlInit();
                     resolve();
                 }
                 head.appendChild(el_js);
@@ -211,11 +211,39 @@ navigatum.registerModule("interactive-map", (function() {
             const nav = new mapboxgl.NavigationControl();
             map.addControl(nav, 'top-left');
             
-            // Fullscreen currently only on mobile
-            if (window.matchMedia &&
-                window.matchMedia("only screen and (max-width: 480px)").matches) {
-                map.addControl(new mapboxgl.FullscreenControl());
+            // (Browser) Fullscreen is enabled only on mobile, on desktop the map
+            // is maximized instead. This is determined once to select the correct
+            // container to maximize, and then remains unchanged even if the browser
+            // is resized (not relevant for users but for developers).
+            const is_mobile = window.matchMedia &&
+                              window.matchMedia("only screen and (max-width: 480px)").matches;
+
+            fs_control = new mapboxgl.FullscreenControl({
+                container: is_mobile ? document.getElementById("interactive-map")
+                                     : document.getElementById("interactive-map-container")
+            });
+            fs_control.__onClickFullscreen = fs_control._onClickFullscreen;
+            fs_control._onClickFullscreen = function() {
+                if (is_mobile) {
+                    fs_control.__onClickFullscreen();
+                } else {
+                    if (fs_control._container.classList.contains("maximize")) {
+                        fs_control._container.classList.remove("maximize");
+                        document.body.classList.remove("no-scroll");
+                    } else {
+                        fs_control._container.classList.add("maximize");
+                        document.body.classList.add("no-scroll");
+                        // "instant" is not part of the spec but nonetheless implemented
+                        // by Firefox and Chrome
+                        window.scrollTo({top: 0, behavior: "instant"});
+                    }
+
+                    fs_control._fullscreen = fs_control._container.classList.contains("maximize");
+                    fs_control._changeIcon();
+                    fs_control._map.resize();
+                }
             }
+            map.addControl(fs_control);
 
             const location = new mapboxgl.GeolocateControl({
                 positionOptions: {

--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -222,10 +222,11 @@ navigatum.registerModule("interactive-map", (function() {
                 container: is_mobile ? document.getElementById("interactive-map")
                                      : document.getElementById("interactive-map-container")
             });
-            fs_control.__onClickFullscreen = fs_control._onClickFullscreen;
+            // "Backup" the mapboxgl default fullscreen handler
+            fs_control._onClickFullscreenDefault = fs_control._onClickFullscreen;
             fs_control._onClickFullscreen = function() {
                 if (is_mobile) {
-                    fs_control.__onClickFullscreen();
+                    fs_control._onClickFullscreenDefault();
                 } else {
                     if (fs_control._container.classList.contains("maximize")) {
                         fs_control._container.classList.remove("maximize");

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -143,6 +143,20 @@
 
             position: relative;
         }
+
+        &.maximize {
+            position: absolute;
+            top: -10px;
+            left: 0;
+            width: 100%;
+            height: calc(100vh - 60px);;
+            z-index: 1000;
+
+            > div {
+                padding-bottom: 0;
+                height: 100%;
+            }
+        }
     }
 
     #interactive-map {


### PR DESCRIPTION
This adds the fullscreen button to the map on desktop as well, but instead of going completely fullscreen, the map is only maximized:

![image](https://user-images.githubusercontent.com/7429408/173199349-73b35283-fb16-485b-aec2-4e1229847787.png)

It was a bit tricky to extend the FullscreenControl to do that (all my attempts of ES5 or ES6 class inheritance failed or ended in a lot of badly readable code, so I decided to modify the FullscreenControl instance).

Note it is intentional, that the map remains maximized when you go somewhere else via search. This feels a bit more like a maps app.

Solves #140 