### PR TITLE
Dropped UTM support

### DIFF
--- a/data/data_format_geo-entry.yaml
+++ b/data/data_format_geo-entry.yaml
@@ -106,7 +106,6 @@ internal_id:
   coords:  # required for anything except type==root
     lat: 0.0
     lon: 0.0
-    utm: {zone_number: 32, zone_letter: "U", northing: 0.0, easting: 0.0}
     source: one of "roomfinder", "navigatum" or "inferred"
     accuracy: one of "building"  # optional
   

--- a/data/processors/coords.py
+++ b/data/processors/coords.py
@@ -36,7 +36,7 @@ def assign_coordinates(data):
             if "source" not in entry["coords"]:
                 entry["coords"]["source"] = "navigatum"
         else:
-            # For rooms we check whether its parent has a coordinate
+            # For rooms, we check whether its parent has a coordinate
             if entry["type"] in {"room", "virtual_room"}:
                 building_parent = [data[e] for e in entry["parents"] if data[e]["type"] == "building"]
                 if len(building_parent) != 1:
@@ -72,14 +72,6 @@ def _get_coordinte_from_parent(building_parent):
 
 def _convert_coordinate_formats(entry):
     """Convert between utm and lat/lon if necessary"""
-    if "utm" not in entry["coords"]:
-        utm_coord = utm.from_latlon(entry["coords"]["lat"], entry["coords"]["lon"])
-        entry["coords"]["utm"] = {
-            "zone_number": utm_coord[2],
-            "zone_letter": utm_coord[3],
-            "easting": utm_coord[0],
-            "northing": utm_coord[1],
-        }
     if "lat" not in entry["coords"]:
         utm_coord = entry["coords"]["utm"]
         latlon_coord = utm.to_latlon(
@@ -101,16 +93,9 @@ def _calc_coordinte_from_children(data, entry):
             lons.append(data[child]["coords"]["lon"])
     lat_coord = sum(lats) / len(lats)
     lon_coord = sum(lons) / len(lons)
-    utm_coord = utm.from_latlon(lat_coord, lon_coord)
     return {
         "lat": lat_coord,
         "lon": lon_coord,
-        "utm": {
-            "zone_number": utm_coord[2],
-            "zone_letter": utm_coord[3],
-            "easting": utm_coord[0],
-            "northing": utm_coord[1],
-        },
         "source": "inferred",
     }
 

--- a/data/processors/roomfinder.py
+++ b/data/processors/roomfinder.py
@@ -156,12 +156,6 @@ def _get_roomfinder_coords(obj):
     return {
         "lat": lat,
         "lon": lon,
-        "utm": {
-            "zone_number": int(obj["utm_zone"]),
-            "zone_letter": "U",
-            "easting": obj["utm_easting"],
-            "northing": obj["utm_northing"],
-        },
         "source": "roomfinder",
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -346,11 +346,6 @@ paths:
                       lat: 48.26244490906312
                       lon: 11.669122601167174
                       source: roomfinder
-                      utm:
-                        easting: 698084.5345
-                        northing: 5348914.6199
-                        zone_letter: U
-                        zone_number: 32
                     id: 5602.EG.001
                     maps:
                       default: interactive
@@ -446,11 +441,6 @@ paths:
                       lat: 48.26217845031176
                       lon: 11.6686932781057
                       source: roomfinder
-                      utm:
-                        easting: 698053.7056
-                        northing: 5348883.8982
-                        zone_letter: U
-                        zone_number: 32
                     id: 5606.EG.036
                     maps:
                       default: interactive
@@ -1213,31 +1203,6 @@ components:
           description: The source of the Coordinates
           type: string
           example: roomfinder
-        utm:
-          type: object
-          properties:
-            easting:
-              description: The easting
-              type: number
-              format: double
-              example: 698288.4681410069
-            northing:
-              description: The northing
-              type: number
-              format: double
-              example: 5349538.736274569
-            zone:
-              description: The zone
-              type: string
-              example: U
-              pattern: '[C-HJ-NP-X]'
-            zone_number:
-              description: The zone number
-              type: integer
-              format: int32
-              example: 32
-              maximum: 60
-              minimum: 1
       required:
         - lat
         - lon


### PR DESCRIPTION

## Proposed Changes (include Screenshots if possible)

- This PR drops the support for UTM being delivered to the client
- Main reason is, that I doubt anybody would ever need this feature (most tools support lat-lon)

## How to test this PR

1. Check if utm is really removed from API responses

## How has this been tested?

- Genereated a few responses, for which utm did not show up

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter

Note, that this will need an entry in #130