### PR TITLE
Website/API Localisation for `/api/get/:id`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: mypy --ignore-missing-imports
         language: system
         types: [python]
   - repo: https://gitlab.com/PyCQA/flake8

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -13,6 +13,7 @@ COPY sources/ sources/
 COPY external/ external/
 COPY processors/ processors/
 COPY *.py ./
+COPY translations.yaml translations.yaml
 RUN mkdir output \
     && python3 compile.py \
     && test -f "./output/search_data.json" \

--- a/data/external/downloader.py
+++ b/data/external/downloader.py
@@ -10,8 +10,8 @@ import zipfile
 from pathlib import Path
 
 import requests
-from bs4 import BeautifulSoup, element  # type:ignore
-from defusedxml import ElementTree as ET  # type:ignore
+from bs4 import BeautifulSoup, element
+from defusedxml import ElementTree as ET
 from utils import convert_to_webp
 
 TUMONLINE_URL = "https://campus.tum.de/tumonline"

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,6 +1,4 @@
-from utils import TranslatableStr
-
-_ = TranslatableStr
+from utils import TranslatableStr as _
 
 
 def compute_props(data):

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,3 +1,8 @@
+from utils import TranslatableStr
+
+_ = TranslatableStr
+
+
 def compute_props(data):
     """
     Create the "computed" value in "props".
@@ -23,27 +28,29 @@ def _append_if_present(props, computed_results, key, human_name):
 def _gen_computed_props(_id, entry, props):
     computed = []
     if "ids" in props:
-        _append_if_present(props["ids"], computed, "b_id", "Gebäudekennung")
-        _append_if_present(props["ids"], computed, "roomcode", "Raumkennung")
+        _append_if_present(props["ids"], computed, "b_id", _("Gebäudekennung"))
+        _append_if_present(props["ids"], computed, "roomcode", _("Raumkennung"))
         if "arch_name" in props["ids"]:
-            computed.append({"Architekten-Name": props["ids"]["arch_name"].split("@")[0]})
+            computed.append({_("Architekten-Name"): props["ids"]["arch_name"].split("@")[0]})
     if "b_prefix" in entry and entry["b_prefix"] != _id:
         b_prefix = [entry["b_prefix"]] if isinstance(entry["b_prefix"], str) else entry["b_prefix"]
         building_names = ", ".join([p.ljust(4, "x") for p in b_prefix])
-        computed.append({"Gebäudekennungen": building_names})
+        computed.append({_("Gebäudekennungen"): building_names})
     if "address" in props:
         address = props["address"]
-        computed.append({"Adresse": f"{address['street']}, {address['plz_place']}"})
+        computed.append({_("Adresse"): f"{address['street']}, {address['plz_place']}"})
     if "stats" in props:
-        _append_if_present(props["stats"], computed, "n_buildings", "Anzahl Gebäude")
-        _append_if_present(props["stats"], computed, "n_seats", "Sitzplätze")
+        _append_if_present(props["stats"], computed, "n_buildings", _("Anzahl Gebäude"))
+        _append_if_present(props["stats"], computed, "n_seats", _("Sitzplätze"))
         if "n_rooms" in props["stats"]:
             if props["stats"]["n_rooms"] == props["stats"]["n_rooms_reg"]:
-                computed.append({"Anzahl Räume": str(props["stats"]["n_rooms"])})
+                computed.append({_("Anzahl Räume"): str(props["stats"]["n_rooms"])})
             else:
-                n_rooms = props["stats"]["n_rooms"]
-                n_rooms_reg = props["stats"]["n_rooms_reg"]
-                computed.append({"Anzahl Räume": f"{n_rooms} ({n_rooms_reg} ohne Flure etc.)"})
+                value = _("{n_rooms} ({n_rooms_reg} ohne Flure etc.)").format(
+                    n_rooms=props["stats"]["n_rooms"],
+                    n_rooms_reg=props["stats"]["n_rooms_reg"],
+                )
+                computed.append({_("Anzahl Räume"): value})
     if "generic" in props:
         for entity in props["generic"]:
             if isinstance(entity[1], dict):
@@ -114,13 +121,16 @@ def generate_buildings_overview(data):
             n_buildings = child["props"]["stats"].get("n_buildings", 0)
             if child["type"] in {"building", "joined_building"}:
                 if n_rooms == 0:
-                    subtext = "Keine Räume bekannt"
+                    subtext = _("Keine Räume bekannt")
                 else:
-                    subtext = f"{n_rooms} Räume"
+                    subtext = _("{n_rooms} Räume").format(n_rooms=n_rooms)
             elif child["type"] == "area":
-                subtext = f"{n_buildings} Gebäude, {n_rooms} Räume"
+                subtext = _("{n_buildings} Gebäude, {n_rooms} Räume").format(n_buildings=n_buildings, n_rooms=n_rooms)
             elif child["type"] == "site":
-                subtext = f"{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)"
+                subtext = _("{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)").format(
+                    n_buildings=n_buildings,
+                    n_rooms=n_rooms,
+                )
             else:
                 raise RuntimeError(
                     f"Cannot generate buildings_overview subtext for type '{child['type']}', "

--- a/data/processors/sitemap.py
+++ b/data/processors/sitemap.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Union
 
 from compile import DEBUG_MODE
-from defusedxml import ElementTree as defusedET  # type:ignore
+from defusedxml import ElementTree as defusedET
 
 # defusedxml only supports parse()
 

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -3,4 +3,5 @@ defusedxml~=0.7.1
 lxml~=4.9.1
 Pillow~=9.2.0
 pyyaml~=6.0
+ruamel.yaml~=0.17.21
 utm~=0.7.0

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -4,7 +4,7 @@
 Gebäudekennung: Buildingcode
 Gebäudekennungen: Buildingcodes
 Raumkennung: Roomcode
-Adresse: Adress
+Adresse: Address
 Anzahl Gebäude: Number of buildings
 Sitzplätze: Seats
 Anzahl Räume: Number of rooms

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -1,0 +1,16 @@
+# de: en translation buffer
+
+# sections
+Gebäudekennung: Buildingcode
+Gebäudekennungen: Buildingcodes
+Raumkennung: Roomcode
+Adresse: Adress
+Anzahl Gebäude: Number of buildings
+Sitzplätze: Seats
+Anzahl Räume: Number of rooms
+"{n_rooms} ({n_rooms_reg} ohne Flure etc.)": "{n_rooms} ({n_rooms_reg} without corridors etc.)"
+Keine Räume bekannt: No rooms known
+"{n_rooms} Räume": "{n_rooms} rooms"
+"{n_buildings} Gebäude, {n_rooms} Räume": "{n_buildings} buildings, {n_rooms} rooms"
+"{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)": "{n_buildings} buildings, {n_rooms} rooms (branch office)"
+Architekten-Name: "Architects name"

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -13,4 +13,4 @@ Keine Räume bekannt: No rooms known
 "{n_rooms} Räume": "{n_rooms} rooms"
 "{n_buildings} Gebäude, {n_rooms} Räume": "{n_buildings} buildings, {n_rooms} rooms"
 "{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)": "{n_buildings} buildings, {n_rooms} rooms (branch office)"
-Architekten-Name: "Architects name"
+Architekten-Name: "Architect's name"

--- a/data/utils.py
+++ b/data/utils.py
@@ -20,8 +20,10 @@ class TranslatableStr(dict):
 
     The string can be formatted using the .format() method or left as is.
 
-    since subclassing from dict, this class does not need any aditional infrasturcture
+    Since it is a subclass of dict, this class does not need any additional infrastructure
     to turn a message into a translated string.
+    
+    Translatable strings will be exported as {"de": "<de string>", "en": "<en string>"}.
     """
 
     def __init__(self, message):

