### PR TITLE
Faster docker builds

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -54,3 +54,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_COMMIT_SHA=${{ github.sha }}
+          cache-from: type=registry,ref=user/app:latest
+          cache-to: type=inline

--- a/server/calendar/Dockerfile.server
+++ b/server/calendar/Dockerfile.server
@@ -3,8 +3,13 @@ FROM    rust:1.68-alpine AS compiler
 
 RUN     apk add -q --update-cache --no-cache build-base openssl-dev sqlite-dev
 
+# first run of the image build (probably cached, just dependencys)
+RUN USER=root cargo new --bin nav
 WORKDIR /nav
 COPY    ./Cargo.* ./
+RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release \
+     && rm ./target/release/deps/nav*
+# second run of the image build (including our code)
 COPY    ./src ./src
 RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 
@@ -13,7 +18,7 @@ RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 FROM alpine:3.17
 
 RUN     apk update --quiet \
-        && apk add -q --no-cache libgcc sqlite-libs tini
+     && apk add -q --no-cache libgcc sqlite-libs tini
 
 # add `navigatum-calendar` to the `/bin` so we can run it from anywhere and it's easy to find.
 COPY    --from=compiler /nav/target/release/navigatum-calendar /bin/navigatum-calendar

--- a/server/feedback/Dockerfile
+++ b/server/feedback/Dockerfile
@@ -3,8 +3,13 @@ FROM    rust:1.68-alpine AS compiler
 
 RUN     apk add -q --update-cache --no-cache build-base openssl-dev
 
+# first run of the image build (probably cached, just dependencys)
+RUN USER=root cargo new --bin nav
 WORKDIR /nav
 COPY    ./Cargo.* ./
+RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release \
+     && rm ./target/release/deps/nav*
+# second run of the image build (including our code)
 COPY    ./src ./src
 RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 
@@ -12,7 +17,7 @@ RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 FROM alpine:3.17
 
 RUN     apk update --quiet \
-        && apk add -q --no-cache openssl1.1-compat libgcc tini
+     && apk add -q --no-cache openssl1.1-compat libgcc tini
 
 # add `navigatum-feedback` to the `/bin` so we can run it from anywhere and it's easy to find.
 COPY    --from=compiler /nav/target/release/navigatum-feedback /bin/navigatum-feedback

--- a/server/feedback/src/main.rs
+++ b/server/feedback/src/main.rs
@@ -90,5 +90,4 @@ async fn main() -> std::io::Result<()> {
     .bind(std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:8070".to_string()))?
     .run()
     .await
-    // revert me
 }

--- a/server/feedback/src/main.rs
+++ b/server/feedback/src/main.rs
@@ -90,4 +90,5 @@ async fn main() -> std::io::Result<()> {
     .bind(std::env::var("BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0:8070".to_string()))?
     .run()
     .await
+    // revert me
 }

--- a/server/main-api/Dockerfile.server
+++ b/server/main-api/Dockerfile.server
@@ -3,8 +3,13 @@ FROM    rust:1.68-alpine AS compiler
 
 RUN     apk add -q --update-cache --no-cache build-base openssl-dev sqlite-dev
 
+# first run of the image build (probably cached, just dependencys)
+RUN USER=root cargo new --bin nav
 WORKDIR /nav
 COPY    ./Cargo.* ./
+RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release \
+     && rm ./target/release/deps/nav*
+# second run of the image build (including our code)
 COPY    ./src ./src
 RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 
@@ -13,8 +18,8 @@ RUN     RUSTFLAGS="-C target-feature=-crt-static" cargo build --release
 FROM alpine:3.17
 
 RUN     apk update --quiet \
-        && apk add -q --no-cache libgcc sqlite-libs tini \
-        && mkdir -p ./src/maps/font
+     && apk add -q --no-cache libgcc sqlite-libs tini \
+     && mkdir -p ./src/maps/font
 
 COPY    ./src/maps ./src/maps
 # add `navigatum-main-api` to the `/bin` so we can run it from anywhere and it's easy to find.


### PR DESCRIPTION
improved the second run runtime of docker builds by ~5-8x

## Proposed Changes (include Screenshots if possible)

- Made shure that dependencys only get build on the first try

## How to test this PR

/

## How has this been tested?

-Build it locally
- build it in github actions

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
