### PR TITLE
Add a floor property for the infotable

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -85,6 +85,7 @@ def main():
 
     logging.info("-- 80 Generate info card")
     sections.extract_calendar_urls(data)
+    sections.compute_floor_prop(data)
     sections.compute_props(data)
     sections.localize_links(data)
 

--- a/data/data_format_geo-entry.yaml
+++ b/data/data_format_geo-entry.yaml
@@ -137,6 +137,15 @@ internal_id:
       # if room
       roomcode: "0401.U1.014"
       arch_name: "-1014@0401"
+    floors:  # For (joined_)buildings
+      - { ... } # List of floors like the `floor` prop
+    floor:  # For rooms
+      id: 0  # Floor id (0 for ground floor if there is one, else 0 for the lowest)
+      floor: "0"  # Floor string in short form
+      tumonline: "EG"  # Floor string as given by TUMonline (might seem like a different floor)
+      type: "ground" | "roof" | "tp" | "basement" | "mezzanine" | "upper"
+      name: "Erdgeschoss"  # Long name of the floor (possibly inclusive description)
+      mezzanine_shift: 0  # How many mezzanines are between this floor and floor 0 (only >= 0)
     address:
       street: "Richard-Wagner-Str. 18"  # required
       plz_place: "80333 München"  # required

--- a/data/data_format_geo-entry.yaml
+++ b/data/data_format_geo-entry.yaml
@@ -146,6 +146,7 @@ internal_id:
       type: "ground" | "roof" | "tp" | "basement" | "mezzanine" | "upper"
       name: "Erdgeschoss"  # Long name of the floor (possibly inclusive description)
       mezzanine_shift: 0  # How many mezzanines are between this floor and floor 0 (only >= 0)
+      trivial: True  # If `floor` and `name` contain basically the same information (e.g. "1 (1st upper floor)")
     address:
       street: "Richard-Wagner-Str. 18"  # required
       plz_place: "80333 München"  # required

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -21,7 +21,7 @@ def compute_floor_prop(data):
     special floor numbering systems of buildings.
     """
     for _id, entry in data.items():
-        if entry["type"] in {"root", "area", "site", "campus", "virtual_room"}:
+        if entry["type"] not in {"building", "joined_building"}:
             continue
 
         parent_type = data[entry["parents"][-1]]["type"]

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -20,8 +20,6 @@ def compute_floor_prop(data):
     Create a human readable floor information prop that takes into account
     special floor numbering systems of buildings.
     """
-    # TODO: Resolve shift in CH
-    # TODO: Improve -1 (1. Basement floor)
     for _id, entry in data.items():
         if entry["type"] in {"root", "area", "site", "campus", "virtual_room"}:
             continue

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -35,8 +35,7 @@ def compute_floor_prop(data):
         #   in TUMonline we build the list of floors in their physical order.
         # - Infer or get details about each floor to generate a name string and get metadata.
         room_data = _collect_floors_room_data(data, entry)
-        floors = _build_sorted_floor_list(entry, room_data)
-        floor_details = _get_floor_details(entry, room_data, floors)
+        floor_details = _get_floor_details(entry, room_data)
 
         entry.setdefault("props", {})["floors"] = floor_details
 
@@ -96,8 +95,9 @@ def _build_sorted_floor_list(entry, room_data):
     return sorted(floors, key=floor_quantifier)
 
 
-def _get_floor_details(entry, room_data, floors):
+def _get_floor_details(entry, room_data):
     """Infer for each floor the metadata and name string"""
+    floors = _build_sorted_floor_list(entry, room_data)
     floors_details = []
 
     patches = entry.get("generators", {}).get("floors", {}).get("floor_patches", {})

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -77,20 +77,19 @@ def _build_sorted_floor_list(entry, room_data):
         """Assign each floor a virtual ID for sorting"""
         if floor_name == "EG":
             return 0
-        elif floor_name == "DG":
+        if floor_name == "DG":
             return 1000
