### PR TITLE
[autoscraper-1] merged `_write_cache_json` and `_cached_json` into a single decorator

### DIFF
--- a/data/external/main.py
+++ b/data/external/main.py
@@ -30,5 +30,5 @@ if __name__ == "__main__":
 
     roomfinder.scrape_maps()
 
-    tumonline.scrape_orgs("de")
-    tumonline.scrape_orgs("en")
+    tumonline.scrape_orgs(lang="de")
+    tumonline.scrape_orgs(lang="en")


### PR DESCRIPTION
In the PR-Train for #424 I noticed that the caching feature would be better served by having a more ergonomic caching function

## Proposed Changes (include Screenshots if possible)

- added a decorator `@cached_json(filename)` which can be added to functions
- said decorator supports formatting

## How to test this PR

```python
@cached_json("abc")
def t():
    return []


@cached_json("abc_{b}")
def t_1(a, b2, b=1, cd=2):
    return []


if __name__ == "__main__":
    t_1(1, 2, b=3)
```


## How has this been tested?

- see above

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
