### PR TITLE
Fixed the roomfinder-cross-bug

### DIFF
--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -662,7 +662,7 @@ navigatum.registerView("view", {
     };
     window.addEventListener("storage", updateCoordinateCounter);
     updateCoordinateCounter();
-    window.addEventListener('resize', () => {
+    window.addEventListener("resize", () => {
       this.loadRoomfinderMap(this.state.map.roomfinder.selected_index, false);
       this.loadModalRoomfinderMap();
     });

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -662,6 +662,10 @@ navigatum.registerView("view", {
     };
     window.addEventListener("storage", updateCoordinateCounter);
     updateCoordinateCounter();
+    window.addEventListener('resize', () => {
+      this.loadRoomfinderMap(this.state.map.roomfinder.selected_index, false);
+      this.loadModalRoomfinderMap();
+    });
 
     this.$nextTick(() => {
       // Even though 'mounted' is called there is no guarantee apparently,


### PR DESCRIPTION
Fixes #323 

## Proposed Changes (include Screenshots if possible)

- Now it updates the cross position when the browser-window is resized
- For the main-roomfinder and the modal-roomfinder

At fullsize:
![grafik](https://user-images.githubusercontent.com/109673982/213402892-7c259532-dc7e-4ef7-9d89-d66efd0d0368.png)

At smaller size:
![grafik](https://user-images.githubusercontent.com/109673982/213403005-9d326ff3-7f61-4341-aae6-2c5af5c83989.png)


## How to test this PR

1. Go to any roomfinder-map or to any modal-roomfinder
2. Resize your browser-window to any size
3. See that the cross stays at the same place

## How has this been tested?

- Windows 11
- Firefox Version 108.0.2 (64-Bit)

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
