### PR TITLE
Improved downloader

### DIFF
--- a/data/external/downloader.py
+++ b/data/external/downloader.py
@@ -20,6 +20,14 @@ ROOMFINDER_API_URL = "http://roomfinder.ze.tum.de:8192"
 CACHE_PATH = Path(__file__).parent / "cache"
 
 
+def maybe_sleep(duration):
+    """
+    Sleep for the given duration, but only if the script was called during a workday and working hours.
+    """
+    if time.gmtime().tm_wday not in [5, 6] and 5 <= time.gmtime().tm_hour <= 22:
+        time.sleep(duration)
+
+
 def roomfinder_buildings():
     """
     Retrieve the (extended, i.e. with coordinates) buildings data from the Roomfinder API
@@ -48,7 +56,7 @@ def roomfinder_buildings():
                 buildings[i][key] = value
             buildings[i]["maps"] = proxy.getBuildingMaps(building["b_id"])
             buildings[i]["default_map"] = proxy.getBuildingDefaultMap(building["b_id"])
-            time.sleep(0.05)
+            maybe_sleep(0.05)
 
     _write_cache_json(cache_name, buildings)
     return buildings
@@ -106,7 +114,7 @@ def roomfinder_rooms():
         extended_data["default_map"] = proxy.getDefaultMap(room)
         extended_data["metas"] = proxy.getRoomMetas(room)
         rooms.append(extended_data)
-        time.sleep(0.05)
+        maybe_sleep(0.05)
 
     _write_cache_json(cache_name, rooms)
     return rooms
@@ -116,7 +124,7 @@ def _guess_queries(rooms, n_rooms):
     # First try: all single-digit numbers
     for i in range(10):
         if len(rooms) < n_rooms:
-            time.sleep(0.05)
+            maybe_sleep(0.05)
             yield str(i)
         else:
             return
@@ -124,7 +132,7 @@ def _guess_queries(rooms, n_rooms):
     # Second try: all double-digit numbers
     for i in range(100):
         if len(rooms) < n_rooms:
-            time.sleep(0.05)
+            maybe_sleep(0.05)
             yield str(i).zfill(2)
         else:
             return
@@ -132,7 +140,7 @@ def _guess_queries(rooms, n_rooms):
     # Thirs try: all characters
     for char in string.ascii_lowercase:
         if len(rooms) < n_rooms:
-            time.sleep(0.05)
+            maybe_sleep(0.05)
             yield char
         else:
             return
@@ -485,7 +493,7 @@ def _retrieve_tumonline_roomlist(f_prefix, f_type, f_name, f_value, area_id=0):
 
         bar.max = pages_cnt
         bar.next()
-        time.sleep(1.5)
+        maybe_sleep(1.5)
 
     _write_cache_json(cache_name, all_rooms)
     return all_rooms
@@ -623,7 +631,7 @@ def _get_html(url: str, params: dict, cache_fname: str) -> BeautifulSoup:
             result = file.read()
     else:
         req = requests.get(url, params)
-        time.sleep(0.5)  # Not the best place to put this
+        maybe_sleep(0.5)  # Not the best place to put this
         with open(cached_xml_file, "w", encoding="utf-8") as file:
             result = req.text
             file.write(result)

--- a/data/external/downloader.py
+++ b/data/external/downloader.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import requests
 from bs4 import BeautifulSoup, element
 from defusedxml import ElementTree as ET
+from progress.bar import Bar  # type: ignore
 from utils import convert_to_webp
 
 TUMONLINE_URL = "https://campus.tum.de/tumonline"
@@ -33,8 +34,9 @@ def roomfinder_buildings():
 
     with xmlrpc.client.ServerProxy(ROOMFINDER_API_URL) as proxy:
         buildings = proxy.getBuildings()
-        print(f"Retrieving {len(buildings)} buildings")
+        bar = Bar("Retrieving", suffix="%(index)d / %(max)d buildings", max=len(buildings))
         for i, building in enumerate(buildings):
+            bar.next()
             # Make sure b_id is numeric. There is an incorrect entry with the value
             # 'CiO/SGInstitute West, Bibliot' which causes a crash
             try:
@@ -47,9 +49,6 @@ def roomfinder_buildings():
             buildings[i]["maps"] = proxy.getBuildingMaps(building["b_id"])
             buildings[i]["default_map"] = proxy.getBuildingDefaultMap(building["b_id"])
             time.sleep(0.05)
-            if i % 10 == 0:
-                print(".", end="", flush=True)
-    print("")
 
     _write_cache_json(cache_name, buildings)
     return buildings
@@ -98,9 +97,8 @@ def roomfinder_rooms():
 
                 rooms_list.extend(list(b_rooms))
 
-    print(f"Retrieving {len(rooms_list)} rooms for {b_cnt} buildings")
     rooms = []
-    for i, room in enumerate(rooms_list):
+    for room in Bar("Retrieving", suffix=f"%(index)d / %(max)d rooms for {b_cnt} buildings").iter(rooms_list):
         extended_data = proxy.getRoomData(room)
         # for k, v in extended_data.items():
         #    rooms[i][k] = v
@@ -109,9 +107,6 @@ def roomfinder_rooms():
         extended_data["metas"] = proxy.getRoomMetas(room)
         rooms.append(extended_data)
         time.sleep(0.05)
-        if i % 10 == 0:
-            print(".", end="", flush=True)
-    print("")
 
     _write_cache_json(cache_name, rooms)
     return rooms
@@ -473,6 +468,7 @@ def _retrieve_tumonline_roomlist(f_prefix, f_type, f_name, f_value, area_id=0):
     pages_cnt = 1
     current_page = 0
 
+    bar = Bar("Searching for Rooms", index=current_page, max=pages_cnt)
     while current_page < pages_cnt:
         search_params = {
             "pStart": len(all_rooms) + 1,  # 1 + current_page * 30,
@@ -487,11 +483,9 @@ def _retrieve_tumonline_roomlist(f_prefix, f_type, f_name, f_value, area_id=0):
         rooms_on_page, pages_cnt, current_page = _parse_rooms_list(BeautifulSoup(req.text, "lxml"))
         all_rooms.extend(rooms_on_page)
 
-        if current_page == 1:
-            print(f"({pages_cnt}) ", end="")
-        print(".", end="", flush=True)
+        bar.max = pages_cnt
+        bar.next()
         time.sleep(1.5)
-    print("")
 
     _write_cache_json(cache_name, all_rooms)
     return all_rooms

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -2,6 +2,7 @@ beautifulsoup4~=4.11.1
 defusedxml~=0.7.1
 lxml~=4.9.1
 Pillow~=9.2.0
+progress~=1.6
 pyyaml~=6.0
 ruamel.yaml~=0.17.21
 utm~=0.7.0


### PR DESCRIPTION
This PR improves the data scaper in two folds:
- If we download during "non working hours" there is really no point in waiting for requests, just to be gentle.
  This change has been cleared by Central IT staff, they wont block us for this.
- The downloader previously used dots to indicate that shit is happening. This PR changes this to the bar graphs from the server tests