### PR TITLE
[feedback-pipeline-3] removed `structopt` for parsing commandline arguments

### DIFF
--- a/server/feedback/Cargo.lock
+++ b/server/feedback/Cargo.lock
@@ -298,15 +298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,17 +312,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.12",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -453,21 +433,6 @@ dependencies = [
  "time 0.1.43",
  "wasm-bindgen",
  "winapi",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -916,27 +881,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1297,7 +1244,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "structopt",
  "tokio",
 ]
 
@@ -1531,30 +1477,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1956,7 +1878,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1977,36 +1899,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "syn"
@@ -2050,15 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2260,12 +2143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,12 +2171,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/server/feedback/Cargo.toml
+++ b/server/feedback/Cargo.toml
@@ -27,7 +27,6 @@ serde_json = "1.0.95"
 actix-cors = "0.6.4"
 tokio = { version = "1.27.0", features = ["full"] }
 rand = "0.8.5"
-structopt = "0.3.26"
 env_logger = "0.10.0"
 jsonwebtoken = "8.3.0"
 chrono = "0.4.23"

--- a/server/feedback/README.md
+++ b/server/feedback/README.md
@@ -11,6 +11,13 @@ Please follow the [system dependencys docs](/resources/documentation/Dependencys
 
 ### Starting the server
 
+The following environment variables are required for all features to work:
+
+| variable       | usage/description                                                                                  |
+|----------------|----------------------------------------------------------------------------------------------------|
+| `GITHUB_TOKEN` | A GitHub token with `write` access to `repo`. This is used to create issues/PRs on the repository. |
+| `JWT_KEY`      | A key used to sign JWTs. This is used to authenticate that feedback tokens were given out by us.   |
+
 Run `cargo run` to start the server.
 The server should now be available on `localhost:8070`.
 

--- a/server/feedback/src/core.rs
+++ b/server/feedback/src/core.rs
@@ -7,18 +7,16 @@ use log::error;
 use tokio::sync::Mutex;
 
 pub struct AppStateFeedback {
-    pub(crate) feedback_keys: crate::FeedbackKeys,
     pub(crate) token_record: Mutex<Vec<TokenRecord>>,
 }
 impl AppStateFeedback {
-    pub fn from(feedback_keys: crate::FeedbackKeys) -> AppStateFeedback {
+    pub fn new() -> AppStateFeedback {
         AppStateFeedback {
-            feedback_keys,
             token_record: Mutex::new(Vec::new()),
         }
     }
     pub fn able_to_process_feedback(&self) -> bool {
-        self.feedback_keys.github_token.is_some() && self.feedback_keys.jwt_key.is_some()
+        std::env::var("GITHUB_TOKEN").is_ok() && std::env::var("JWT_KEY").is_ok()
     }
 }
 
@@ -34,7 +32,7 @@ pub async fn get_token(state: Data<AppStateFeedback>) -> HttpResponse {
             .body("Feedback is currently not configured on this server.");
     }
 
-    let secret = state.feedback_keys.jwt_key.clone().unwrap(); // we checked available
+    let secret = std::env::var("JWT_KEY").unwrap(); // we checked the ability to process feedback
     let token = encode(
         &Header::default(),
         &Claims::new(),

--- a/server/feedback/src/github.rs
+++ b/server/feedback/src/github.rs
@@ -4,12 +4,14 @@ use log::error;
 use octocrab::Octocrab;
 use regex::Regex;
 
-pub async fn open_issue(
-    github_token: String,
-    title: &str,
-    description: &str,
-    labels: Vec<String>,
-) -> HttpResponse {
+fn github_token() -> String {
+    std::env::var("GITHUB_TOKEN")
+        .expect("GITHUB_TOKEN not set")
+        .trim()
+        .to_string()
+}
+
+pub async fn open_issue(title: &str, description: &str, labels: Vec<String>) -> HttpResponse {
     let title = clean_feedback_data(title, 512);
     let description = clean_feedback_data(description, 1024 * 1024);
 
@@ -19,7 +21,7 @@ pub async fn open_issue(
             .body("Subject or body missing or too short");
     }
 
-    let octocrab = Octocrab::builder().personal_token(github_token).build();
+    let octocrab = Octocrab::builder().personal_token(github_token()).build();
     if octocrab.is_err() {
         error!("Error creating issue: {octocrab:?}");
         return HttpResponse::InternalServerError().body("Could not create Octocrab instance");

--- a/server/feedback/src/main.rs
+++ b/server/feedback/src/main.rs
@@ -5,26 +5,12 @@ use std::collections::HashMap;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
 use actix_web_prometheus::PrometheusMetricsBuilder;
 
-use structopt::StructOpt;
-
 mod core;
 mod github;
 mod post_feedback;
 mod tokens;
 
 const MAX_JSON_PAYLOAD: usize = 1024 * 1024; // 1 MB
-
-#[derive(StructOpt, Debug)]
-#[structopt(name = "server")]
-pub struct FeedbackKeys {
-    // Feedback
-    /// GitHub personal access token
-    #[structopt(short = "t", long)]
-    github_token: Option<String>,
-    /// Secret for the feedback token generation
-    #[structopt(short = "jwt", long)]
-    jwt_key: Option<String>,
-}
 
 #[get("/api/feedback/status")]
 async fn health_status_handler() -> HttpResponse {
@@ -41,14 +27,6 @@ const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
-
-    let mut opt = FeedbackKeys::from_args();
-    if opt.github_token.is_none() {
-        opt.github_token = std::env::var("GITHUB_TOKEN").ok();
-    }
-    if opt.jwt_key.is_none() {
-        opt.jwt_key = std::env::var("JWT_KEY").ok();
-    }
 
     let feedback_ratelimit = GovernorConfigBuilder::default()
         .key_extractor(GlobalKeyExtractor)
@@ -68,7 +46,7 @@ async fn main() -> std::io::Result<()> {
         .build()
         .unwrap();
 
-    let state_feedback = web::Data::new(core::AppStateFeedback::from(opt));
+    let state_feedback = web::Data::new(core::AppStateFeedback::new());
     HttpServer::new(move || {
         let cors = Cors::default()
             .allow_any_origin()

--- a/server/feedback/src/post_feedback.rs
+++ b/server/feedback/src/post_feedback.rs
@@ -34,15 +34,7 @@ pub async fn send_feedback(
     };
     let (title_category, labels) = parse_request(&req_data);
 
-    let github_token = state
-        .feedback_keys
-        .github_token
-        .as_ref()
-        .unwrap()
-        .trim()
-        .to_string();
     github::open_issue(
-        github_token,
         &format!("[{title_category}] {subject}", subject = req_data.subject),
         &req_data.body,
         labels,

--- a/server/feedback/src/tokens.rs
+++ b/server/feedback/src/tokens.rs
@@ -46,7 +46,7 @@ pub async fn validate_token(
         );
     }
 
-    let secret = state.feedback_keys.jwt_key.clone().unwrap(); // we checked available
+    let secret = std::env::var("JWT_KEY").unwrap(); // we checked the ability to process feedback
     let x = DecodingKey::from_secret(secret.as_bytes());
     let jwt_token = decode::<Claims>(supplied_token, &x, &Validation::default());
     let kid = match jwt_token {


### PR DESCRIPTION
First PR in the https://github.com/TUM-Dev/NavigaTUM/issues/501 PR-Train

⚠️  This change has been pulled out, as this is a breaking API-Chnage ⚠️ 

## Proposed Changes (include Screenshots if possible)

- removal of `structopt` to get keys from arguments as an alternative to commandline arguments

## How to test this PR

- see if this removal is okay

## How has this been tested?

- smoke + unit tests

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