--- a/data/utils.py
+++ b/data/utils.py
@@ -2,6 +2,47 @@ import os
 from pathlib import Path
 
 from PIL import Image
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="rt")
+
+TRANSLATION_BUFFER_PATH = Path(__file__).parent / "translations.yaml"
+
+with open(TRANSLATION_BUFFER_PATH, encoding="utf-8") as yaml_file:
+    TRANSLATION_BUFFER = yaml.load(yaml_file)
+
+
+class TranslatableStr(dict):
+    """
+    Wrapper for translations.
+    Takes a string, that should be translated and looks it up in the translation buffer.
+    If the string is not found, it an entry is created in the buffer.
+
+    The string can be formatted using the .format() method or left as is.
+
+    since subclassing from dict, this class does not need any aditional infrasturcture
+    to turn a message into a translated string.
+    """
+
+    def __init__(self, message):
+        if message in TRANSLATION_BUFFER:
+            en_message = TRANSLATION_BUFFER[message]
+        else:
+            en_message = message
+            TRANSLATION_BUFFER[message] = ""
+            with open(TRANSLATION_BUFFER_PATH, "w", encoding="utf-8") as file:
+                yaml.dump(TRANSLATION_BUFFER, file)
+        super().__init__(en=en_message, de=message)
+
+    def __hash__(self):
+        """returns a hash as if this was a string."""
+        return hash(self["de"])
+
+    def format(self, *args, **kwargs):
+        """Format the string using the .format() method, as if this was a string."""
+        self["de"] = self["de"].format(*args, **kwargs)
+        self["en"] = self["en"].format(*args, **kwargs)
+        return self
 
 
 def convert_to_webp(source: Path):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -283,6 +283,26 @@ paths:
         Preloading this is not an issue on our end, but keep in mind bandwith constraints on your side. The data can be up to 50kB (using gzip) or 200kB unzipped
         The exact data format is specified in the NavigaTUM-data documentation
       parameters:
+        - name: lang
+          in: query
+          description: The language you want your details to be in. If either this or the query parameter is set to en, this will be delivered.
+          required: false
+          schema:
+            type: string
+            default: de
+            enum:
+              - de
+              - en
+        - name: lang
+          in: cookie
+          description: The language you want your details to be in. If either this or the query parameter is set to en, this will be delivered.
+          required: false
+          schema:
+            type: string
+            default: de
+            enum:
+              - de
+              - en
         - name: id
           in: path
           description: string you want to search for

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -898,11 +898,11 @@ components:
           items:
             $ref: '#/components/schemas/LinkProp'
         comment:
-          type: string
           description: |
             A comment to show to an entry.  
             It is used in the rare cases, where some aspect about the rooom/.. or its translation are misleading.  
             An example of a room with a comment is MW1801.
+          type: string
       required:
         - computed
     ComputedProp:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -897,6 +897,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LinkProp'
+        comment:
+          type: string
+          description: |
+            A comment to show to an entry.  
+            It is used in the rare cases, where some aspect about the rooom/.. or its translation are misleading.  
+            An example of a room with a comment is MW1801.
       required:
         - computed
     ComputedProp:
@@ -938,16 +944,6 @@ components:
       required:
         - text
         - url
-    CommentProp:
-      description: 'A comment to show to an entry. It is used in the rare cases, where some aspect about the rooom/ translation are misleading.'
-      type: object
-      properties:
-        de:
-          description: German version of the comment
-          type: string
-        en:
-          description: English version of the comment
-          type: string
     ImageInfo:
       description: 'The information you need to request Images from the /cdn/{size}/{id}_{counter}.webp endpoint'
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -274,7 +274,7 @@ paths:
         - core
   '/api/get/{id}':
     get:
-      operationId: get
+      operationId: details
       summary: Get entry-details
       description: |
         This returns the full data available for the entry (room/building).

--- a/server/load_api_data_to_db.py
+++ b/server/load_api_data_to_db.py
@@ -1,22 +1,51 @@
 import json
 import sqlite3
+from typing import Any, Union
 
