### PR TITLE
[Cal-9] Pipelined scraper

### DIFF
--- a/server/calendar/src/scrape_task/mod.rs
+++ b/server/calendar/src/scrape_task/mod.rs
@@ -21,6 +21,7 @@ pub struct ScrapeTask {
     scraping_start: DateTime<Utc>,
 }
 
+const CONCURRENT_REQUESTS: usize = 2;
 impl ScrapeTask {
     pub fn new(time_window: chrono::Duration) -> Self {
         Self {
@@ -41,7 +42,7 @@ impl ScrapeTask {
         let mut work_queue = FuturesUnordered::new();
         let start = self.scraping_start - self.time_window / 2;
         while !all_room_ids.is_empty() {
-            while work_queue.len() < 2 {
+            while work_queue.len() < CONCURRENT_REQUESTS {
                 if let Some(room) = all_room_ids.pop() {
                     // sleep to not overload TUMonline.
                     // It is critical for successfully scraping that we are not blocked.

--- a/server/calendar/src/scrape_task/mod.rs
+++ b/server/calendar/src/scrape_task/mod.rs
@@ -10,7 +10,8 @@ use crate::scrape_task::tumonline_calendar_connector::{Strategy, XMLEvents};
 use crate::utils;
 use chrono::{DateTime, NaiveDate, Utc};
 use diesel::prelude::*;
-use futures::future::join_all;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use log::{info, warn};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -32,41 +33,42 @@ impl ScrapeTask {
         info!("Starting scraping calendar entries");
         let start_time = Instant::now();
 
-        let all_room_ids = get_all_ids().await;
+        let mut all_room_ids = get_all_ids().await;
         let entry_cnt = all_room_ids.len();
         let mut time_stats = Statistic::new();
         let mut entry_stats = Statistic::new();
 
-        let mut i = 0;
-        for round in all_room_ids.chunks(2) {
-            i += round.len();
-            let round_start_time = Instant::now();
-            let mut futures = vec![];
-            for room in round {
-                let start = self.scraping_start - self.time_window / 2;
-                futures.push(scrape(
-                    (room.key.clone(), room.tumonline_room_nr),
-                    start.date_naive(),
-                    self.time_window,
-                ));
+        let mut work_queue = FuturesUnordered::new();
+        let start = self.scraping_start - self.time_window / 2;
+        while !all_room_ids.is_empty() {
+            while work_queue.len() < 2 {
+                if let Some(room) = all_room_ids.pop() {
+                    // sleep to not overload TUMonline.
+                    // It is critical for successfully scraping that we are not blocked.
+                    sleep(Duration::from_millis(50)).await;
+
+                    work_queue.push(scrape(
+                        (room.key.clone(), room.tumonline_room_nr),
+                        start.date_naive(),
+                        self.time_window,
+                    ));
+                }
             }
-            let results: Vec<ScrapeResult> = join_all(futures).await;
-            results
-                .iter()
-                .for_each(|e| entry_stats.push(e.success_cnt as u32));
-            // if one of the futures needed to be retried smaller, this would skew the stats a lot
-            if results.iter().all(|e| !e.retry_smaller_happened) {
-                time_stats.push(round_start_time.elapsed());
+            if let Some(res) = work_queue.next().await {
+                entry_stats.push(res.success_cnt as u32);
+                // if one of the futures needed to be retried smaller, this would skew the stats a lot
+                if !res.retry_smaller_happened {
+                    time_stats.push(res.elapsed_time);
+                }
             }
-            if i % 30 == 0 {
-                let progress = i as f32 / entry_cnt as f32 * 100.0;
+
+            let scraped_entries = entry_cnt - all_room_ids.len();
+            if scraped_entries % 30 == 0 {
+                let progress = scraped_entries as f32 / entry_cnt as f32 * 100.0;
                 let elapsed = start_time.elapsed();
-                let time_per_key = elapsed / i as u32;
+                let time_per_key = elapsed / scraped_entries as u32;
                 info!("Scraped {progress:.2}% (avg {time_per_key:.1?}/key, total {elapsed:.1?}) result-{entry_stats:?} in time-{time_stats:.1?}");
             }
-            // sleep to not overload TUMonline.
-            // It is critical for successfully scraping that we are not blocked.
-            sleep(Duration::from_millis(100)).await;
         }
 
         info!(
@@ -100,11 +102,13 @@ impl ScrapeTask {
 
 struct ScrapeResult {
     retry_smaller_happened: bool,
+    elapsed_time: Duration,
     success_cnt: usize,
 }
 
 async fn scrape(id: (String, i32), from: NaiveDate, duration: chrono::Duration) -> ScrapeResult {
     // request and parse the xml file
+    let start_time = Instant::now();
     let mut request_queue = vec![ScrapeRoomTask::new(id, from, duration)];
     let mut success_cnt = 0;
     let mut retry_smaller_happened = false;
@@ -142,6 +146,7 @@ async fn scrape(id: (String, i32), from: NaiveDate, duration: chrono::Duration) 
     }
     ScrapeResult {
         retry_smaller_happened,
+        elapsed_time: start_time.elapsed(),
         success_cnt,
     }
 }


### PR DESCRIPTION
Previously, we scraped in this fassion:

- scrape(), scrape() # concurrently 
- sleep(100)

## Proposed Changes (include Screenshots if possible)

- This PR changes the scheduling of the scrapes to two parallel instances of
  - sleep(50)
  - scrape()
- => if one is faster, it can continue with another piece of work instead of waiting for the stragler

## How to test this PR

1. Code review

## How has this been tested?

- Let it run

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
