### PR TITLE
Fixed api loading indicator

### DIFF
--- a/webclient/gulpfile.js
+++ b/webclient/gulpfile.js
@@ -31,6 +31,7 @@ import fs from "fs";
 import merge from "merge-stream";
 import dartSass from "sass";
 import path from "path";
+import postcssRemoveDeclaration from "postcss-remove-declaration";
 import postcssPrependSelector from "postcss-prepend-selector";
 import source from "vinyl-source-stream";
 
@@ -642,13 +643,26 @@ gulp.task("map", gulp.parallel(copyMapCSS, copyMapJS));
 
 // --- api-visualiser (currently swagger-ui) Pipeline ---
 function copyApiCSS() {
+  // swagger-ui has its own loading button
+  const loadingCSS = {
+    ".swagger-ui .loading-container": "*",
+    ".swagger-ui .loading-container .loading": "*",
+    ".swagger-ui .loading-container .loading:before":"*",
+    ".swagger-ui .loading-container .loading::before":"*",
+    ".swagger-ui .loading-container .loading:after":"*",
+    ".swagger-ui .loading-container .loading::after":"*",
+  };
   return gulp
     .src("node_modules/swaggerdark/SwaggerDark.css")
     .pipe(postcss([
+      postcssRemoveDeclaration({remove: loadingCSS}),
       postcssPrependSelector({ selector: "body.theme-dark #swagger-ui " })
     ]))
     .pipe(csso())
     .pipe(addsrc.prepend("node_modules/swagger-ui-dist/swagger-ui.css"))
+    .pipe(postcss([
+      postcssRemoveDeclaration({remove: loadingCSS}),
+    ]))
     .pipe(concat("swagger-ui.min.css")) // swagger-ui is already minified => minifying here does not make sense
     .pipe(gulp.dest("build/css"));
 }

--- a/webclient/gulpfile.js
+++ b/webclient/gulpfile.js
@@ -643,7 +643,7 @@ gulp.task("map", gulp.parallel(copyMapCSS, copyMapJS));
 
 // --- api-visualiser (currently swagger-ui) Pipeline ---
 function copyApiCSS() {
-  // swagger-ui has its own loading button
+  // swagger-ui has its own loading spinner, but it is apparently broken if we included it
   const loadingCSS = {
     ".swagger-ui .loading-container": "*",
     ".swagger-ui .loading-container .loading": "*",

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -109,6 +109,7 @@
     "merge-stream": "^2.0.0",
     "postcss": "^8.4.16",
     "postcss-prepend-selector": "^0.3.1",
+    "postcss-remove-declaration" : "^1.0.0",
     "sass": "^1.52.3",
     "stylelint-scss": "^4.2.0",
     "swagger-ui-dist": "^4.13.2",

--- a/webclient/src/main.scss
+++ b/webclient/src/main.scss
@@ -20,6 +20,7 @@ body {
     display: none;
 }
 
+.loading-container,
 #loading-page {
     display: block;
     height: 100%;
@@ -28,12 +29,16 @@ body {
     pointer-events: none;
 }
 
+
+.loading-container > .loading,
 #loading-page > .loading {
     margin: 0 auto;
     display: block;
     position: static;
 }
 
+
+.loading-container > .loading::after,
 #loading-page > .loading::after {
     border-bottom-color: transparent;
     border-left-color: #ccc;

--- a/webclient/src/views/api/view-api.scss
+++ b/webclient/src/views/api/view-api.scss
@@ -2,5 +2,15 @@
 
 #view-api {
     .swagger-ui{
+         // we cannot apply loading-lg to this external dependency
+        .loading-container .loading {
+            min-height: 2rem;
+         }
+        .loading-container .loading::after {
+              height: 1.6rem;
+              margin-left: -.8rem;
+              margin-top: -.8rem;
+              width: 1.6rem;
+        }
     }
 }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/26258709/184702506-bba2cb89-bfe0-4fe4-b960-1ee02e335fc7.png)

after:
![image](https://user-images.githubusercontent.com/26258709/184702365-9187ed7e-1e9c-4903-bb0f-d6e15e1a57b1.png)

Notie, that the indicator shifts around a bit on load, which I cannot debug.