### PR TITLE
Logging+better progressbar for scapers

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -15,6 +15,7 @@ from processors import (
     structure,
     tumonline,
 )
+from utils import setup_logging
 
 DEBUG_MODE = "GIT_COMMIT_SHA" not in os.environ
 
@@ -109,11 +110,7 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG if DEBUG_MODE else logging.INFO, format="%(levelname)s: %(message)s")
-    logging.addLevelName(logging.INFO, f"\033[1;36m{logging.getLevelName(logging.INFO)}\033[1;0m")
-    logging.addLevelName(logging.WARNING, f"\033[1;33m{logging.getLevelName(logging.WARNING)}\033[1;0m")
-    logging.addLevelName(logging.ERROR, f"\033[1;41m{logging.getLevelName(logging.ERROR)}\033[1;0m")
-    logging.addLevelName(logging.CRITICAL, f"\033[1;41m{logging.getLevelName(logging.CRITICAL)}\033[1;0m")
+    setup_logging(level=logging.DEBUG if DEBUG_MODE else logging.INFO)
 
     # Pillow prints all imported modules to the debug stream
     logging.getLogger("PIL").setLevel(logging.INFO)

--- a/data/external/main.py
+++ b/data/external/main.py
@@ -1,9 +1,12 @@
+import logging
 import os
 
 from external.scrapers import roomfinder, tumonline
 from external.scraping_utils import CACHE_PATH
+from utils import setup_logging
 
 if __name__ == "__main__":
+    setup_logging(level=logging.INFO)
     # Create cache directory structure
     os.makedirs(CACHE_PATH, exist_ok=True)
     os.makedirs(CACHE_PATH / "filter", exist_ok=True)

--- a/data/external/scraping_utils.py
+++ b/data/external/scraping_utils.py
@@ -1,6 +1,9 @@
 import json
+import logging
 import time
+import urllib.request
 from pathlib import Path
+from urllib.error import HTTPError
 
 CACHE_PATH = Path(__file__).parent / "cache"
 
@@ -15,7 +18,7 @@ def maybe_sleep(duration):
 
 def _write_cache_json(fname, data):
     with open(CACHE_PATH / fname, "w", encoding="utf-8") as file:
-        json.dump(data, file)
+        json.dump(data, file, indent=4)
 
 
 def _cached_json(fname):
@@ -24,3 +27,18 @@ def _cached_json(fname):
         with open(path, encoding="utf-8") as file:
             return json.load(file)
     return None
+
+
+def _download_file(url, target_cache_file, quiet=False, quiet_errors=False):
+    if not target_cache_file.exists():
+        # url parameter does not allow path traversal, because we build it further up in the callstack
+        try:
+            urllib.request.urlretrieve(url, target_cache_file)  # nosec: B310
+        except HTTPError as e:
+            if not quiet_errors:
+                logging.warning(f"GET {url} -> Failed to retrieve {url}: {e}")
+            return None
+        if not quiet:
+            logging.warning(f"GET {url}")
+
+    return target_cache_file

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -2,7 +2,6 @@ beautifulsoup4~=4.11.1
 defusedxml~=0.7.1
 lxml~=4.9.1
 Pillow~=9.3.0
-progress~=1.6
 pyyaml~=6.0
 ruamel.yaml~=0.17.21
 utm~=0.7.0

--- a/data/utils.py
+++ b/data/utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -76,3 +77,14 @@ def convert_to_webp(source: Path):
     image.save(destination, format="webp")
     os.remove(source)
     return str(destination)
+
+
+def setup_logging(level):
+    """
+    Sets up the loglevels with colors, with correct terminal colors
+    """
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    logging.addLevelName(logging.INFO, f"\033[1;36m{logging.getLevelName(logging.INFO)}\033[1;0m")
+    logging.addLevelName(logging.WARNING, f"\033[1;33m{logging.getLevelName(logging.WARNING)}\033[1;0m")
+    logging.addLevelName(logging.ERROR, f"\033[1;41m{logging.getLevelName(logging.ERROR)}\033[1;0m")
+    logging.addLevelName(logging.CRITICAL, f"\033[1;41m{logging.getLevelName(logging.CRITICAL)}\033[1;0m")

--- a/server/test/requirements.txt
+++ b/server/test/requirements.txt
@@ -1,2 +1,2 @@
-progress~=1.6
+tqdm~=4.64.1
 termcolor~=1.1.0

--- a/server/test/search_test.py
+++ b/server/test/search_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import requests
 import yaml
-from progress.bar import Bar  # type: ignore
+from tqdm import tqdm
 from termcolor import colored, cprint
 
 SEARCH_ENDPOINT = "http://localhost:8080/api/search"
@@ -35,7 +35,7 @@ def test_specific_queries(queries):
     """Test the specific queries, and return the results"""
     searches = []
 
-    for query in Bar("Querying", suffix="%(index)d / %(max)d").iter(queries):
+    for query in tqdm(queries, desc="Querying"):
         search = _do_search(query["query"], query)
 
         # Apart from the target search we iteratively type the query and assess how much of


### PR DESCRIPTION
This PR migrates:
- the scraper to logging (this one should be uncontreversial)
- from `progress.bar` to `tqdm`.
  - Reasons being a more mature API (it can do more)
  - being typechecked