### PR TITLE
localised `type_common_name` and `usage`

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -77,19 +77,6 @@ def export_for_api(data, path):
             entry.setdefault("maps", {})["default"] = "interactive"
         export_data[_id] = {
             "parent_names": [data[p]["name"] for p in entry["parents"]],
-            # "type_common_name": {
-            #    "root": "Standortübersicht",
-            #    "site": "Standort",
-            #    "campus": "Campus",
-            #    "area": "Gebiet / Gruppe von Gebäuden",
-            #    "joined_building": "Gebäudekomplex",
-            #    "building": "Gebäudeteil"
-            #                if (entry["type"] == "building" and
-            #                    data[entry["parents"][-1]]["type"] == "joined_building")
-            #                else "Gebäude",
-            #    "room": entry["usage"]["name"] if "usage" in entry else "Raum",
-            #    "virtual_room": entry["usage"]["name"] if "usage" in entry else "Raum/Gebäudeteil",
-            # }[entry["type"]],
             **entry,
         }
         if "children" in export_data[_id]:

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -161,7 +161,7 @@ def generate_rooms_overview(data):
         for child_id in entry["children_flat"]:
             child = data[child_id]
             if child["type"] == "room":
-                usage = child["usage"] if "usage" in child else {"name": "unbekannt"}
+                usage = child["usage"] if "usage" in child else {"name": _("Unbekannt")}
                 rooms.setdefault(usage["name"], []).append(
                     {
                         "id": child_id,

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -1,4 +1,5 @@
 import logging
+from utils import TranslatableStr as _
 
 
 def add_children_properties(data):
@@ -94,18 +95,18 @@ def infer_type_common_name(data):
 
     def _get_type(_id, _data):
         if _data["type"] == "building" and data[_data["parents"][-1]]["type"] == "joined_building":
-            return {"de": "Gebäudeteil", "en": "Part of the building"}
+            return _("Gebäudeteil")
         if _data["type"] in ["virtual_room", "room"] and "usage" in _data:
             return _data["usage"]["name"]
         return {
-            "root": {"de": "Standortübersicht", "en": "Location overview"},
-            "site": {"de": "Standort", "en": "Location"},
+            "root": _("Standortübersicht"),
+            "site": _("Standort"),
             "campus": "Campus",
-            "area": {"de": "Gebiet / Gruppe von Gebäuden", "en": "Area / Group of buildings"},
-            "joined_building": {"de": "Gebäudekomplex", "en": "Building complex"},
-            "building": {"de": "Gebäude", "en": "Building"},
-            "room": {"de": "Raum", "en": "Room"},
-            "virtual_room": {"de": "Raum/Gebäudeteil", "en": "Room/Part of the building"},
+            "area": _("Gebiet / Gruppe von Gebäuden"),
+            "joined_building": _("Gebäudekomplex"),
+            "building": _("Gebäude"),
+            "room": _("Raum"),
+            "virtual_room": _("Raum/Gebäudeteil"),
         }[_data["type"]]
 
     for _id, _data in data.items():

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -41,7 +41,7 @@ def add_stats(data):
                 if not child.get("usage", {}).get("din_277", "").startswith("VF"):
                     n_rooms_reg += 1
             if child["type"] == "joined_building" or (
-                child["type"] == "building" and data[child["parents"][-1]]["type"] != "joined_building"
+                    child["type"] == "building" and data[child["parents"][-1]]["type"] != "joined_building"
             ):
                 n_buildings += 1
 
@@ -91,16 +91,22 @@ def infer_addresses(data):
 
 def infer_type_common_name(data):
     """This function infers the type_common_name property for each entry via the type property."""
-    for _id, _data in data.items():
-        _data["type_common_name"] = {
-            "root": "Standortübersicht",
-            "site": "Standort",
+
+    def _get_type(_id, _data):
+        if _data["type"] == "building" and data[_data["parents"][-1]]["type"] == "joined_building":
+            return {"de": "Gebäudeteil", "en": "Part of the building"}
+        if _data["type"] in ["virtual_room", "room"] and "usage" in _data:
+            return _data["usage"]["name"]
+        return {
+            "root": {"de": "Standortübersicht", "en": "Location overview"},
+            "site": {"de": "Standort", "en": "Location"},
             "campus": "Campus",
-            "area": "Gebiet / Gruppe von Gebäuden",
-            "joined_building": "Gebäudekomplex",
-            "building": "Gebäudeteil"
-            if (_data["type"] == "building" and data[_data["parents"][-1]]["type"] == "joined_building")
-            else "Gebäude",
-            "room": _data["usage"]["name"] if "usage" in _data else "Raum",
-            "virtual_room": _data["usage"]["name"] if "usage" in _data else "Raum/Gebäudeteil",
+            "area": {"de": "Gebiet / Gruppe von Gebäuden", "en": "Area / Group of buildings"},
+            "joined_building": {"de": "Gebäudekomplex", "en": "Building complex"},
+            "building": {"de": "Gebäude", "en": "Building"},
+            "room": {"de": "Raum", "en": "Room"},
+            "virtual_room": {"de": "Raum/Gebäudeteil", "en": "Room/Part of the building"},
         }[_data["type"]]
+
+    for _id, _data in data.items():
+        _data["type_common_name"] = _get_type(_id, _data)

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -5,6 +5,7 @@ import string
 import yaml
 from processors.merge import merge_object
 from processors.patch import apply_patches
+from utils import TranslatableStr as _
 
 ALLOWED_ROOMCODE_CHARS = set(string.ascii_letters) | set(string.digits) | {".", "-"}
 
@@ -139,7 +140,7 @@ def merge_tumonline_rooms(data):
             tumonline_usage = usages_lookup[room["usage"]]
             parts = tumonline_usage["din_277"].split(" - ")
             r_data["usage"] = {
-                "name": tumonline_usage["name"],
+                "name": _(tumonline_usage["name"]),
                 "din_277": parts[0],
                 "din_277_desc": parts[1],
             }

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -8,17 +8,18 @@ Adresse: Address
 Anzahl Gebäude: Number of buildings
 Sitzplätze: Seats
 Anzahl Räume: Number of rooms
-"{n_rooms} ({n_rooms_reg} ohne Flure etc.)": "{n_rooms} ({n_rooms_reg} without corridors etc.)"
+'{n_rooms} ({n_rooms_reg} ohne Flure etc.)': '{n_rooms} ({n_rooms_reg} without corridors etc.)'
 Keine Räume bekannt: No rooms known
-"{n_rooms} Räume": "{n_rooms} rooms"
-"{n_buildings} Gebäude, {n_rooms} Räume": "{n_buildings} buildings, {n_rooms} rooms"
-"{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)": "{n_buildings} buildings, {n_rooms} rooms (branch office)"
-Architekten-Name: "Architect's name"
-Gebäudeteil: "Part of the building"
-Standortübersicht: "Location overview"
+'{n_rooms} Räume': '{n_rooms} rooms'
+'{n_buildings} Gebäude, {n_rooms} Räume': '{n_buildings} buildings, {n_rooms} rooms'
+'{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)': '{n_buildings} buildings, {n_rooms} rooms (branch office)'
+Architekten-Name: Architect's name
+# type_common_name
+Gebäudeteil: Part of the building
+Standortübersicht: Location overview
 Standort: Location
-"Gebiet / Gruppe von Gebäuden": "Area / Group of buildings"
-Gebäudekomplex: "Building complex"
+Gebiet / Gruppe von Gebäuden: Area / Group of buildings
+Gebäudekomplex: Building complex
 Gebäude: Building
 Raum: Room
 Raum/Gebäudeteil: "Room/Part of the building"

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -14,3 +14,11 @@ Keine Räume bekannt: No rooms known
 "{n_buildings} Gebäude, {n_rooms} Räume": "{n_buildings} buildings, {n_rooms} rooms"
 "{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)": "{n_buildings} buildings, {n_rooms} rooms (branch office)"
 Architekten-Name: "Architect's name"
+Gebäudeteil: "Part of the building"
+Standortübersicht: "Location overview"
+Standort: Location
+"Gebiet / Gruppe von Gebäuden": "Area / Group of buildings"
+Gebäudekomplex: "Building complex"
+Gebäude: Building
+Raum: Room
+Raum/Gebäudeteil: "Room/Part of the building"

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -32,15 +32,15 @@ Praktikumsraum - Physik: Lab room - Physics
 Labor - Video: Laboratory - Video
 Labor (Technik): Laboratory (technical)
 Labor - Physik: Laboratory - Physics
-Labor - Chemie: Laboratory - chemistry
+Labor - Chemie: Laboratory - Chemistry
 Labor - Biologie: Laboratory - Biology
-Labor - Foto: Laboratory - photo
+Labor - Foto: Laboratory - Photo
 Teeküche: Kitchenette
 Sanitärraum: Sanitary room
 WC: WC
 WC Vorraum: WC Anteroom
 WC Herren: WC Men
-WC Damen: WC Ladies
+WC Damen: WC Women
 Putzraum: Cleaning room
 Sekretariat: Secretariat
 Archiv: Archive
@@ -63,11 +63,11 @@ Versuchshalle: Experimental hall
 Zeichensaal: Drawing room
 Flur: Corridor
 Sozialraum: Social room
-Windfang: vestibule
+Windfang: Vestibule
 Behandlungsraum: Treatment room
 Fernmeldetechnik: Telecommunications
-Portierloge: porter's lodge
-Aufzugsschacht: elevator shaft
+Portierloge: Porter's lodge
+Aufzugsschacht: Elevator shaft
 Terrasse: Terrace
 Aufzugsanlage: Elevator system
 Außenstiege: Exterior staircase
@@ -97,7 +97,7 @@ Tischlerei: Joinery
 Bad: Bathroom
 Gebäudeleittechnik: Building control system
 Raum mit medizin. Ausstattung: Room with medical equipment
-Bühnen-, Studioraum: stage, studio room
+Bühnen-, Studioraum: Stage, studio room
 Sportraum: Sports room
 Sakralraum: Sacral room
 Unterrichtsraum: Classroom
@@ -122,7 +122,7 @@ Stall: Stable
 Futteraufbereitung: Fodder preparation
 Operationsraum: Operation room
 Fahrradraum: Bicycle room
-Poststelle: Mailroom
+Poststelle: Postal service
 Wäscherei: Laundry room
 Wasseraufbereitung: Water treatment
 Wassertechnische Anlage: Water technical installation
@@ -142,7 +142,7 @@ Fahrzeugverkehrsfläche: Vehicle traffic area
 Gang (Galerie): Corridor (gallery)
 Sonderarbeitsraum: Special workroom
 Waschraum: Washroom
-Praktikumsraum - Chemie: practical room - chemistry
+Praktikumsraum - Chemie: Practical room - chemistry
 Praktikumsraum - EDV: Practical room - EDP
 Müllsammelraum: Waste collection room
 Müll-/Wertstoffcontainer: Waste / recyclable material container

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -22,4 +22,132 @@ Gebiet / Gruppe von Gebäuden: Area / Group of buildings
 Gebäudekomplex: Building complex
 Gebäude: Building
 Raum: Room
-Raum/Gebäudeteil: "Room/Part of the building"
+Raum/Gebäudeteil: Room/Part of the building
+# usages
+Hörsaal: Lecture hall
+Büro: Office
+Serverraum: Server room
+Übungsraum: Exercise room
+Praktikumsraum - Physik: Lab room - Physics
+Labor - Video: Laboratory - Video
+Labor (Technik): Laboratory (technical)
+Labor - Physik: Laboratory - Physics
+Labor - Chemie: Laboratory - chemistry
+Labor - Biologie: Laboratory - Biology
+Labor - Foto: Laboratory - photo
+Teeküche: Kitchenette
+Sanitärraum: Sanitary room
+WC: WC
+WC Vorraum: WC Anteroom
+WC Herren: WC Men
+WC Damen: WC Ladies
+Putzraum: Cleaning room
+Sekretariat: Secretariat
+Archiv: Archive
+Seminarraum: Seminar room
+Bibliothek: Library
+Studentenarbeitsraum: Student workroom
+Kopierraum: Copy room
+Aufzug: Elevator
+Treppenhaus: Staircase
+Besprechungsraum: Meeting room
+Lager: Warehouse
+Vorbereitungsraum: Preparation room
+WC Barrierefrei: WC Barrier-free
+Geschäftsraum: Business room
+Werkstatt: Workshop
+Dusche: Shower
+Metallverarbeitung: Metalworking
+Garderobe: Wardrobe
+Versuchshalle: Experimental hall
+Zeichensaal: Drawing room
+Flur: Corridor
+Sozialraum: Social room
+Windfang: vestibule
+Behandlungsraum: Treatment room
+Fernmeldetechnik: Telecommunications
+Portierloge: porter's lodge
+Aufzugsschacht: elevator shaft
+Terrasse: Terrace
+Aufzugsanlage: Elevator system
+Außenstiege: Exterior staircase
+Beobachterraum: Observation room
+Durchfahrt: Passage
+Foyer: Foyer
+Gang: Corridor
+Gasanlage: Gas system
+Geräteraum: Equipment room
+Hörsaaltechnik: Lecture hall technology
+Klimatechnische Anlage: Air conditioning system
+Küche: Kitchen
+Luftraum: Air room
+Lufttechnische Anlage: Air conditioning system
+Rampe: Ramp
+Schacht: Shaft
+Sitzungszimmer: Meeting room
+Speiseraum: Dining room
+Starkstromanlage: Heavy current installation
+Vorraum: Anteroom
+Wohnung: Apartment
+Wärmetechnische Anlage: Heat engineering plant
+Garage: Garage
+Schleuse: Sluice
+Tierstall: Animal stable
+Tischlerei: Joinery
+Bad: Bathroom
+Gebäudeleittechnik: Building control system
+Raum mit medizin. Ausstattung: Room with medical equipment
+Bühnen-, Studioraum: stage, studio room
+Sportraum: Sports room
+Sakralraum: Sacral room
+Unterrichtsraum: Classroom
+Chemikalienlager: Chemical storage
+EDV-Raum: IT room
+Sprachlabor: Language laboratory
+Dachterrasse: Roof terrace
+Cafeteria: Cafeteria
+Konferenzraum: Conference room
+Halle: Hall
+Kindergarten: Pre-school
+Mensa: Cafeteria
+Ausstellungssaal: Exhibition hall
+Lesesaal: Reading room
+Werkhalle: Workshop
+Garten: Garden
+Abstellraum: Storage room
+Elektrische Stromversorgung: Electric power supply
+Film und AV-Medien: Film and AV media
+Glas-, Gewächshaus: Glass, greenhouse
+Stall: Stable
+Futteraufbereitung: Fodder preparation
+Operationsraum: Operation room
+Fahrradraum: Bicycle room
+Poststelle: Mailroom
+Wäscherei: Laundry room
+Wasseraufbereitung: Water treatment
+Wassertechnische Anlage: Water technical installation
+Neutralisationsanlage: Neutralization plant
+Anlieferung: Delivery
+Lehrmittelraum: Teaching material room
+Musikunterricht: Music lessons
+Freihandbibliothek: Open access library
+Turnsaal: Gymnasium
+Schwimmhalle: Indoor swimming pool
+Tierhaltung: Animal husbandry
+Kühlraum: Cold storage
+Sonstiger Lagerraum: Other storage room
+Heizungsanlage: Heating system
+Stiege: Staircase
+Fahrzeugverkehrsfläche: Vehicle traffic area
+Gang (Galerie): Corridor (gallery)
+Sonderarbeitsraum: Special workroom
+Waschraum: Washroom
+Praktikumsraum - Chemie: practical room - chemistry
+Praktikumsraum - EDV: Practical room - EDP
+Müllsammelraum: Waste collection room
+Müll-/Wertstoffcontainer: Waste / recyclable material container
+Abfallsammelstation: Waste collection station
+Freifläche: Open air area
+Freiluftfläche: Open air area
+Fluchtweg: Escape route
+Unbekannt: Unknown

--- a/data/utils.py
+++ b/data/utils.py
@@ -40,6 +40,14 @@ class TranslatableStr(dict):
         """returns a hash as if this was a string."""
         return hash(self["de"])
 
+    def __le__(self, other):
+        """compares one String to another, sorting by the german string."""
+        return self["de"] <= other["de"]
+
+    def __lt__(self, other):
+        """compares one String to another, sorting by the german string."""
+        return self["de"] < other["de"]
+
     def format(self, *args, **kwargs):
         """Format the string using the .format() method, as if this was a string."""
         self["de"] = self["de"].format(*args, **kwargs)


### PR DESCRIPTION
When browsing our site, I noticed that these fields are not localised:

Before
![image](https://user-images.githubusercontent.com/26258709/193429685-bb955dca-1db6-4a9f-a803-c4b9a454ce6b.png)

After
![image](https://user-images.githubusercontent.com/26258709/193430230-34c50a7d-0150-4419-a2c3-9adfa6c1b2ac.png)


This PR fixes this