### PR TITLE
Room names

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
 openapi.yaml
 data/sources/01_areas-extended.yaml
 data/sources/02_rooms-extended.yaml
-data/sources/02_rooms-extended_generators.yaml
+data/sources/_02_rooms-extended_generators.yaml
 data/sources/15_patches-rooms_tumonline.yaml
 data/sources/45_custom-maps.yaml
 data/sources/46_overlay-maps.yaml

--- a/data/compile.py
+++ b/data/compile.py
@@ -28,10 +28,10 @@ def main():
     data = areatree.read_areatree()
 
     logging.info("-- 01 areas extendend")
-    data = merge.merge_yaml(data, "sources/01_areas-extended.yaml")
+    data = merge.patch_areas(data, "sources/01_areas-extended.yaml")
 
     logging.info("-- 02 rooms extendend")
-    data = merge.merge_yaml(data, "sources/02_rooms-extended.yaml")
+    data = merge.patch_rooms(data, "sources/02_rooms-extended.yaml")
     merge.add_coordinates(data, "sources/02_coordinates.yaml")
 
     # Add source information for these entries, which are up to here

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -3,7 +3,7 @@ import logging
 import string
 
 import yaml
-from processors.merge import merge_object
+from processors.merge import recursively_merge
 from processors.patch import apply_patches
 from utils import TranslatableStr as _
 
@@ -152,7 +152,7 @@ def merge_tumonline_rooms(data):
             r_data["tumonline_data"]["extended"] = room["extended"]
 
         # TUMonline data does not overwrite the existing data when merged
-        merge_object(data, {r_data["id"]: r_data}, overwrite=False)
+        recursively_merge(data, {r_data["id"]: r_data}, overwrite=False)
 
         # Add TUMonline as source
         data[r_data["id"]].setdefault("sources", {}).setdefault("base", []).append(

--- a/data/sources/02_rooms-extended.yaml
+++ b/data/sources/02_rooms-extended.yaml
@@ -112,8 +112,8 @@
   name: Ernst-Schmidt-Hörsaal
   props:
     comment:
-      de: Es wird auch 5508.02.801 statt 5508.01.801 verwendet, obwohl der Hörsaal im 1. Stock ist.
-      en: Also 5508.02.801 instead of 5508.01.801 is being used, even though the lecture hall is in the 1st floor.
+      de: Dieser Hörsaal ist in TUMonline 5508.02.801 statt 5508.01.801, obwohl der Hörsaal im 1. Stock ist. Aus Konsistenzgründen übernehmen wir diese ID.
+      en: This lecture hall is 5508.02.801 in TUMonline instead of 5508.01.801, although the lecture hall is on the 1st floor. For consistency, we also use this ID.
 "5510.EG.026C":
   name: IKOM-Besprechungsraum
 

--- a/data/sources/02_rooms-extended.yaml
+++ b/data/sources/02_rooms-extended.yaml
@@ -1,125 +1,125 @@
 # ========================== Innenstadt =============================
 # === Arcisstraße ===
 "2907.01.130":
-  name: "2907.01.130 (Fachschaft Lehrertum/Lehramt)"
+  name: Fachschaft Lehrertum/Lehramt
 "0501.03.173":
-  name: "0501.03.173 (Vorhoelzer Forum Foyer)"
+  name: Vorhoelzer Forum Foyer
 "0501.05.131":
-  name: "0501.05.131 (Vorhoelzer-Forum Dachterasse)"
+  name: Vorhoelzer-Forum Dachterasse
 "0509.EG.980":
-  name: "0509.EG.980 (Audimax, Werner-von-Siemens-Hörsaal)"
+  name: Audimax, Werner-von-Siemens-Hörsaal
   ranking_factors:
     rank_custom: 150
 "0101.02.157":
-  name: "0101.02.157 (Fachschaft Bau, Geo und Umwelt)"
+  name: Fachschaft Bau, Geo und Umwelt
   usage: # previously: CIP-Pool
     name:
-      de: "Büro"
-      en: "Office"
-    din_277: "NF2.1"
-    din_277_desc: "Büroräume"
+      de: Büro
+      en: Office
+    din_277: NF2.1
+    din_277_desc: Büroräume
 "0206.EG.002":
-  name: "0206.EG.002 (Küche Studentische Vertretung / SV)"
+  name: Küche Studentische Vertretung / SV
   props:
     links:
       - text:
-          de: "Weitere Informationen"
-          en: "More informations"
-        url: "https://www.sv.tum.de/"
+          de: Weitere Informationen
+          en: More informations
+        url: https://www.sv.tum.de/
 "0206.EG.003":
-  name: "0206.EG.003 (Besprechungsraum Studentische Vertretung / SV))"
+  name: Besprechungsraum Studentische Vertretung / SV)
   props:
     links:
       - text:
-          de: "Weitere Informationen"
-          en: "More informations"
-        url: "https://www.sv.tum.de/"
+          de: Weitere Informationen
+          en: More informations
+        url: https://www.sv.tum.de/
 
 # ========================== Garching =============================
 # === Physik ===
 "5101.EG.257":
-  name: "5101.EG.257 (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)"
+  name: Büro Fachschaft Mathe Physik Informatik Chemie / MPIC
 "5107.U1.114":
-  name: "5107.U1.114 (Büro)" # previously: Fachschaftsraum
+  name: Büro # previously: Fachschaftsraum
   usage: # previously: Social Room
     name:
-      de: "Büro"
-      en: "Office"
-    din_277: "NF2.1"
-    din_277_desc: "Büroräume"
+      de: Büro
+      en: Office
+    din_277: NF2.1
+    din_277_desc: Büroräume
 
 # === MI ===
 "5606.EG.036":
