### PR TITLE
added an export for props.operator to the details-api

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -84,7 +84,7 @@ def main():
     images.add_img(data)
 
     logging.info("-- 80 Generate info card")
-    sections.extract_calendar_urls(data)
+    sections.extract_tumonline_props(data)
     sections.compute_floor_prop(data)
     sections.compute_props(data)
     sections.localize_links(data)

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -116,7 +116,7 @@ def export_for_api(data, path):
         if "roomfinder_data" in export_data[_id]:
             del export_data[_id]["roomfinder_data"]
         if "props" in export_data[_id]:
-            prop_keys_to_keep = {"computed", "links", "comment", "calendar_url", "tumonline_room_nr"}
+            prop_keys_to_keep = {"computed", "links", "comment", "calendar_url", "tumonline_room_nr", "operator"}
             to_delete = [e for e in export_data[_id]["props"].keys() if e not in prop_keys_to_keep]
             for k in to_delete:
                 del export_data[_id]["props"][k]

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -2,7 +2,7 @@ from utils import TranslatableStr as _
 
 
 def extract_tumonline_props(data):
-    """Extracts the calendar from the tumonline data sets it to the proper value."""
+    """Extracts some of the TUMonline data and provides it as `prop`."""
     for entry in data.values():
         if entry.get("tumonline_data", {}).get("calendar", None):
             url = f"https://campus.tum.de/tumonline/{entry['tumonline_data']['calendar']}"

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,12 +1,19 @@
 from utils import TranslatableStr as _
 
 
-def extract_calendar_urls(data):
+def extract_tumonline_props(data):
     """Extracts the calendar from the tumonline data sets it to the proper value."""
     for entry in data.values():
         if entry.get("tumonline_data", {}).get("calendar", None):
             url = f"https://campus.tum.de/tumonline/{entry['tumonline_data']['calendar']}"
             entry["props"]["calendar_url"] = url
+        if entry.get("tumonline_data", {}).get("operator", None):
+            operator_id = int(entry["tumonline_data"]["operator_link"].strip("'webnav.navigate_to?corg="))
+            entry["props"]["operator"] = {
+                "name": entry["tumonline_data"]["operator"].lstrip("[ ").rstrip(" ]"),
+                "url": f"https://campus.tum.de/tumonline/webnav.navigate_to?corg={operator_id}",
+                "id": operator_id,
+            }
         if entry.get("tumonline_data", {}).get("room_link", None):
             url: str = entry["tumonline_data"]["room_link"]
             entry["props"]["tumonline_room_nr"] = int(url.removeprefix("wbRaum.editRaum?pRaumNr="))

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1129,6 +1129,22 @@ components:
       description: Data for the info-card table
       type: object
       properties:
+        operator:
+          description: The operator of the room
+          type: object
+          properties:
+            name:
+              description: The name of the operator
+              type: string
+              example: TUS7000
+            url:
+              description: A link to the operator
+              type: string
+              example: 'https://campus.tum.de/tumonline/webnav.navigate_to?corg=51901'
+            id:
+              description: The id of the operator
+              type: integer
+              example: 51901
         computed:
           type: array
           items:


### PR DESCRIPTION
Fixes #410

## Proposed Changes (include Screenshots if possible)

- Added an export for the operator

## How to test this PR

1. Recompile the data
2. See that the output of `/api/get/5508.02.801`
3. See that the API matches.

## How has this been tested?

- See if the output of the `extract_tumonline_props()` function matches the expected format+content 

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [ ] I have run the linter
