### PR TITLE
Allow opening search suggestions in new tab

### DIFF
--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -112,7 +112,8 @@
                         v-if="s.n_visible === undefined || (s.n_visible !== undefined && i < s.n_visible) || s.expanded"
                         class="menu-item">
                       <a v-bind:class="{active: e.id == search.autocomplete.highlighted}"
-                         @click="searchGoTo(e.id, true)"
+                         v-bind:href="'/view/' + e.id"
+                         @click.exact.prevent="searchGoTo(e.id, true)"
                          @mousedown="search.keep_focus = true"
                          @mouseover="search.autocomplete.highlighted = null">
                         <div class="tile">


### PR DESCRIPTION
This PR fixes TUM-Dev/NavigaTUM#275

I tested this in Firefox and Chromium on Windows, as well as Bromite (Chromium-based) and [Fennec](https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/) on Android.

The click attribute has been changed to only trigger when no other modifier keys are pressed, that way browsers can use their native handling for Control+Click, Shift-Click, Right-Clicking etc. 

The link points to `/view/...` even for entries where other links would be more appropriate (e.g. `/campus/...`), but upon opening it gets corrected. This is in line with how the normal search result page links to entries.

![Demo recording](https://user-images.githubusercontent.com/32465636/200345018-8e70e8f4-6972-4ddc-a864-073842cb680c.gif)
