### PR TITLE
Modal for roomfinder

### DIFF
--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -115,3 +115,4 @@ view_view:
     image_alt:
       de: "Ein Bild welches den Lageplan zeigt"
       en: "Image showing the Site Plan"
+      

--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -107,3 +107,11 @@ view_view:
     author: { de: "Autor", en: "Author" }
     source: { de: "Quelle", en: "Source" }
     license: { de: "Lizenz", en: "License" }
+  modalRoomfinder:
+    header:
+      de: "Lageplan"
+      en: "Site Plan"
+    close: { de: "Schließen", en: "Close"}
+    image_alt:
+      de: "Ein Bild welches den Lageplan zeigt"
+      en: "Image showing the Site Plan"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -355,7 +355,7 @@
             <h5 class="modal-title">${{_.view_view.modalRoomfinder.header}}$</h5>
         </div>
         <div class="modal-body">
-          <div class="content" id="modalRoomfinderContent">
+          <div class="roomfinder-map-container">
             <img
               alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
               src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -359,7 +359,6 @@
             <img
               alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
               src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"
-              style="display: none"
               v-bind:style="{'transform': 'translate(' + state.map.roomfinder.modalX + 'px, ' + state.map.roomfinder.modalY + 'px)'}"
               id="modalRoomfinder-map-cross"
             />

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -334,7 +334,7 @@
     </div>
     <!-- Modal-Roomfinder -->
     <div
-      class="modal modal-lg active"
+      class="modal modal-lg"
       id="modal-roomfinder"
       v-bind:class="{active: map.roomfinder.modalOpen}"
     >

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -239,7 +239,10 @@
           <div id="interactive-map" class="loading"></div>
         </div>
       </div>
-        <a @click="map.roomfinder.modalOpen=true">
+        <a
+          v-on:click="loadModalRoomfinderMap()"
+          @click="map.roomfinder.modalOpen=true"
+        >
           <div
             class="roomfinder-map-container"
             v-bind:class="{'d-none': state.map.selected !== 'roomfinder'}"
@@ -333,7 +336,7 @@
     <div
       class="modal modal-lg active"
       id="modal-roomfinder"
-      v-if="map.roomfinder.modalOpen"
+      v-bind:class="{active: map.roomfinder.modalOpen}"
     >
       <a
         class="modal-overlay"
@@ -341,7 +344,7 @@
         @click="map.roomfinder.modalOpen=false"
       >
       </a>
-      <div class="modal-container modal-fullheight">
+      <div class="modal-container modal-fullheight" id="roomfinderModal-container">
         <div class="modal-header">
           <button
             class="btn btn-clear float-right"
@@ -353,6 +356,12 @@
         </div>
         <div class="modal-body">
           <div class="content" id="modalRoomfinderContent">
+            <img
+              alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
+              src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"
+              v-bind:style="{'transform': 'translate(' + state.map.roomfinder.modalX + 'px, ' + state.map.roomfinder.modalY + 'px)'}"
+              id="modalRoomfinder-map-cross"
+            />
             <img
               alt="Hand-drawn roomfinder map image"
               v-bind:src="'<!-- @echo cdn_prefix -->maps/roomfinder/' + view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].file"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -240,7 +240,7 @@
         </div>
       </div>
         <a
-          v-on:click="loadModalRoomfinderMap()"
+          v-on:click="setTimeout(loadModalRoomfinderMap, 1000)"
           @click="map.roomfinder.modalOpen=true"
         >
           <div
@@ -359,6 +359,7 @@
             <img
               alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
               src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"
+              style="display: none"
               v-bind:style="{'transform': 'translate(' + state.map.roomfinder.modalX + 'px, ' + state.map.roomfinder.modalY + 'px)'}"
               id="modalRoomfinder-map-cross"
             />

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -239,7 +239,7 @@
           <div id="interactive-map" class="loading"></div>
         </div>
       </div>
-        <a @click="map.roomfinder.modalRoomfinder_open=true">
+        <a @click="map.roomfinder.modalOpen=true">
           <div
             class="roomfinder-map-container"
             v-bind:class="{'d-none': state.map.selected !== 'roomfinder'}"