-        elif floor_name.startswith("U"):
+        if floor_name.startswith("U"):
             return -10 * int(floor_name[1:])
-        elif floor_name.isnumeric():
+        if floor_name.isnumeric():
             return 10 * int(floor_name)
-        elif floor_name.startswith("Z"):
+        if floor_name.startswith("Z"):
             # Default placement: Z1 is below 01 etc.
             return 10 * int(floor_name[1:]) - 5
-        elif floor_name == "TP":  # Tiefparterre / Semi-Basement
+        if floor_name == "TP":  # Tiefparterre / Semi-Basement
             # Default placement: below EG
             return -5
-        else:
-            raise RuntimeError(f"Unknown TUMonline floor name {floor_name}")
+        raise RuntimeError(f"Unknown TUMonline floor name {floor_name}")
 
     return sorted(floors, key=floor_quantifier)
 

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -20,6 +20,8 @@ def compute_floor_prop(data):
     Create a human readable floor information prop that takes into account
     special floor numbering systems of buildings.
     """
+    # TODO: Resolve shift in CH
+    # TODO: Improve -1 (1. Basement floor)
     for _id, entry in data.items():
         if entry["type"] in {"root", "area", "site", "campus", "virtual_room"}:
             continue
@@ -152,24 +154,24 @@ def _get_floor_name_and_type(f_id, floor, mezzanine_shift):
     elif floor.startswith("U"):
         floor_type = "basement"
         floor_abbr = f"-{floor[1:]}"
-        floor_name = _("{n}. Untergeschoss").format(n=floor[1:])
+        floor_name = _(f"{floor[1:]}. ") + _("Untergeschoss")
     elif floor.startswith("Z"):
         floor_type = "mezzanine"
         floor_abbr = f"Z{floor[1:]}"
         if f_id == 1:
             floor_name = _("1. Zwischengeschoss, über EG")
         else:
-            floor_name = _("{n}. Zwischengeschoss").format(n=floor[1:])
+            floor_name = _(f"{floor[1:]}. ") + _("Zwischengeschoss")
     else:
         floor_type = "upper"
         n = int(floor[1:])
         floor_abbr = str(n)
         if mezzanine_shift == 0:
-            floor_name = _("{n}. Obergeschoss").format(n=n)
+            floor_name = _(f"{n}. ") + _("Obergeschoss")
         elif mezzanine_shift == 1:
-            floor_name = _("{n}. OG + 1 Zwischengeschoss").format(n=n)
+            floor_name = _(f"{n}. ") + _("OG + 1 Zwischengeschoss")
         else:
-            floor_name = _("{n}. OG + {m} Zwischengeschosse").format(n=n, m=mezzanine_shift)
+            floor_name = _(f"{n}. ") + _("OG + {m} Zwischengeschosse").format(m=mezzanine_shift)
 
     return floor_type, floor_abbr, floor_name
 

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -44,14 +44,14 @@ def compute_floor_prop(data):
         entry.setdefault("props", {})["floors"] = floor_details
 
         # Now add this floor information to all children
-        lookup = { floor["tumonline"]: floor for floor in floor_details }
+        lookup = {floor["tumonline"]: floor for floor in floor_details}
         for room in room_data:
             room_entry = data[room["id"]]
             room_entry.setdefault("props", {})["floor"] = lookup[room["floor"]]
 
 
 def _collect_floors_room_data(data, entry):
-    """ Collect floors of a (joined_)building """
+    """Collect floors of a (joined_)building"""
     missing_cnt = 0
     room_data = []
     for child_id in entry["children_flat"]:
@@ -64,20 +64,22 @@ def _collect_floors_room_data(data, entry):
             else:
                 floor = roomcode.split(".")[1]
 
-            room_data.append({
-                "id": child_id,
-                "floor": floor,
-            })
+            room_data.append(
+                {
+                    "id": child_id,
+                    "floor": floor,
+                }
+            )
 
     return room_data
 
 
 def _build_sorted_floor_list(entry, room_data):
-    """ Build a physically sorted list of floors (using TUMonline floor names) """
+    """Build a physically sorted list of floors (using TUMonline floor names)"""
     floors = set([room["floor"] for room in room_data])
 
     def floor_quantifier(floor_name):
-        """Assign each floor a virtual ID for sorting """
+        """Assign each floor a virtual ID for sorting"""
         if floor_name == "EG":
             return 0
         elif floor_name == "DG":
@@ -99,7 +101,7 @@ def _build_sorted_floor_list(entry, room_data):
 
 
 def _get_floor_details(entry, room_data, floors):
-    """ Infer for each floor the metadata and name string """
+    """Infer for each floor the metadata and name string"""
     floors_details = []
 
     patches = entry.get("generators", {}).get("floors", {}).get("floor_patches", {})
@@ -110,19 +112,20 @@ def _get_floor_details(entry, room_data, floors):
         floor = patches.get(floor_tumonline, {}).get("use_as", floor_tumonline)
         f_id = patches.get(floor_tumonline, {}).get("id", i - eg_index)
 
-        floor_type, floor_abbr, floor_name = \
-            _get_floor_name_and_type(f_id, floor, mezzanine_shift)
+        floor_type, floor_abbr, floor_name = _get_floor_name_and_type(f_id, floor, mezzanine_shift)
 
         floor_name = patches.get(floor_tumonline, {}).get("name", floor_name)
 
-        floors_details.append({
-            "id": f_id,
-            "floor": floor_abbr,
-            "tumonline": floor_tumonline,
-            "type": floor_type,
-            "name": floor_name,
-            "mezzanine_shift": mezzanine_shift,
-        })
+        floors_details.append(
+            {
+                "id": f_id,
+                "floor": floor_abbr,
+                "tumonline": floor_tumonline,
+                "type": floor_type,
+                "name": floor_name,
+                "mezzanine_shift": mezzanine_shift,
+            }
+        )
         if i - eg_index >= 0 and floor.startswith("Z"):
             mezzanine_shift += 1
 

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -52,7 +52,6 @@ def compute_floor_prop(data):
 
 def _collect_floors_room_data(data, entry):
     """Collect floors of a (joined_)building"""
-    missing_cnt = 0
     room_data = []
     for child_id in entry["children_flat"]:
         child = data[child_id]

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -158,7 +158,7 @@ def _get_floor_name_and_type(f_id, floor, mezzanine_shift):
         floor_name = _(f"{floor[1:]}. ") + _("Untergeschoss")
     elif floor.startswith("Z"):
         floor_type = "mezzanine"
-        floor_abbr = f"Z{floor[1:]}"
+        floor_abbr = floor
         if f_id == 1:
             floor_name = _("1. Zwischengeschoss, über EG")
         else:

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -17,7 +17,7 @@ def extract_calendar_urls(data):
 
 def compute_floor_prop(data):
     """