-  name: "5606.EG.036 (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)"
-  short_name: "MPIC Büro"
+  name: Büro Fachschaft Mathe Physik Informatik Chemie / MPIC
+  short_name: MPIC Büro
 "5606.EG.037":
-  name: "5606.EG.037 (Besprechungsraum Fachschaft Mathe Physik Informatik Chemie / MPIC)"
-  short_name: "MPIC Glaskasten"
+  name: Besprechungsraum Fachschaft Mathe Physik Informatik Chemie / MPIC
+  short_name: MPIC Glaskasten
 "5606.EG.038":
-  name: "5606.EG.038 (Lager Fachschaft Mathe Physik Informatik Chemie / MPIC)"
-  short_name: "MPIC Lager"
+  name: Lager Fachschaft Mathe Physik Informatik Chemie / MPIC
+  short_name: MPIC Lager"
 "5606.EG.039":
-  name: "5606.EG.039 (Skriptenverkauf Fachschaft Mathe Physik Informatik Chemie / MPIC)"
+  name: Skriptenverkauf Fachschaft Mathe Physik Informatik Chemie / MPIC
   usage:
     name:
-      de: "Geschäftsraum"
-      en: "Retail space"
-    din_277: "NF4.5"
-    din_277_desc: "Verkaufsräume"
+      de: Geschäftsraum
+      en: Retail space
+    din_277: NF4.5
+    din_277_desc: Verkaufsräume
   props:
     links:
       - text:
-          de: "Öffnungszeiten & Artikel"
-          en: "Opening hours & articles"
-        url: "https://skripten.mpi.fs.tum.de/"
+          de: Öffnungszeiten & Artikel
+          en: Opening hours & articles
+        url: https://skripten.mpi.fs.tum.de/
 
 # === Chemie ===
 "5401.01.101I":
-  name: "5401.01.101I (CIP-Raum)" # Original name is "Rechenzentrum" ...
+  name: CIP-Raum # Original name is "Rechenzentrum" ...
 "5406.01.650C":
-  name: "5406.01.650C (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)" # Original name is "Büro" ...
+  name: Büro Fachschaft Mathe Physik Informatik Chemie / MPIC # Original name is "Büro" ...
 
 # === Maschinenwesen / MW ===
 "5501.EG.101":
-  name: "5501.EG.101 (Fachschaft Maschinenbau / FSMB)"
+  name: Fachschaft Maschinenbau / FSMB
 "5510.EG.011M":
-  name: "5510.EG.011M (Skriptenverkauf Fachschaft Maschinenbau / FSMB)"
-  short_name: "FSMB Skriptenverkauf"
+  name: Skriptenverkauf Fachschaft Maschinenbau / FSMB
+  short_name: FSMB Skriptenverkauf
   usage:
     name:
-      de: "Geschäftsraum"
-      en: "Retail space"
-    din_277: "NF4.5"
-    din_277_desc: "Verkaufsräume"
+      de: Geschäftsraum
+      en: Retail space
+    din_277: NF4.5
+    din_277_desc: Verkaufsräume
   props:
     links:
       - text:
-          de: "Öffnungszeiten & Artikel"
-          en: "Opening hours & articles"
-        url: "https://fsmb.de/studierende/skriptenverkauf/"
+          de: Öffnungszeiten & Artikel
+          en: Opening hours & articles
+        url: https://fsmb.de/studierende/skriptenverkauf/
 
 "5501.02.150":
-  name: "5501.02.150 (IKOM-Büro)"
+  name: IKOM-Büro
   usage: # previously: Meeting room
     name:
-      de: "Büro"
-      en: "Office"
-    din_277: "NF2.1"
-    din_277_desc: "Büroräume"
+      de: Büro
+      en: Office
+    din_277: NF2.1
+    din_277_desc: Büroräume
 "5504.EG.450":
-  name: "5504.EG.450 (Rechnerhalle)"
+  name: Rechnerhalle
 "5508.02.801":  # ID is probably wrong in TUMonline, but we need to use it for compatibility
-  name: "5508.01.801 (Ernst-Schmidt-Hörsaal)"
+  name: Ernst-Schmidt-Hörsaal
   props:
     comment:
-      de: "Es wird auch 5508.02.801 statt 5508.01.801 verwendet, obwohl der Hörsaal im 1. Stock ist."
-      en: "Also 5508.02.801 instead of 5508.01.801 is being used, even though the lecture hall is in the 1st floor."
+      de: Es wird auch 5508.02.801 statt 5508.01.801 verwendet, obwohl der Hörsaal im 1. Stock ist.
+      en: Also 5508.02.801 instead of 5508.01.801 is being used, even though the lecture hall is in the 1st floor.
 "5510.EG.026C":
-  name: "5510.EG.026C (IKOM-Besprechungsraum)"
+  name: IKOM-Besprechungsraum
 
 # === Galileo Garching ===
 "8120.EG.001":
-  name: "8120.EG.001 (Hörsaal im Galileo)"
+  name: Hörsaal im Galileo
 
 "8120.01.101":
-  name: "8120.01.101 (Audimax im Galileo)"
+  name: Audimax im Galileo


### PR DESCRIPTION
Makes sure that things like #394, #393, #392 don't happen

## Proposed Changes (include Screenshots if possible)

- refactored that our room patches no longer expect that the id is in the name
- removed unused methods

## How to test this PR

1. Code Review
2. Run the data pipeline

## How has this been tested?

- internal Code Review
- Ran the data pipeline

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
