### PR TITLE
[Preview-overlay-1] text-overlays

### DIFF
--- a/server/main-api/src/maps/fetch_tile.rs
+++ b/server/main-api/src/maps/fetch_tile.rs
@@ -1,4 +1,4 @@
-use crate::maps::overlay::OverlayMapTask;
+use crate::maps::overlay_map::OverlayMapTask;
 use actix_web::web;
 use awc::Client;
 use log::error;

--- a/server/main-api/src/maps/overlay_map.rs
+++ b/server/main-api/src/maps/overlay_map.rs
@@ -66,6 +66,15 @@ impl OverlayMapTask {
                 }
             }
         }
+
+        // add the location pin image to the center
+        let pin = image::open("src/maps/pin.webp").unwrap();
+        image::imageops::overlay(
+            img,
+            &pin,
+            1200 / 2 - pin.width() as i64 / 2,
+            (630 - 125) / 2 - pin.height() as i64,
+        );
         true
     }
 }

--- a/server/main-api/src/maps/overlay_text.rs
+++ b/server/main-api/src/maps/overlay_text.rs
@@ -1,0 +1,47 @@
+use cached::lazy_static::lazy_static;
+use image::Rgba;
+use imageproc::definitions::HasBlack;
+use imageproc::drawing::{draw_text_mut, text_size};
+use rusttype::{Font, Scale};
+
+lazy_static! {
+    pub static ref CANTARELL_BOLD: Font<'static> =
+        Font::try_from_bytes(include_bytes!("font/Cantarell-Bold.ttf")).unwrap();
+    pub static ref CANTARELL_REGULAR: Font<'static> =
+        Font::try_from_bytes(include_bytes!("font/Cantarell-Regular.ttf")).unwrap();
+}
+const SCALE: Scale = Scale { x: 35.0, y: 35.0 };
+
+pub(crate) struct OverlayText {
+    x: i32,
+    y: i32,
+    text: String,
+    font: &'static Font<'static>,
+}
+
+impl OverlayText {
+    pub fn with(text: &str, font: &'static Font<'static>) -> Self {
+        Self {
+            x: 0,
+            y: 0,
+            text: text.to_string(),
+            font,
+        }
+    }
+    /// x and y are in pixels from bottom right corner
+    pub fn at(self, x: i32, y: i32) -> Self {
+        Self { x, y, ..self }
+    }
+    pub fn draw_onto(self, img: &mut image::RgbaImage) {
+        let (w, _) = text_size(SCALE, self.font, &self.text);
+        draw_text_mut(
+            img,
+            Rgba::black(),
+            img.width() as i32 - w - self.x,
+            img.height() as i32 - self.y,
+            SCALE,
+            self.font,
+            &self.text,
+        );
+    }
+}


### PR DESCRIPTION
Extracts TextOverlays into its own file

## Proposed Changes (include Screenshots if possible)

- This PR separates TextOverlays into a separate Controlflow for readability and maintainability

## How to test this PR

1. see #374

## How has this been tested?

- Checking that it still generates the same overlays

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