-    Create a human readable floor information prop that takes into account
+    Create a human and machine readable floor information prop that takes into account
     special floor numbering systems of buildings.
     """
     for _id, entry in data.items():
@@ -28,12 +28,6 @@ def compute_floor_prop(data):
         if parent_type == "joined_building" or "children_flat" not in entry:
             continue
 
-        # Steps in the assignment of floors:
-        # - Collect the relevant information from all rooms within the building.
-        # - Extract all floors given by TUMonline. TUMonline is used as the source for
-        #   the information about the floor, unless there is a patch. From the floors
-        #   in TUMonline we build the list of floors in their physical order.
-        # - Infer or get details about each floor to generate a name string and get metadata.
         room_data = _collect_floors_room_data(data, entry)
         floor_details = _get_floor_details(entry, room_data)
 

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -25,10 +25,7 @@ def compute_floor_prop(data):
             continue
 
         parent_type = data[entry["parents"][-1]]["type"]
-        if parent_type == "joined_building":
-            continue
-
-        if "children_flat" not in entry:
+        if parent_type == "joined_building" or "children_flat" not in entry:
             continue
 
         # Steps in the assignment of floors:

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -73,9 +73,6 @@ def infer_addresses(data):
                 )
 
                 if street is not None and plz_place is not None:
-                    # Remove the floor level from the address as it will be given in another field
-                    street = ",".join(street.split(",")[:-1])
-
                     child_addresses.add((street, plz_place))
 
             if len(child_addresses) == 1:
@@ -88,6 +85,7 @@ def infer_addresses(data):
                         "source": "inferred",
                     },
                 )
+    #exit()
 
 
 def infer_type_common_name(data):

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -73,14 +73,10 @@ def infer_addresses(data):
                 )
 
                 if street is not None and plz_place is not None:
-                    child_addresses.add((street, plz_place))
+                    # Remove the floor level from the address as it will be given in another field
+                    street = ",".join(street.split(",")[:-1])
 
-            # If there are multiple, try removing the floor level
-            if len(child_addresses) > 1:
-                new_child_addresses = set()
-                for street, plz_place in child_addresses:
-                    new_child_addresses.add((",".join(street.split(",")[:-1]), plz_place))
-                child_addresses = new_child_addresses
+                    child_addresses.add((street, plz_place))
 
             if len(child_addresses) == 1:
                 street, plz_place = child_addresses.pop()

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -85,7 +85,6 @@ def infer_addresses(data):
                         "source": "inferred",
                     },
                 )
-    #exit()
 
 
 def infer_type_common_name(data):

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -119,7 +119,7 @@ def merge_tumonline_rooms(data):
                     "roomcode": room["roomcode"],
                 },
                 "address": {
-                    "street": _clean_spaces(room["address"]),
+                    "street": _clean_address_street(room["address"]),
                     "plz_place": room["plz_place"],
                     "source": "tumonline",  # TODO: Wrong is only source is not set up to here
                 },
@@ -354,3 +354,9 @@ def _maybe_set_alt_name(arch_name_parts, room):
 def _clean_spaces(_string: str) -> str:
     """Remove leading and trailing spaces as well as duplicate spaces in-between"""
     return " ".join(_string.split())
+
+
+def _clean_address_street(street: str) -> str:
+    """Clean the given street address from the floor and unneccesary spaces"""
+    street = _clean_spaces(street)
+    return ",".join(street.split(",")[:-1])

--- a/data/sources/00_areatree
+++ b/data/sources/00_areatree
@@ -505,6 +505,7 @@
       5405:Messwarte, Freigerüst:
       5406:Laborgebäude CH6 (orange):
       5407:Laborgebäude CH7 (lila):
+    :Chemie Nebengebäude:chemie-nebengebaeude
       5408:Hofgebäude 1:
       5409:Umfüllstation / Sondermüll:
       -5410:Catalysis Research Center (CRC):  # Nur auf Karte

--- a/data/sources/01_areas-extended.yaml
+++ b/data/sources/01_areas-extended.yaml
@@ -171,6 +171,14 @@ zentralgelaende:
   osm: ["way/31095013", "way/264566973"] # Last is Dieter-Thoma-Labor
 "0509": # Wienandsbau, E-Technik / Audimax (Z9)
   osm: ["way/31095011", "way/50299848"] # Last is Audimax
+  generators:
+    floors:
+      floor_patches:
+        "01": { use_as: "Z1" }
+        "02": { use_as: "01" }
+        "03": { use_as: "02" }
+        "04": { use_as: "03" }
+        "05": { use_as: "04" }
 "0510": # Verwaltungsbau (Z10)
   osm: ["relation/6758375"] # smaller part: "way/31095179"
 "0511": # Elektro/Werkstatt/Lösungsmittel (Z11)
@@ -683,6 +691,23 @@ physik-main:
 5101:
   osm: ["relation/3277929", "node/1240863070"] # last one is bib
 
+5107:
+  generators:
+    floors:
+      floor_patches:
+        "U2":
+          id: -1
+          use_as: "U1"
+          name: { de: "= -1 zur Physik I", en: "= -1 rel. to. Physik I" }
+        "U1":
+          id: 0
+          use_as: "EG"
+          name: { de: "Eingang, -1 zur Brücke", en: "Entrance, -1 to the bridge" }
+        "EG":
+          id: 1
+          use_as: "01"
+          name: { de: "Obere Ebene, Zugang über Brücke", en: "Upper floor, access over bridge" }
+
 5126: # CALA
   coords: { lat: 48.26929, lon: 11.67459 }
   osm: ["way/308082257"]
@@ -745,6 +770,15 @@ chemie:
       street: "Lichtenbergstraße 4"
       plz_place: "85748 Garching bei München"
       source: "navigatum"
+  generators:
+    floors:
+      floor_patches:
+        "EG": { id: -1, name: { de: "Ebene 1", en: "Floor nb. 1" } }
+        "01": { id: 0, name: { de: "Ebene 2", en: "Floor nb. 2" } }
+        "02": { id: 1, name: { de: "Ebene 3", en: "Floor nb. 3" } }
+        "03": { id: 2, name: { de: "Ebene 4", en: "Floor nb. 4" } }
+        "04": { id: 3, name: { de: "Ebene 5", en: "Floor nb. 5" } }
+        "05": { id: 4, name: { de: "Ebene 6", en: "Floor nb. 6" } }
 
 5410:
   coords: { lat: 48.26914, lon: 11.67174 }

--- a/data/sources/01_areas-extended.yaml
+++ b/data/sources/01_areas-extended.yaml
@@ -773,12 +773,13 @@ chemie:
   generators:
     floors:
       floor_patches:
-        "EG": { id: -1, name: { de: "Ebene 1", en: "Floor nb. 1" } }
-        "01": { id: 0, name: { de: "Ebene 2", en: "Floor nb. 2" } }
-        "02": { id: 1, name: { de: "Ebene 3", en: "Floor nb. 3" } }
-        "03": { id: 2, name: { de: "Ebene 4", en: "Floor nb. 4" } }
-        "04": { id: 3, name: { de: "Ebene 5", en: "Floor nb. 5" } }
-        "05": { id: 4, name: { de: "Ebene 6", en: "Floor nb. 6" } }
+        "Z1": { use_as: "U1" }
+        "EG": { use_as: "U1", id: -1, name: { de: "Ebene 1", en: "Floor nb. 1" } }
+        "01": { use_as: "EG", id: 0, name: { de: "Ebene 2", en: "Floor nb. 2" } }
+        "02": { use_as: "01", id: 1, name: { de: "Ebene 3", en: "Floor nb. 3" } }
+        "03": { use_as: "02", id: 2, name: { de: "Ebene 4", en: "Floor nb. 4" } }
+        "04": { use_as: "03", id: 3, name: { de: "Ebene 5", en: "Floor nb. 5" } }
+        "05": { use_as: "04", id: 4, name: { de: "Ebene 6", en: "Floor nb. 6" } }
 
 5410:
   coords: { lat: 48.26914, lon: 11.67174 }

--- a/data/sources/02_rooms-extended.yaml
+++ b/data/sources/02_rooms-extended.yaml
@@ -114,6 +114,9 @@
     comment:
       de: Dieser Hörsaal ist in TUMonline 5508.02.801 statt 5508.01.801, obwohl der Hörsaal im 1. Stock ist. Aus Konsistenzgründen übernehmen wir diese ID.
       en: This lecture hall is 5508.02.801 in TUMonline instead of 5508.01.801, although the lecture hall is on the 1st floor. For consistency, we also use this ID.
+  generators:
+    floors:
+      floor_patch: "01"
 "5510.EG.026C":
   name: IKOM-Besprechungsraum
 

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -19,7 +19,7 @@ Erdgeschoss: Ground floor
 Dachgeschoss: Roof floor
 Tiefparterre: Semi-basement
 Untergeschoss: basement floor
-  # More common translation is mezzanine, but intermediate is not wrong and easier to understand
+# More common translation is mezzanine, but intermediate is not wrong and easier to understand
 Zwischengeschoss: intermediate floor
 "1. Zwischengeschoss, über EG": "1st intermediate floor, above ground floor"
 Obergeschoss: upper floor

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -16,15 +16,14 @@ Keine Räume bekannt: No rooms known
 Architekten-Name: Architect's name
 Stockwerk: Floor
 Erdgeschoss: Ground floor
-Dachgeschoss: Roof floor
+Dachgeschoss: Top floor
 Tiefparterre: Semi-basement
 Untergeschoss: basement floor
-# More common translation is mezzanine, but intermediate is not wrong and easier to understand
-Zwischengeschoss: intermediate floor
-"1. Zwischengeschoss, über EG": "1st intermediate floor, above ground floor"
+Zwischengeschoss: mezzanine
+"1. Zwischengeschoss, über EG": "1st mezzanine, above ground floor"
 Obergeschoss: upper floor
-"OG + 1 Zwischengeschoss": "upper floor + 1 intermediate floor"
-"OG + {m} Zwischengeschosse": "upper floor + {m} intermediate floors"
+"OG + 1 Zwischengeschoss": "upper floor + 1 mezzanine"
+"OG + {m} Zwischengeschosse": "upper floor + {m} mezzanines"
 "1. ": "1st "
 "2. ": "2nd "
 "3. ": "3rd "

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -14,6 +14,17 @@ Keine Räume bekannt: No rooms known
 "{n_buildings} Gebäude, {n_rooms} Räume": "{n_buildings} buildings, {n_rooms} rooms"
 "{n_buildings} Gebäude, {n_rooms} Räume (Außenstelle)": "{n_buildings} buildings, {n_rooms} rooms (branch office)"
 Architekten-Name: Architect's name
+Stockwerk: Floor
+Erdgeschoss: Ground floor
+Dachgeschoss: Roof floor
+Tiefparterre: Semi-basement
+"{n}. Untergeschoss": "{n}. Basement floor"
+  # More common translation is mezzanine, but intermediate is not wrong and easier to understand
+"{n}. Zwischengeschoss": "{n}. Intermediate floor"
+"1. Zwischengeschoss, über EG": "1. Intermediate floor, above ground floor"
+"{n}. Obergeschoss": "{n}. Upper floor"
+"{n}. OG + 1 Zwischengeschoss": "{n}. Upper floor + 1 intermediate floor"
+"{n}. OG + {m} Zwischengeschosse": "{n}. Upper floor + {m} intermediate floors"
 # type_common_name
 Gebäudeteil: Part of the building
 Standortübersicht: Location overview

--- a/data/translations.yaml
+++ b/data/translations.yaml
@@ -18,13 +18,22 @@ Stockwerk: Floor
 Erdgeschoss: Ground floor
 Dachgeschoss: Roof floor
 Tiefparterre: Semi-basement
-"{n}. Untergeschoss": "{n}. Basement floor"
+Untergeschoss: basement floor
   # More common translation is mezzanine, but intermediate is not wrong and easier to understand
-"{n}. Zwischengeschoss": "{n}. Intermediate floor"
-"1. Zwischengeschoss, über EG": "1. Intermediate floor, above ground floor"
-"{n}. Obergeschoss": "{n}. Upper floor"
-"{n}. OG + 1 Zwischengeschoss": "{n}. Upper floor + 1 intermediate floor"
-"{n}. OG + {m} Zwischengeschosse": "{n}. Upper floor + {m} intermediate floors"
+Zwischengeschoss: intermediate floor
+"1. Zwischengeschoss, über EG": "1st intermediate floor, above ground floor"
+Obergeschoss: upper floor
+"OG + 1 Zwischengeschoss": "upper floor + 1 intermediate floor"
+"OG + {m} Zwischengeschosse": "upper floor + {m} intermediate floors"
+"1. ": "1st "
+"2. ": "2nd "
+"3. ": "3rd "
+"4. ": "4th "
+"5. ": "5th "
+"6. ": "6th "
+"7. ": "7th "
+"8. ": "8th "
+"9. ": "9th "
 # type_common_name
 Gebäudeteil: Part of the building
 Standortübersicht: Location overview

--- a/data/utils.py
+++ b/data/utils.py
@@ -50,6 +50,16 @@ class TranslatableStr(dict):
         """compares one String to another, sorting by the german string."""
         return self["de"] < other["de"]
 
+    def __add__(self, other):
+        if type(other) is str:
+            return TranslatableStr(self["de"] + other, self["en"] + other)
+        elif type(other) is TranslatableStr:
+            return TranslatableStr(self["de"] + other["de"], self["en"] + other["en"])
+
+    def __radd__(self, other):
+        if type(other) is str:
+            return TranslatableStr(other + self["de"], other + self["en"])
+
     def format(self, *args, **kwargs):
         """Format the string using the .format() method, as if this was a string."""
         self["de"] = self["de"].format(*args, **kwargs)

--- a/data/utils.py
+++ b/data/utils.py
@@ -51,14 +51,16 @@ class TranslatableStr(dict):
         return self["de"] < other["de"]
 
     def __add__(self, other):
-        if type(other) is str:
+        if isinstance(other, str):
             return TranslatableStr(self["de"] + other, self["en"] + other)
-        elif type(other) is TranslatableStr:
+        if isinstance(other, TranslatableStr):
             return TranslatableStr(self["de"] + other["de"], self["en"] + other["en"])
+        raise ValueError(f"{self} + {other} is not implmented")
 
     def __radd__(self, other):
-        if type(other) is str:
+        if isinstance(other, str):
             return TranslatableStr(other + self["de"], other + self["en"])
+        raise ValueError(f"{other} + {self} is not implmented")
 
     def format(self, *args, **kwargs):
         """Format the string using the .format() method, as if this was a string."""

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -414,6 +414,8 @@ paths:
                           text: 5602.EG.001
                         - name: Architekten-Name
                           text: 00.02.001
+                        - name: Stockwerk
+                          text: '0 (Erdgeschoss)'
                         - name: Adresse
                           text: 'Boltzmannstr. 3, EG, 85748 Garching b. München'
                         - name: Sitzplätze
@@ -513,6 +515,8 @@ paths:
                           text: 5606.EG.036
                         - name: Architekten-Name
                           text: 00.06.036
+                        - name: Stockwerk
+                          text: '0 (Erdgeschoss)'
                         - name: Adresse
                           text: 'Boltzmannstr. 3, EG, 85748 Garching b. München'
                     ranking_factors:


### PR DESCRIPTION
Fixes #232 

## Proposed Changes (include Screenshots if possible)
This adds
- a `floors` property to each (joined_)building,
- a `floor` property to each room, and
- a computed floor property for the infotable.

Computing the floor property turned out to be a lot more tricky than I thought. For some buildings there are patches to account for errors or weird numberings. I first tried to generalize this, so that some patches might be simplified or even left out. But as soon as I do that, the code complexity increases a lot. So I think it is better this way, because I assume the floors of a building do change only very rarely.

## How to test this PR

1. Recompile the data
2. Reload the data into the server database
3. Access entry pages

## How has this been tested?
A few (hopefully representative) rooms, including:
- 5606.01.020
- 5101.EG.271
- 5107.U1.127
- 5142.02.001E
- 5401.01.101K
- 5406.03.621D
- 5407.Z1.760A
- 0101.02.190
- 0104.U1.403
- 0502.01.200
- 0509.EG.980
- 0509.01.995
- 0509.04.999

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
