### PR TITLE
[Cal-5] Added the calendar-modal

### DIFF
--- a/webclient/src/views/view/i18n-view.yaml
+++ b/webclient/src/views/view/i18n-view.yaml
@@ -10,7 +10,9 @@ view_view:
       share: { de: "Teilen", en: "Share" }
       share_link: { de: "Teilen mit ...", en: "Share with ..." }
       copied: { de: "Kopiert", en: "Copied" }
-    calendar: { de: "Kalender öffnen", en: "Open calendar" }
+    calendar:
+      open: { de: "Kalender öffnen", en: "Open calendar" }
+      close: { de: "Kalender schließen", en: "Close calendar" }
     feedback:
       de: "Problem melden oder Änderung vorschlagen"
       en: "Report issue or suggest changes"

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -204,7 +204,7 @@
           </div>
           <div class="modal-body">
             <div class="content" id="modalCalendarContent">
-              <iframe src="view_data.props.calendar_url"></iframe>
+              <iframe src="view_data.props.calendar_url" id="calendarModalIFrame"></iframe>
             </div>
           </div>
         </div>

--- a/webclient/src/views/view/view-view.inc
+++ b/webclient/src/views/view/view-view.inc
@@ -97,8 +97,6 @@
         <a
           class="btn btn-link btn-action btn-sm"
           v-if="view_data.props?.calendar_url"
-          v-bind:href="view_data.props.calendar_url"
-          target="_blank"
           title="${{ _.view_view.header.calendar }}$"
         >
           <svg
@@ -184,6 +182,33 @@
       </div>
     </div>
     <div class="divider"></div>
+    <!-- Modal-Calendar -->
+    <div
+      class="modal modal-lg"
+      id="modal-calendar"
+      v-bind:class="{active: calendar.modalOpen}"
+    >
+      <a
+        class="modal-overlay"
+        aria-label="Close"
+        @click="calendar.modalOpen=false"
+      >
+      </a>
+        <div class="modal-container modal-fullheight" id="calendarModal-container">
+          <div class="modal-header">
+            <button
+              class="btn btn-clear float-right"
+              aria-label="${{_.view_view.header.calendar.close}}$"
+              @click="calendar.modalOpen=false"
+            ></button>
+          </div>
+          <div class="modal-body">
+            <div class="content" id="modalCalendarContent">
+              <iframe src="view_data.props.calendar_url"></iframe>
+            </div>
+          </div>
+        </div>
+    </div>
   </div>
 
   <!-- First info section (map + infocard) -->

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -117,6 +117,9 @@ navigatum.registerView("view", {
         body_backup: null,
         force_reopen: false,
       },
+      calendar: {
+        modalOpen: false,
+      },
       browser_supports_share: "share" in navigator,
     };
   },

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -104,6 +104,16 @@
         }
     }
 
+    /* --- Modal Calendar --- */
+    #modal-calendar {
+        align-items: baseline;
+
+        & .modal-container {
+            position: relative;
+            top: 5em;
+        }
+    }
+
     /* --- Pending coordinates counter --- */
     .coord-counter {
         margin: 8px 0;

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -114,6 +114,10 @@
         }
     }
 
+    #calendarModalIFrame {
+        width: 100%;
+    }
+
     /* --- Pending coordinates counter --- */
     .coord-counter {
         margin: 8px 0;


### PR DESCRIPTION
Closes https://github.com/TUM-Dev/NavigaTUM/issues/289

![grafik](https://user-images.githubusercontent.com/109673982/204244240-6ca4369e-f723-48fb-aaf6-80ebfc3dee0a.png)

I added the modal for the calendar when clicking on the calendar icon. I used an iframe to display the TUMOnline website but the URL is not found. I don't know what's the problem because it is the same URL which is used to open the website.