@@ -333,12 +333,12 @@
     <div
       class="modal modal-lg active"
       id="modal-roomfinder"
-      v-if="map.roomfinder.modalRoomfinder_open"
+      v-if="map.roomfinder.modalOpen"
     >
       <a
         class="modal-overlay"
         aria-label="Close"
-        @click="map.roomfinder.modalRoomfinder_open=false"
+        @click="map.roomfinder.modalOpen=false"
       >
       </a>
       <div class="modal-container modal-fullheight">
@@ -346,7 +346,7 @@
           <button
             class="btn btn-clear float-right"
             aria-label="${{_view_view.modalRoomfinder.close}}$"
-            @click="map.roomfinder.modalRoomfinder_open=false"
+            @click="map.roomfinder.modalOpen=false"
           >
           </button>
             <h5 class="modal-title">${{_.view_view.modalRoomfinder.header}}$</h5>

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -240,8 +240,8 @@
         </div>
       </div>
         <a
-          v-on:click="setTimeout(loadModalRoomfinderMap, 1000)"
           @click="map.roomfinder.modalOpen=true"
+          v-on:click="delayedLoadModalRoomfinderMap"
         >
           <div
             class="roomfinder-map-container"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -340,7 +340,7 @@
     >
       <a
         class="modal-overlay"
-        aria-label="Close"
+        aria-label="${{_.view_view.modalRoomfinder.close}}$"
         @click="map.roomfinder.modalOpen=false"
       >
       </a>
@@ -370,6 +370,11 @@
               v-bind:height="state.map.roomfinder.height"
               id="modalRoomfinder-map-img"
             />
+            <div>
+              ${{_.view_view.map.img_source}}$: {{
+                  view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].source
+              }}
+            </div>
           </div>
         </div>
       </div>

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -239,31 +239,33 @@
           <div id="interactive-map" class="loading"></div>
         </div>
       </div>
-      <div
-        class="roomfinder-map-container"
-        v-bind:class="{'d-none': state.map.selected !== 'roomfinder'}"
-        v-if="view_data.maps.roomfinder && view_data.maps.roomfinder.available"
-      >
-        <img
-          alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
-          src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"
-          v-bind:style="{'transform': 'translate(' + state.map.roomfinder.x + 'px, ' + state.map.roomfinder.y + 'px)'}"
-          id="roomfinder-map-cross"
-        />
-        <img
-          alt="Hand-drawn roomfinder map image"
-          v-bind:src="'<!-- @echo cdn_prefix -->maps/roomfinder/' + view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].file"
-          class="img-responsive"
-          v-bind:width="state.map.roomfinder.width"
-          v-bind:height="state.map.roomfinder.height"
-          id="roomfinder-map-img"
-        />
-        <div>
-          ${{_.view_view.map.img_source}}$: {{
-          view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].source
-          }}
-        </div>
-      </div>
+        <a @click="map.roomfinder.modalRoomfinder_open=true">
+          <div
+            class="roomfinder-map-container"
+            v-bind:class="{'d-none': state.map.selected !== 'roomfinder'}"
+            v-if="view_data.maps.roomfinder && view_data.maps.roomfinder.available"
+          >
+            <img
+              alt="Cross showing where the room is located on the hand-drawn roomfinder map image"
+              src="<!-- @echo app_prefix -->assets/roomfinder_cross-v2.webp"
+              v-bind:style="{'transform': 'translate(' + state.map.roomfinder.x + 'px, ' + state.map.roomfinder.y + 'px)'}"
+              id="roomfinder-map-cross"
+            />
+            <img
+              alt="Hand-drawn roomfinder map image"
+              v-bind:src="'<!-- @echo cdn_prefix -->maps/roomfinder/' + view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].file"
+              class="img-responsive"
+              v-bind:width="state.map.roomfinder.width"
+              v-bind:height="state.map.roomfinder.height"
+              id="roomfinder-map-img"
+            />
+            <div>
+              ${{_.view_view.map.img_source}}$: {{
+              view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].source
+              }}
+            </div>
+          </div>
+        </a>
       <div
         class="accordion"
         id="roomfinder-map-select"
