### PR TITLE
Try to fix the share menu not opening on Safari

### DIFF
--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -120,7 +120,8 @@
         <button
           class="btn btn-link btn-action btn-sm"
           title="${{ _.view_view.header.external_link.tooltip }}$"
-        >
+          onclick="this.focus()"
+        > <!-- The onclick handler is a fix for Safari -->
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="14"


### PR DESCRIPTION
This tries to fix the share menu not opening on safari (#220).

The menu opens when its button is focused, which usually happens when you click on it. This makes it very easy to open and especially close (by clicking somewhere else) the menu CSS only. But maybe Safari doesn't focus the button upon a click.

My problem is I don't have an iOS device available to test, so I can just guess. This patch _shouldn't_ pose a problem for other browsers, unless they have a different opinion on that `this` in the context of a click means. It doesn't affect the recent Firefox or Chromium versions. So maybe we can just merge and test.