-con: sqlite3.Connection = sqlite3.connect("data/api_data.db")
-con.execute(
-    """
-CREATE TABLE IF NOT EXISTS api_data (
-    key     VARCHAR(30) UNIQUE PRIMARY KEY NOT NULL,
-    value   BLOB NOT NULL
-);""",
-)
-# we are using this file in docker, so we don't want to use an acid compliant database ;)
-con.execute("""PRAGMA journal_mode = OFF;""")
-con.execute("""PRAGMA synchronous = OFF;""")
 
-with open("data/api_data.json", encoding="utf-8") as file:
-    data = json.load(file)
-    new_data: list[tuple[str, str]] = [(key, json.dumps(value)) for key, value in data.items()]
+def add_to_database(new_data):
+    """add data consisting of (key, de, en) to the sqlite database"""
+    con: sqlite3.Connection = sqlite3.connect("data/api_data.db")
+    con.execute(
+        """
+    CREATE TABLE IF NOT EXISTS api_data (
+        key     VARCHAR(30) UNIQUE PRIMARY KEY NOT NULL,
+        de      BLOB NOT NULL,
+        en      BLOB NOT NULL
+    );""",
+    )
+    # we are using this file in docker, so we don't want to use an acid compliant database ;)
+    con.execute("""PRAGMA journal_mode = OFF;""")
+    con.execute("""PRAGMA synchronous = OFF;""")
 
-with con:
-    con.executemany("INSERT INTO api_data(key, value) VALUES (?,?)", new_data)
-print("Initialized KV store")
+    with con:
+        con.executemany("INSERT INTO api_data(key, de, en) VALUES (?,?,?)", new_data)
+
+
+def localise(value: Union[str, list[Any], dict[str, Any]], language: str) -> Any:
+    """Recursively localise a dictionary"""
+    if isinstance(value, (bool, float, int, str)) or value is None:
+        return value
+    if isinstance(value, list):
+        return [localise(v, language) for v in value]
+    if isinstance(value, dict):
+        # since we only localise strings, the default to the empty string is safe
+        if "en" in value or "de" in value:
+            return value.get(language, "")
+
+        return {k: localise(v, language) for k, v in value.items()}
+    raise ValueError(f"Unhandled type {type(value)}")
+
+
+def get_localised_data() -> list[tuple[str, str, str]]:
+    """get all data from the json dump and convert it to a list of tuples"""
+    with open("data/api_data.json", encoding="utf-8") as file:
+        data = json.load(file)
+    split_data = [(key, localise(value, "de"), localise(value, "en")) for key, value in data.items()]
+    return [(key, json.dumps(de), json.dumps(en)) for key, de, en in split_data]
+
+
+if __name__ == "__main__":
+    localised_data = get_localised_data()
+    add_to_database(localised_data)
+    print("Initialized KV store")

--- a/server/load_api_data_to_db.py
+++ b/server/load_api_data_to_db.py
@@ -29,8 +29,9 @@ def localise(value: Union[str, list[Any], dict[str, Any]], language: str) -> Any
     if isinstance(value, list):
         return [localise(v, language) for v in value]
     if isinstance(value, dict):
-        # since we only localise strings, the default to the empty string is safe
-        if "en" in value or "de" in value:
+        # We consider each dict that has only the keys "de" and/or "en" as translated string
+        if set(value.keys()) | {"de", "en"} == {"de", "en"}:
+            # Since we only localise strings, the default to the empty string is safe
             return value.get(language, "")
 
         return {k: localise(v, language) for k, v in value.items()}

--- a/server/src/core/get.rs
+++ b/server/src/core/get.rs
@@ -1,21 +1,37 @@
-use actix_web::{get, web, HttpResponse};
+use actix_web::{get, web, HttpRequest, HttpResponse};
+use log::error;
 use rusqlite::{Connection, OpenFlags};
 
 #[get("/get/{id}")]