@@ -326,6 +328,42 @@
         </button>
       </div>
       <div class="divider" style="margin-top: 10px"></div>
+    </div>
+    <!-- Modal-Roomfinder -->
+    <div
+      class="modal modal-lg active"
+      id="modal-roomfinder"
+      v-if="map.roomfinder.modalRoomfinder_open"
+    >
+      <a
+        class="modal-overlay"
+        aria-label="Close"
+        @click="map.roomfinder.modalRoomfinder_open=false"
+      >
+      </a>
+      <div class="modal-container modal-fullheight">
+        <div class="modal-header">
+          <button
+            class="btn btn-clear float-right"
+            aria-label="${{_view_view.modalRoomfinder.close}}$"
+            @click="map.roomfinder.modalRoomfinder_open=false"
+          >
+          </button>
+            <h5 class="modal-title">${{_.view_view.modalRoomfinder.header}}$</h5>
+        </div>
+        <div class="modal-body">
+          <div class="content" id="modalRoomfinderContent">
+            <img
+              alt="Hand-drawn roomfinder map image"
+              v-bind:src="'<!-- @echo cdn_prefix -->maps/roomfinder/' + view_data.maps.roomfinder.available[state.map.roomfinder.selected_index].file"
+              class="img-responsive"
+              v-bind:width="state.map.roomfinder.width"
+              v-bind:height="state.map.roomfinder.height"
+              id="modalRoomfinder-map-img"
+            />
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Information section (on mobile) -->

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -53,6 +53,8 @@ const _viewDefaultState = {
       selected_index: null, // Index in the 'available' list
       x: -1023 - 10, // Outside in top left corner
       y: -1023 - 10,
+      modalX: -1023 -10,
+      modalY: -1023 -10,
       width: 400,
       height: 300,
     },

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -541,6 +541,9 @@ navigatum.registerView("view", {
           (map.y / map.height) * (rect.width - 16) * (map.height / map.width);
       document.getElementById("modalRoomfinder-map-cross").style.display="block"
     },
+    delayedLoadModalRoomfinderMap: function () {
+      setTimeout(this.loadModalRoomfinderMap, 1000);
+    },
     updateRoomsOverview: function (setSelected) {
       const state = this.state.rooms_overview;
       const data = this.view_data.sections.rooms_overview;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -524,6 +524,22 @@ navigatum.registerView("view", {
         );
       }
     },
+    loadModalRoomfinderMap: function () {
+      const map = this.view_data.maps.roomfinder.available[mapIndex];
+
+      const rect = document
+          .getElementById("roomfinderModal-container")
+          .getBoundingClientRect();
+      // -1023px, -1023px is top left corner, 16px = 2*8px is element padding
+      this.state.map.roomfinder.modalX =
+          -1023 + (map.x / map.width) * (rect.width - 16);
+
+      // We cannot use "height" here as it might be still zero before layouting
+      // finished, so we use the aspect ratio here.
+      this.state.map.roomfinder.modalY =
+          -1023 +
+          (map.y / map.height) * (rect.width - 16) * (map.height / map.width);
+    },
     updateRoomsOverview: function (setSelected) {
       const state = this.state.rooms_overview;
       const data = this.view_data.sections.rooms_overview;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -85,6 +85,9 @@ navigatum.registerView("view", {
           marker: null,
           marker2: null,
         },
+        roomfinder: {
+          modalRoomfinder_open: false,
+        }
       },
       sections: {
         rooms_overview: {

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -532,14 +532,13 @@ navigatum.registerView("view", {
           .getBoundingClientRect();
       // -1023px, -1023px is top left corner, 16px = 2*8px is element padding
       this.state.map.roomfinder.modalX =
-          -1023 + (map.x / map.width) * (rect.width - 16);
+          -1023 + (map.x / map.width) * (rect.width - 65);
 
       // We cannot use "height" here as it might be still zero before layouting
       // finished, so we use the aspect ratio here.
       this.state.map.roomfinder.modalY =
           -1023 +
-          (map.y / map.height) * (rect.width - 16) * (map.height / map.width);
-      document.getElementById("modalRoomfinder-map-cross").style.display="block"
+          (map.y / map.height) * (rect.width - 65) * (map.height / map.width);
     },
     delayedLoadModalRoomfinderMap: function () {
       setTimeout(this.loadModalRoomfinderMap, 1000);

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -86,7 +86,7 @@ navigatum.registerView("view", {
           marker2: null,
         },
         roomfinder: {
-          modalRoomfinder_open: false,
+          modalOpen: false,
         }
       },
       sections: {

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -539,6 +539,7 @@ navigatum.registerView("view", {
       this.state.map.roomfinder.modalY =
           -1023 +
           (map.y / map.height) * (rect.width - 16) * (map.height / map.width);
+      document.getElementById("modalRoomfinder-map-cross").style.display="block"
     },
     updateRoomsOverview: function (setSelected) {
       const state = this.state.rooms_overview;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -525,7 +525,7 @@ navigatum.registerView("view", {
       }
     },
     loadModalRoomfinderMap: function () {
-      const map = this.view_data.maps.roomfinder.available[mapIndex];
+      const map = this.view_data.maps.roomfinder.available[this.state.map.roomfinder.selected_index];
 
       const rect = document
           .getElementById("roomfinderModal-container")

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -359,7 +359,7 @@
     }
 
     #modalRoomfinder-map-img {
-        width: 100%;
+        width: 100%; // Without this part the image doesn't fill the modal over the whole width.
     }
 
     .accordion-body {

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -320,6 +320,7 @@
         overflow: hidden;
         position: relative;
         margin-bottom: 6px;
+        cursor: pointer;
 
         > div {  // Image source label
             position: absolute;
@@ -345,6 +346,17 @@
 
     #roomfinder-map-select > label {
         padding: .05rem .3rem;
+    }
+
+    #modalRoomfinder-map-cross {
+        position: absolute;
+        transition: transform .3s;
+        pointer-events: none;
+    }
+
+    #modalRoomfinder-map-img {
+        width: 100%;
+        display: block;
     }
 
     .accordion-body {
@@ -547,6 +559,16 @@
                 animation: none;
                 transform: translateX(0);
             }
+        }
+    }
+
+    /* --- Modal Roomfinder --- */
+    #modal-roomfinder {
+        align-items: baseline;
+
+        & .modal-container {
+            position: relative;
+            top: 5em;
         }
     }
 }

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -348,9 +348,15 @@
         padding: .05rem .3rem;
     }
 
+    #roomfinderModal-container {
+        overflow: hidden;
+        position: relative;
+        margin-bottom: 6px;
+    }
+
     #modalRoomfinder-map-cross {
         position: absolute;
-        transition: transform .3s;
+        transition: transform 1s;
         pointer-events: none;
     }
 

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -354,7 +354,7 @@
 
     #modalRoomfinder-map-cross {
         position: absolute;
