### PR TITLE
[preview-2] Fixed missing truncation on preview images

### DIFF
--- a/server/main-api/src/maps/mod.rs
+++ b/server/main-api/src/maps/mod.rs
@@ -17,6 +17,7 @@ use image::Rgba;
 use log::{debug, error, warn};
 
 use tokio::time::Instant;
+use unicode_truncate::UnicodeTruncateStr;
 
 use crate::utils;
 
@@ -102,7 +103,12 @@ fn draw_bottom(data: &DBRoomEntry, img: &mut image::RgbaImage) {
         15,
         630 - (125 / 2) - (logo.height() as i64 / 2) + 9,
     );
-    OverlayText::with(&data.name, &CANTARELL_BOLD)
+    let name = if data.name.chars().count() >= 45 {
+        format!("{}...", data.name.unicode_truncate(45).0)
+    } else {
+        data.name.clone()
+    };
+    OverlayText::with(&name, &CANTARELL_BOLD)
         .at(10, 125 - 10)
         .draw_onto(img);
     OverlayText::with(&data.type_common_name, &CANTARELL_REGULAR)


### PR DESCRIPTION
## Proposed Changes (include Screenshots if possible)

- This PR makes shure that the names in our previews are correctly truncated

Before:
![](https://nav.tum.de/api/preview/4126)
After:
![image](https://user-images.githubusercontent.com/26258709/216732509-208f73cb-cb96-478d-b2b9-2ee96e642ba9.png)


## How to test this PR

1. see #374

## How has this been tested?

- Checking that it still generates the same overlays

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