-pub async fn get_handler(params: web::Path<String>) -> HttpResponse {
+pub async fn get_handler(params: web::Path<String>, req: HttpRequest) -> HttpResponse {
     let id = params.into_inner();
     let conn = Connection::open_with_flags(
         "data/api_data.db",
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .expect("Cannot open database");
-    let mut stmt = conn
-        .prepare_cached("SELECT value FROM api_data WHERE key = ?")
-        .expect("Cannot prepare statement");
-    let result = stmt.query_row([id], |row| {
-        let data: String = row.get_unwrap(0);
-        Ok(data)
-    });
+
+    let en_stmt = conn.prepare_cached("SELECT en FROM api_data WHERE key = ?");
+    let de_stmt = conn.prepare_cached("SELECT de FROM api_data WHERE key = ?");
+    let stmt = match req.cookie("lang") {
+        Some(cookie) => match cookie.value() {
+            "en" => en_stmt,
+            _ => de_stmt,
+        },
+        None => de_stmt,
+    };
+    let result = match stmt {
+        Ok(mut stmt) => stmt.query_row([id], |row| {
+            let data: String = row.get_unwrap(0);
+            Ok(data)
+        }),
+        Err(e) => {
+            error!("Error preparing statement: {:?}", e);
+            return HttpResponse::InternalServerError()
+                .content_type("text/plain")
+                .body("Internal Server Error");
+        }
+    };
     match result {
         Ok(data) => HttpResponse::Ok()
             .content_type("application/json")

--- a/server/src/core/get.rs
+++ b/server/src/core/get.rs
@@ -1,9 +1,19 @@
 use actix_web::{get, web, HttpRequest, HttpResponse};
 use log::error;
 use rusqlite::{Connection, OpenFlags};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct DetailsQuerryArgs {
+    lang: Option<String>,
+}
 
 #[get("/get/{id}")]
-pub async fn get_handler(params: web::Path<String>, req: HttpRequest) -> HttpResponse {
+pub async fn get_handler(
+    params: web::Path<String>,
+    web::Query(args): web::Query<DetailsQuerryArgs>,
+    req: HttpRequest,
+) -> HttpResponse {
     let id = params.into_inner();
     let conn = Connection::open_with_flags(
         "data/api_data.db",
@@ -13,12 +23,12 @@ pub async fn get_handler(params: web::Path<String>, req: HttpRequest) -> HttpRes
 
     let en_stmt = conn.prepare_cached("SELECT en FROM api_data WHERE key = ?");
     let de_stmt = conn.prepare_cached("SELECT de FROM api_data WHERE key = ?");
-    let stmt = match req.cookie("lang") {
-        Some(cookie) => match cookie.value() {
-            "en" => en_stmt,
-            _ => de_stmt,
-        },
-        None => de_stmt,
+    // we calculate the language from the request by checking if either the query or the cookie are set to en
+    let cookie_en = req.cookie("lang").map_or(false, |c| c.value() == "en");
+    let arg_en = args.lang.map_or(false, |c| c == "en");
+    let stmt = match arg_en || cookie_en {
+        true => en_stmt,
+        false => de_stmt,
     };
     let result = match stmt {
         Ok(mut stmt) => stmt.query_row([id], |row| {

--- a/server/src/feedback.rs
+++ b/server/src/feedback.rs
@@ -159,9 +159,7 @@ async fn send_feedback(
     let octocrab = Octocrab::builder().personal_token(token).build();
     if octocrab.is_err() {
         error!("Error creating issue: {:?}", octocrab);
-        return HttpResponse::InternalServerError()
-            .content_type("text/plain")
-            .body("Could not create Octocrab instance");
+        return HttpResponse::InternalServerError().body("Could not create Octocrab instance");
     }
     let resp = octocrab
         .unwrap()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,6 @@
 use actix_cors::Cors;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
+use log::warn;
 
 use structopt::StructOpt;
 
@@ -52,8 +53,20 @@ async fn main() -> std::io::Result<()> {
     let state_feedback = web::Data::new(feedback::init_state(opt));
 
     HttpServer::new(move || {
-        let cors = Cors::default()
-            .allow_any_origin()
+        // in local development we serve our website from two diverent CORS sources
+        // since we need the lang cookie for api localisation, we have to add
+        // Access-Control-Allow-Credentials=true to the response header
+        // since origin cannot be '*' in this case, we explicitly set it
+        let base_cors = match std::env::var("GIT_COMMIT_SHA") {
+            Ok(_) => Cors::default().allow_any_origin(),
+            Err(_) => {
+                warn!("Running in local development mode. only allowing http://localhost:8000 as origin");
+                Cors::default()
+                    .supports_credentials()
+                    .allowed_origin("http://localhost:8000")
+            }
+        };
+        let cors = base_cors
             .allow_any_header()
             .allowed_methods(vec!["GET", "POST"])
             .max_age(3600);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -60,7 +60,7 @@ async fn main() -> std::io::Result<()> {
         let base_cors = match std::env::var("GIT_COMMIT_SHA") {
             Ok(_) => Cors::default().allow_any_origin(),
             Err(_) => {
-                warn!("Running in local development mode. only allowing http://localhost:8000 as origin");
+                warn!("Running in local development mode. Only allowing http://localhost:8000 as origin");
                 Cors::default()
                     .supports_credentials()
                     .allowed_origin("http://localhost:8000")

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,6 @@
 max-line-length = 120
 # T201: print statements used
 # W503: line break before binary operator
-ignore = T201,W503
+# FS003: f-string mssiing prefix (we have translations, which trigger this)
+ignore = T201,W503,FS003
 min_python_version = 3.10.0

--- a/webclient/src/core.js
+++ b/webclient/src/core.js
@@ -16,6 +16,12 @@ const cachedFetch = (() => ({
         this.promise_callbacks[url].push(resolve);
       } else {
         this.promise_callbacks[url] = [resolve];
+
+        // in local development we serve our website from two diverent CORS sources.
+        // since we need the lang cookie for the api localisation, we have to add crecentials:"include"
+        // to the fetech options
+        options.credentials =
+          "/* @if target='release' */same-origin/* @else */include/* @endif */";
         if (!options.headers) options.headers = {};
         fetch(url, options)
           .then((response) => {

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -181,11 +181,8 @@
         >
           ${{_.view_view.msg.no_floor_overlay}}$
         </div>
-        <div
-          class="toast"
-          v-if="view_data.props && view_data.props.comment && view_data.props.comment.${{_lang_}}$"
-        >
-          {{ view_data.props.comment.${{_lang_}}$ }}
+        <div class="toast" v-if="view_data.props && view_data.props.comment">
+          {{ view_data.props.comment }}
         </div>
       </div>
 
@@ -323,9 +320,7 @@
             <td>
               <ul>
                 <li v-for="link in view_data.props.links">
-                  <a v-bind:href="link.url.${{ _lang_ }}$">
-                    {{ link.text.${{ _lang_ }}$ }}
-                  </a>
+                  <a v-bind:href="link.url">{{ link.text }}</a>
                 </li>
               </ul>
             </td>
@@ -369,9 +364,7 @@
                 <td>
                   <ul>
                     <li v-for="link in view_data.props.links">
-                      <a v-bind:href="link.url.${{ _lang_ }}$">
-                        {{ link.text.${{ _lang_ }}$ }}
-                      </a>
+                      <a v-bind:href="link.url">{{ link.text }}</a>
                     </li>
                   </ul>
                 </td>
@@ -394,11 +387,8 @@
           >
             ${{_.view_view.msg.no_floor_overlay}}$
           </div>
-          <div
-            class="toast"
-            v-if="view_data.props && view_data.props.comment && view_data.props.comment.${{_lang_}}$"
-          >
-            {{ view_data.props.comment.${{_lang_}}$ }}
+          <div class="toast" v-if="view_data.props && view_data.props.comment">
+            {{ view_data.props.comment }}
           </div>
         </div>
         <!--<div class="card-footer">


### PR DESCRIPTION
- [x] Migrated `/api/get/:id` to include the `lang` cookie as an indicator for which langugage should be delivered
- [x] Migrated the webclient to the new API Scheme for `/api/get/:id`
- [x] Added a way to easily localize strings in the data preprocessor

partially resolves #168 