-        transition: transform 1s;
+        transition: transform .3s;
         pointer-events: none;
     }
 

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -320,7 +320,6 @@
         overflow: hidden;
         position: relative;
         margin-bottom: 6px;
-        cursor: pointer;
 
         > div {  // Image source label
             position: absolute;
@@ -342,6 +341,7 @@
     #roomfinder-map-img {
         width: 100%;
         display: block;
+        cursor: pointer;
     }
 
     #roomfinder-map-select > label {
@@ -349,9 +349,7 @@
     }
 
     #roomfinderModal-container {
-        overflow: hidden;
-        position: relative;
-        margin-bottom: 6px;
+        padding-bottom: 4em;
     }
 
     #modalRoomfinder-map-cross {
@@ -362,7 +360,6 @@
 
     #modalRoomfinder-map-img {
         width: 100%;
-        display: block;
     }
 
     .accordion-body {


### PR DESCRIPTION
Resolves: https://github.com/TUM-Dev/NavigaTUM/issues/143
![grafik](https://user-images.githubusercontent.com/109673982/200568545-d2cb8577-e699-4f62-963d-5084839d70ef.png)

Is the roomfinder-map sufficient or should the map-cross also be implemented to the modal?
I already tried to implement the cross but it is a bit difficult with the position because I think you have to make a function like the `loadRoomfinderMap`-function for the roomfinder modal. 