### PR TITLE
Switch to MapLibre GL

### DIFF
--- a/webclient/gulpfile.js
+++ b/webclient/gulpfile.js
@@ -632,19 +632,19 @@ function copyWellKnownRoot() {
 }
 gulp.task("well_known", gulp.parallel(copyWellKnown, copyWellKnownRoot));
 
-// --- map (currently mapbox) Pipeline ---
+// --- map (currently maplibre) Pipeline ---
 function copyMapCSS() {
   return gulp
-    .src(["node_modules/mapbox-gl/dist/mapbox-gl.css"])
-    .pipe(concat("mapbox.css"))
+    .src(["node_modules/maplibre-gl/dist/maplibre-gl.css"])
+    .pipe(concat("maplibre.css"))
     .pipe(gulpif(config.target === "release", csso()))
     .pipe(gulpif(config.target === "release", rename({ suffix: ".min" })))
     .pipe(gulp.dest("build/css"));
 }
 function copyMapJS() {
   return gulp
-    .src(["node_modules/mapbox-gl/dist/mapbox-gl.js"])
-    .pipe(concat("mapbox.js"))
+    .src(["node_modules/maplibre-gl/dist/maplibre-gl.js"])
+    .pipe(concat("maplibre.js"))
     .pipe(gulpif(config.target === "release", uglify()))
     .pipe(gulpif(config.target === "release", rename({ suffix: ".min" })))
     .pipe(gulp.dest("build/js"));

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -119,7 +119,7 @@
     "@babel/core": "^7.14.8",
     "@babel/preset-env": "^7.14.8",
     "babel-plugin-transform-remove-strict-mode": "^0.0.2",
-    "mapbox-gl": "^2.7.0",
+    "maplibre-gl": "^2.4.0",
     "polyfill": "^0.1.0",
     "regenerator": "^0.14.7",
     "regenerator-runtime": "^0.13.9",

--- a/webclient/src/md/datenschutz.md
+++ b/webclient/src/md/datenschutz.md
@@ -119,32 +119,6 @@ Schreiben Sie dafür bitte eine E-Mail an den unten aufgeführten Datenschutzbea
 
 Die Bereitstellung dieser nicht personenbezogenen Daten erfolgt freiwillig.
 
-## Karten
-
-### Freiwilligkeit
-
-Die Nutzung der Maps erfolgt auf einer freiwilligen Basis.
-Für die Nutzung des Kartenfeatures muss den [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zugestimmt werden.
-
-### Übertragene Daten
-
-Die übertragenen Daten sind unter [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zu finden.
-Mapbox benutzt diese als telemetriedaten, um den Service zu verbessern.
-
-### Empfänger:
-
-Die übertragenen Daten werden von Mapbox übermittelt.
-
-### Speicherdauer:
-
-Die Daten werden laut Mapbox spätestens nach 30 Tagen automatisch gelöscht.
-Zu weiteren Rechten sind die [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zu beachten.
-
-### Bereitstellung vorgeschrieben oder erforderlich:
-
-Die Bereitstellung dieser nicht personenbezogenen Daten wird erforderlich, sofern ein nutzer die Details-Seite mit Karten angeschauten will.  
-Andernfalls sind sie freiwillig.
-
 ## SSL-Verschlüsselung
 
 Um die Sicherheit Ihrer Daten bei der Übertragung zu schützen, verwenden wir dem aktuellen Stand der Technik entsprechende Verschlüsselungsverfahren (z. B. SSL) über HTTPS.

--- a/webclient/src/md/privacy.md
+++ b/webclient/src/md/privacy.md
@@ -121,32 +121,6 @@ Schreiben Sie dafür bitte eine E-Mail an den unten aufgeführten Datenschutzbea
 
 Die Bereitstellung dieser nicht personenbezogenen Daten erfolgt freiwillig.
 
-## Karten
-
-### Freiwilligkeit
-
-Die Nutzung der Maps erfolgt auf einer freiwilligen Basis.
-Für die Nutzung des Kartenfeatures muss den [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zugestimmt werden.
-
-### Übertragene Daten
-
-Die übertragenen Daten sind unter [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zu finden.
-Mapbox benutzt diese als telemetriedaten, um den Service zu verbessern.
-
-### Empfänger:
-
-Die übertragenen Daten werden von Mapbox übermittelt.
-
-### Speicherdauer:
-
-Die Daten werden laut Mapbox spätestens nach 30 Tagen automatisch gelöscht.
-Zu weiteren Rechten sind die [Tearms of Service und den Datenschutzbestimmungen von Mapbox](https://www.mapbox.com/legal/privacy) zu beachten.
-
-### Bereitstellung vorgeschrieben oder erforderlich:
-
-Die Bereitstellung dieser nicht personenbezogenen Daten wird erforderlich, sofern ein nutzer die Details-Seite mit Karten angeschauten will.  
-Andernfalls sind sie freiwillig.
-
 ## SSL-Verschlüsselung
 
 Um die Sicherheit Ihrer Daten bei der Übertragung zu schützen, verwenden wir dem aktuellen Stand der Technik entsprechende Verschlüsselungsverfahren (z. B. SSL) über HTTPS.

--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -233,7 +233,7 @@ navigatum.registerModule(
           antialias: true,
 
           // preview of the following style is available at
-          // https://nav.tum.de/maps/styles/osm_liberty/?vector
+          // https://nav.tum.de/maps/
           style: "https://nav.tum.de/maps/styles/osm_liberty/style.json",
 
           center: [11.5748, 48.14], // Approx Munich

--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -282,6 +282,14 @@ navigatum.registerModule(
             fullscreenCtl._map.resize();
           }
         };
+        // There is a bug that the map doesn't update to the new size
+        // when changing between fullscreen in the mobile version.
+        if (isMobile && ResizeObserver) {
+          const fullscreenObserver = new ResizeObserver(() => {
+            fullscreenCtl._map.resize();
+          });
+          fullscreenObserver.observe(fullscreenCtl._container);
+        }
         map.addControl(fullscreenCtl);
 
         const location = new maplibregl.GeolocateControl({

--- a/webclient/src/modules/interactive-map.js
+++ b/webclient/src/modules/interactive-map.js
@@ -1,22 +1,22 @@
 navigatum.registerModule(
   "interactive-map",
   (() => {
-    /* global mapboxgl */
+    /* global maplibregl */
     let _map;
 
     function FloorControl() {}
 
-    // Because mapboxgl might not be loaded yet, we need to postpone
+    // Because maplibregl might not be loaded yet, we need to postpone
     // the declaration of the FloorControl class
     function floorControlInit() {
-      // Add Evented functionality from mapboxgl
-      FloorControl.prototype = Object.create(mapboxgl.Evented.prototype);
+      // Add Evented functionality from maplibregl
+      FloorControl.prototype = Object.create(maplibregl.Evented.prototype);
 
       FloorControl.prototype.onAdd = function onAdd(map) {
         this.map = map;
         this.container = document.createElement("div");
-        this.container.classList.add("mapboxgl-ctrl-group");
-        this.container.classList.add("mapboxgl-ctrl");
+        this.container.classList.add("maplibregl-ctrl-group");
+        this.container.classList.add("maplibregl-ctrl");
         this.container.classList.add("floor-ctrl");
 
         // vertical open/collapse button
@@ -137,10 +137,10 @@ navigatum.registerModule(
         const mapHeight =
           document.getElementById("interactive-map").clientHeight;
         const topCtrlHeight = document.querySelector(
-          ".mapboxgl-ctrl-top-left"
+          ".maplibregl-ctrl-top-left"
         ).clientHeight;
         const bottomCtrlHeight = document.querySelector(
-          ".mapboxgl-ctrl-bottom-left"
+          ".maplibregl-ctrl-bottom-left"
         ).clientHeight;
         const floorCtrlHeight =
           document.querySelector(".floor-ctrl").clientHeight;
@@ -186,17 +186,17 @@ navigatum.registerModule(
       init: () =>
         new Promise((resolve) => {
           const head = document.getElementsByTagName("head")[0];
-          // Add CSS first (required by Mapbox)
+          // Add CSS first (required by Maplibre)
           const elCSS = document.createElement("link");
           elCSS.rel = "stylesheet";
           elCSS.href =
-            "/* @echo app_prefix */css/mapbox/* @if target='release' */.min/* @endif */.css";
+            "/* @echo app_prefix */css/maplibre/* @if target='release' */.min/* @endif */.css";
           head.appendChild(elCSS);
 
           // JS should trigger init on load
           const elJS = document.createElement("script");
           elJS.src =
-            "/* @echo app_prefix */js/mapbox/* @if target='release' */.min/* @endif */.js";
+            "/* @echo app_prefix */js/maplibre/* @if target='release' */.min/* @endif */.js";
           elJS.onload = () => {
             floorControlInit();
             resolve();
@@ -225,9 +225,7 @@ navigatum.registerModule(
         return markerDiv;
       },
       initMap: function (containerId) {
-        mapboxgl.accessToken =
-          "pk.eyJ1IjoiY29tbWFuZGVyc3Rvcm0iLCJhIjoiY2t6ZGJyNDBoMDU2ZzJvcGN2eTg2cWtxaSJ9.PY6Drc3tYHGqSy0UVmVnCg";
-        const map = new mapboxgl.Map({
+        const map = new maplibregl.Map({
           container: containerId,
 
           // create the gl context with MSAA antialiasing, so custom layers are antialiasing.
@@ -235,16 +233,16 @@ navigatum.registerModule(
           antialias: true,
 
           // preview of the following style is available at
-          // https://api.mapbox.com/styles/v1/commanderstorm/ckzdc14en003m14l9l8iqwotq.html?title=copy&access_token=pk.eyJ1IjoiY29tbWFuZGVyc3Rvcm0iLCJhIjoiY2t6ZGJyNDBoMDU2ZzJvcGN2eTg2cWtxaSJ9.PY6Drc3tYHGqSy0UVmVnCg&zoomwheel=true&fresh=true#16.78/48.264624/11.670726
-          style:
-            "mapbox://styles/commanderstorm/ckzdc14en003m14l9l8iqwotq?optimize=true",
+          // https://nav.tum.de/maps/styles/osm_liberty/?vector
+          style: "https://nav.tum.de/maps/styles/osm_liberty/style.json",
 
           center: [11.5748, 48.14], // Approx Munich
           zoom: 11, // Zoomed out so that the whole city is visible
 
-          logoPosition: "bottom-left",
+          attributionControl: false,
         });
-        const nav = new mapboxgl.NavigationControl();
+
+        const nav = new maplibregl.NavigationControl();
         map.addControl(nav, "top-left");
 
         // (Browser) Fullscreen is enabled only on mobile, on desktop the map
@@ -255,12 +253,12 @@ navigatum.registerModule(
           window.matchMedia &&
           window.matchMedia("only screen and (max-width: 480px)").matches;
 
-        const fullscreenCtl = new mapboxgl.FullscreenControl({
+        const fullscreenCtl = new maplibregl.FullscreenControl({
           container: isMobile
             ? document.getElementById("interactive-map")
             : document.getElementById("interactive-map-container"),
         });
-        // "Backup" the mapboxgl default fullscreen handler
+        // "Backup" the maplibregl default fullscreen handler
         fullscreenCtl._onClickFullscreenDefault =
           fullscreenCtl._onClickFullscreen;
         fullscreenCtl._onClickFullscreen = () => {
@@ -286,7 +284,7 @@ navigatum.registerModule(
         };
         map.addControl(fullscreenCtl);
 
-        const location = new mapboxgl.GeolocateControl({
+        const location = new maplibregl.GeolocateControl({
           positionOptions: {
             enableHighAccuracy: true,
           },
@@ -301,6 +299,15 @@ navigatum.registerModule(
         // succeded.
         map.on("load", () => {
           map.initialLoaded = true;
+
+          // The attributionControl is automatically open, which takes up a lot of
+          // space on the small map display that we have. That's why we add it ourselves
+          // and then toggle it.
+          // It's only added after loading because if we add it directly on map initialization
+          // for some reason it doesn't work.
+          const attrib = new maplibregl.AttributionControl({ compact: true });
+          map.addControl(attrib);
+          attrib._toggleAttribution();
         });
 
         const _this = this;

--- a/webclient/src/views/view/view-view.js
+++ b/webclient/src/views/view/view-view.js
@@ -1,4 +1,4 @@
-/* global mapboxgl */
+/* global maplibregl */
 function viewNavigateTo(to, from, next, component) {
   navigatum.beforeNavigate(to, from);
 
@@ -252,7 +252,7 @@ navigatum.registerView("view", {
         );
 
         const { coords } = currentEdits[this.view_data.id] || this.view_data;
-        const marker2 = new mapboxgl.Marker({
+        const marker2 = new maplibregl.Marker({
           draggable: true,
           color: "#ff0000",
         });
@@ -428,7 +428,7 @@ navigatum.registerView("view", {
             if (
               document
                 .getElementById("interactive-map")
-                .classList.contains("mapboxgl-map")
+                .classList.contains("maplibregl-map")
             ) {
               marker.remove();
             } else {
@@ -440,7 +440,7 @@ navigatum.registerView("view", {
                 .classList.remove("loading");
             }
           }
-          marker = new mapboxgl.Marker({ element: c.createMarker() });
+          marker = new maplibregl.Marker({ element: c.createMarker() });
           _this.map.interactive.marker = marker;
           const coords = _this.view_data.coords;
           marker.setLngLat([coords.lon, coords.lat]).addTo(map);
@@ -476,7 +476,7 @@ navigatum.registerView("view", {
       };
 
       // The map element should be visible when initializing
-      if (!document.querySelector("#interactive-map .mapboxgl-canvas"))
+      if (!document.querySelector("#interactive-map .maplibregl-canvas"))
         this.$nextTick(doMapUpdate());
       else doMapUpdate();
 
@@ -663,8 +663,10 @@ navigatum.registerView("view", {
     window.addEventListener("storage", updateCoordinateCounter);
     updateCoordinateCounter();
     window.addEventListener("resize", () => {
-      this.loadRoomfinderMap(this.state.map.roomfinder.selected_index, false);
-      this.loadModalRoomfinderMap();
+      if (this.state.map.selected === "roomfinder") {
+        this.loadRoomfinderMap(this.state.map.roomfinder.selected_index, false);
+        this.loadModalRoomfinderMap();
+      }
     });
 
     this.$nextTick(() => {

--- a/webclient/src/views/view/view-view.scss
+++ b/webclient/src/views/view/view-view.scss
@@ -168,7 +168,7 @@
         padding: 0 8px;
 
         // The marker2 (draggable)
-        .mapboxgl-marker + .mapboxgl-marker {
+        .maplibregl-marker + .maplibregl-marker {
             animation: fade-in .1s linear .05s;
             animation-fill-mode: both;
         }
@@ -222,7 +222,7 @@
         padding: 0;
     }
 
-    .mapboxgl-ctrl-group.floor-ctrl {
+    .maplibregl-ctrl-group.floor-ctrl {
         max-width: 100%;
         display: none;
         overflow: hidden;
@@ -305,13 +305,6 @@
                     border-top: 0;
                 }
             }
-        }
-
-        // mapbox logo
-        & + .mapboxgl-ctrl {
-            opacity: .4;
-            pointer-events: none;
-            z-index: -1;
         }
     }
 
@@ -474,8 +467,8 @@
     }
 
     /* --- User location dot --- */
-    .mapboxgl-user-location-dot,
-    .mapboxgl-user-location-dot::before {
+    .maplibregl-user-location-dot,
+    .maplibregl-user-location-dot::before {
         background-color: #3070b3;
     }
 
@@ -596,15 +589,6 @@
 // 'sm' (mobile)
 @media (max-width: 600px) {
     #view-view {
-        // The mapbox logo is taking away space from the layer
-        // selection on the bottom left on mobile, so we move
-        // it a bit
-        .floor-ctrl.visible + .mapboxgl-ctrl {
-            position: absolute;
-            bottom: 2px;
-            left: 42px;
-        }
-
         #rooms-overview-select .panel-body {
             max-height: 260px;
         }


### PR DESCRIPTION
Fixes #366 

## Proposed Changes (include Screenshots if possible)

- Drop-In replacement of MapBox GL with MapLibre GL
- Only visual change is that there is no longer a MapBox logo
- MapBox removed from the privacy

## How to test this PR

1. Open the website and a room on the website, the map shows by default

## How has this been tested?

- Map display seems to work without issues
- Floor overlays work
- Selecting a coordinate on feedback works
- 3D works (noticed this the first time that you can use Ctrl to turn in 3D, see screenshot)
- Geolocation works
- Fullscreen works (one bug remaining¹)
- Resize of the window works now (one bug fixed in this PR as well²)

¹ Opening the fullscreen and then closing it again doesn't update the fullscreen icon. The issue also exists for the old mapbox version

² Fixed a bug from #360 where the map would switch to the roomfinder on window resize

![image](https://user-images.githubusercontent.com/7429408/215282159-55cd12a7-633f-4073-9fbb-cf87610c50d4.png)

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
