### PR TITLE
Preview debugging experience

### DIFF
--- a/server/main-api/Cargo.toml
+++ b/server/main-api/Cargo.toml
@@ -21,7 +21,8 @@ log = "0.4.17"
 diesel = { version = "2.0.2", features = ["default","sqlite"] }
 actix-web = "4.2.1"
 actix-rt = "2.7.0"
-awc = "3.0.1"
+rustls = "0.20.8"
+awc = { version="3.0.1",features=["rustls"] }
 cached = "0.42.0"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"

--- a/server/main-api/src/maps/fetch_tile.rs
+++ b/server/main-api/src/maps/fetch_tile.rs
@@ -81,22 +81,28 @@ impl FetchTileTask {
         }
     }
 
-    async fn download_map_image(&self, file: &std::path::PathBuf) -> Option<web::Bytes> {
-        let tileserver_addr = std::env::var("MAPS_SVC_PORT_7770_TCP_ADDR")
-            .unwrap_or_else(|_| "localhost".to_string());
-        let tileserver_port = std::env::var("MAPS_SVC_SERVICE_PORT_TILESERVER")
-            .unwrap_or_else(|_| "7770".to_string());
-        let url = format!(
-            "http://{tileserver_addr}:{tileserver_port}/styles/osm_liberty/{z}/{x}/{y}@2x.png",
+    fn tileserver_url(&self) -> String {
+        let tileserver_addr = std::env::var("MAPS_SVC_PORT_7770_TCP_ADDR");
+        let tileserver_port = std::env::var("MAPS_SVC_SERVICE_PORT_TILESERVER");
+        let base_url = match (tileserver_port, tileserver_addr) {
+            (Ok(port), Ok(addr)) => format!("http://{port}:{addr}"),
+            _ => "https://nav.tum.de/maps".to_string(),
+        };
+        format!(
+            "{base_url}/styles/osm_liberty/{z}/{x}/{y}@2x.png",
             z = self.z,
             x = self.x,
             y = self.y,
-        );
+        )
+    }
+
+    async fn download_map_image(&self, file: &std::path::PathBuf) -> Option<web::Bytes> {
+        let url = self.tileserver_url();
         let client = Client::new().get(&url).send();
         let res = match client.await {
             Ok(mut r) => r.body().await,
             Err(e) => {
-                error!("Error downloading map {}: {:?}", url, e);
+                error!("Error downloading map {url}: {e:?}");
                 return None;
             }
         };


### PR DESCRIPTION
This PR makes debugging anything map related eazier by not requiring users to have a tileserver installed

## Proposed Changes (include Screenshots if possible)

- The fallback for the Tileserver-environment variables is now our main tileserver

## How to test this PR

1. see https://github.com/TUM-Dev/NavigaTUM/pull/374

## How has this been tested?

- Checking that it still generates the same overlays

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
