### PR TITLE
Add possibility to add comments to entries

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1333,6 +1333,8 @@ components:
               $ref: "#/components/schemas/Coordinate"
             maps:
               $ref: "#/components/schemas/Maps"
+            comment:
+              $ref: "#/components/schemas/Comment"
           required:
             - id
             - type
@@ -1428,6 +1430,19 @@ components:
         - rank_combined
         - rank_type
         - rank_usage
+    Comment:
+      type: object
+      description: A comment to show to an entry
+      properties:
+        de:
+          description: German version of the comment
+          type: string
+        en:
+          description: English version of the comment
+          type: string
+      required:
+        - de
+        - en
     TokenRequest:
       type: object
       properties:

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -181,6 +181,12 @@
         >
           ${{_.view_view.msg.no_floor_overlay}}$
         </div>
+        <div
+          class="toast"
+          v-if="view_data.comment && view_data.comment.${{_lang_}}$"
+        >
+          {{ view_data.comment.${{_lang_}}$ }}
+        </div>
       </div>
 
       <div
@@ -363,6 +369,12 @@
             v-if="view_data.type == 'room' && view_data.maps && view_data.maps.overlays && view_data.maps.overlays.default === null"
           >
             ${{_.view_view.msg.no_floor_overlay}}$
+          </div>
+          <div
+            class="toast"
+            v-if="view_data.comment && view_data.comment.${{_lang_}}$"
+          >
+            {{ view_data.comment.${{_lang_}}$ }}
           </div>
         </div>
         <!--<div class="card-footer">


### PR DESCRIPTION
This adds a very simple, multilingual comment field for entries. I don't expect that we will use this often, but it allows to avoid cases where users could be irritated. The background is the probably wrong ID in TUMonline for MW1801 (#187).

In the Webclient:
![image](https://user-images.githubusercontent.com/7429408/184638881-7f7155fe-5158-419c-9dc3-5f848fb34cec.png)
