### PR TITLE
Fixed the feedback-success-ok-button bug

### DIFF
--- a/webclient/src/feedback.js
+++ b/webclient/src/feedback.js
@@ -221,6 +221,9 @@ window.feedback = (() => {
     .getElementById("feedback-close-2")
     .addEventListener("click", closeForm, false);
   document
+      .getElementById("feedback-ok")
+      .addEventListener("click", closeForm, false);
+  document
     .getElementById("feedback-overlay-2")
     .addEventListener("click", closeForm, false);
 

--- a/webclient/src/index.html
+++ b/webclient/src/index.html
@@ -414,7 +414,7 @@
             <p>${{_.feedback.success.thank_you}}$</p>
             <p>${{_.feedback.success.response_at}}$ <a id="feedback-success-url" class="btn-link" href="https://github.com/TUM-Dev/navigatum/issues">${{_.feedback.success.this_issue}}$</a></p>
             <div class="buttons">
-              <button class="btn btn-primary" id="feedback-close-2">${{_.feedback.success.ok}}$</button>
+              <button class="btn btn-primary" id="feedback-ok">${{_.feedback.success.ok}}$</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Resolves #350 

## Proposed Changes 

- Now the ok-button closes the feedback-success-modal

## How to test this PR

1. Submit a feedback
2. Get the feedback-success-modal
3. Click on the ok-button
4. See that it closes the modal

## How has this been tested?

- Windows 11
- Firefox Version: 108.0.2 (64-bit)
## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [ ] I have run the linter
