### PR TITLE
[feedback-pipeline-5] Basic implementation of the `/api/feedback/propose_edit` API Endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -742,12 +742,13 @@ paths:
         - feedback
   /api/feedback/feedback:
     post:
-      operationId: feedback
+      operationId: post_feedback
       summary: Post feedback
       description: |
         ***Do not abuse this endpoint.***
 
         This posts the actual feedback to github and returns the github link.
+        This API will create issues instead of pull-requests => all feedback is allowed, but `/api/feedback/propose_edit` is prefered, if it can be posted there.
         For this Endpoint to work, you need to generate a token via the `/api/feedback/get_token` endpoint.
 
         ***Important Note:*** Tokens are only used if we return a 201 Created response. Otherwise, they are still valid
@@ -755,7 +756,73 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenRequest'
+              $ref: '#/components/schemas/PostFeedbackRequest'
+      responses:
+        '201':
+          description: |
+            The feedback has been successfully posted to GitHub.
+            We return the link to the GitHub issue.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: 'https://github.com/TUM-Dev/navigatum/issues/9'
+        '400':
+          description: If not all fields in the body are present as defined above
+        '403':
+          description: |
+            Forbidden. Causes are (delivered via the body):
+
+              - `Invalid token`: You have not supplied a token generated via the `gen_token`-Endpoint.
+              - `Token not old enough, please wait`: Tokens are only valid after 10s.
+              - `Token expired`: Tokens are only valid for 12h.
+              - `Token already used`: Tokens are non reusable/refreshable single-use items.
+          content:
+            text/plain:
+              schema:
+                type: string
+                enum:
+                  - Invalid token
+                  - 'Token not old enough, please wait'
+                  - Token expired
+                  - Token already used
+        '422':
+          description: |
+            Unprocessable Entity
+            Subject or body missing or too short.
+        '451':
+          description: |
+            Unavailable for legal reasons.
+            Using this endpoint without accepting the privacy policy is not allowed.
+            For us to post to GitHub, this has to be true
+        '500':
+          description: |
+            Internal Server Error.  
+            We have a problem communicating with GitHubs servers. Please try again later.
+        '503':
+          description: |
+            Service unavailable.  
+            We have not configured a GitHub Access Token.  
+            This could be because we are experiencing technical difficulties or intentional. Please try again later.
+      tags:
+        - feedback
+  /api/feedback/propose_edit:
+    post:
+      operationId: propose_edit
+      summary: Post Edit-Requests
+      description: |
+        ***Do not abuse this endpoint.***
+
+        This posts the actual feedback to github and returns the github link.
+        This API will create pull-requests instead of issues => only a subset of feedback is allowed.
+        For this Endpoint to work, you need to generate a token via the `/api/feedback/get_token` endpoint.
+
+        ***Important Note:*** Tokens are only used if we return a 201 Created response. Otherwise, they are still valid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProposeEditsRequest'
       responses:
         '201':
           description: |
@@ -1842,6 +1909,65 @@ components:
         - rank_combined
         - rank_type
         - rank_usage
+    ProposeEditsRequest:
+      allOf:
+        - $ref: '#/components/schemas/TokenRequest'
+        - type: object
+          properties:
+            edits:
+              description: 'The edits to be made to the room. The keys are the ID of the props to be edited, the values are the proposed Edits.'
+              type: object
+            additional_context:
+              description: |
+                Additional context for the edit.  
+                Will be displayed in the discription field of the PR
+              type: string
+              example: 'I have a picture of the room, please add it to the roomfinder'
+          required:
+            - edits
+            - additional_context
+    PostFeedbackRequest:
+      allOf:
+        - $ref: '#/components/schemas/TokenRequest'
+        - type: object
+          properties:
+            category:
+              description: |-
+                The category of the feedback.  
+                Enum attribute is softly enforced: Any value not listed below will be replaced by "other"
+              type: string
+              example: bug
+              enum:
+                - bug
+                - feature
+                - search
+                - entry
+                - general
+                - other
+            subject:
+              description: The subject/title of the feedback
+              type: string
+              example: A catchy title
+              maxLength: 512
+              minLength: 4
+            body:
+              description: The body/description of the feedback
+              type: string
+              example: A clear description what happened where and how we should improve it
+              maxLength: 1048576
+              minLength: 4
+            deletion_requested:
+              description: |
+                Whether the user has requested to delete the issue.
+                If the user has requested to delete the issue, we will delete it from GitHub after processing it
+                If the user has not requested to delete the issue, we will not delete it from GitHub and it will remain as a closed issue.
+              type: boolean
+              example: true
+          required:
+            - category
+            - subject
+            - body
+            - deletion_requested
     TokenRequest:
       type: object
       properties:
@@ -1849,52 +1975,13 @@ components:
           description: 'The JWT token, that can be used to generate feedback'
           type: string
           example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2Njk2MzczODEsImlhdCI6MTY2OTU5NDE4MSwibmJmIjoxNjY5NTk0MTkxLCJraWQiOjE1ODU0MTUyODk5MzI0MjU0Mzg2fQ.sN0WwXzsGhjOVaqWPe-Fl5x-gwZvh28MMUM-74MoNj4
-        category:
-          description: |
-            The category of the feedback.  
-            Enum attribute is softly enforced: Any value not listed below will be replaced by "other"
-          type: string
-          example: bug
-          enum:
-            - general
-            - bug
-            - feature
-            - search
-            - entry
-            - other
-        subject:
-          description: The subject/title of the feedback
-          type: string
-          example: A catchy title
-          maxLength: 512
-          minLength: 4
-        body:
-          description: The body/description of the feedback
-          type: string
-          example: A clear description what happened where and how we should improve it
-          maxLength: 1048576
-          minLength: 4
         privacy_checked:
-          description: |
-            Whether the user has checked the privacy-checkbox.
-            We are posting the feedback publicly on GitHub (not a EU-Company). You have to also include such a checkmark.
-            For inspiration on how to do this, see our website.
-          type: boolean
-          example: true
-        deletion_requested:
-          description: |
-            Whether the user has requested to delete the issue.
-            If the user has requested to delete the issue, we will delete it from GitHub after processing it
-            If the user has not requested to delete the issue, we will not delete it from GitHub and it will remain as a closed issue.
+          description: Whether the user has checked the privacy-checkbox. We are posting the feedback publicly on GitHub (not a EU-Company). You have to also include such a checkmark.
           type: boolean
           example: true
       required:
         - token
-        - category
-        - subject
-        - body
         - privacy_checked
-        - deletion_requested
 tags:
   - name: core
     description: the API to access/search for room information

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1581,9 +1581,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libnghttp2-sys"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -911,15 +911,15 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "exr"
-version = "1.6.3"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4"
+checksum = "279d3efcc55e19917fff7ab3ddd6c14afb6a90881a0078465196fe2f99d08c56"
 dependencies = [
  "bit_field",
  "flume",
  "half",
  "lebe",
- "miniz_oxide 0.6.2",
+ "miniz_oxide 0.7.1",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -1581,9 +1581,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1889,6 +1889,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -2074,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
@@ -2336,7 +2337,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -2352,7 +2353,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3396,9 +3397,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -989,9 +989,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1376,9 +1376,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -2504,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3342,9 +3342,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/server/feedback/Cargo.toml
+++ b/server/feedback/Cargo.toml
@@ -33,5 +33,8 @@ jsonwebtoken = "8.3.0"
 chrono= { version = "0.4.26", default-features = false }
 actix-governor = { version = "0.4.0", features = ["log"] }
 
+# proposing feedback
+tempfile = "3.5.0"
+
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/server/feedback/src/main.rs
+++ b/server/feedback/src/main.rs
@@ -7,6 +7,7 @@ use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
 use actix_web_prometheus::PrometheusMetricsBuilder;
 mod github;
 mod post_feedback;
+mod proposed_edits;
 mod tokens;
 
 const MAX_JSON_PAYLOAD: usize = 1024 * 1024; // 1 MB
@@ -61,6 +62,7 @@ async fn main() -> std::io::Result<()> {
             .service(health_status_handler)
             .app_data(recorded_tokens.clone())
             .service(post_feedback::send_feedback)
+            .service(proposed_edits::propose_edits)
             .service(
                 web::scope("/api/feedback/get_token")
                     .wrap(Governor::new(&feedback_ratelimit))

--- a/server/feedback/src/proposed_edits/discription.rs
+++ b/server/feedback/src/proposed_edits/discription.rs
@@ -1,0 +1,92 @@
+use crate::proposed_edits::AppliableEdit;
+use std::collections::HashMap;
+use std::path::Path;
+
+pub struct Description {
+    pub title: String,
+    pub body: String,
+}
+
+impl Default for Description {
+    fn default() -> Self {
+        Self {
+            title: "[empty commit]".to_string(),
+            body: Default::default(),
+        }
+    }
+}
+
+impl Description {
+    pub(crate) fn add_context(&mut self, additional_context: &str) {
+        if !additional_context.is_empty() {
+            self.body += &format!("Additional context: {additional_context}\n");
+        }
+    }
+    pub(crate) fn appply_set<T: AppliableEdit>(
+        &mut self,
+        category_name: &'static str,
+        set: HashMap<String, T>,
+        base_dir: &Path,
+    ) {
+        if !set.is_empty() {
+            self.title += &format!("{amount} {category_name} edits", amount = set.len());
+
+            self.body += &format!("The following {category_name} edits were made:\n");
+
+            self.body += "| entry | edit | \n";
+            self.body += "| --- | --- | \n";
+            for (key, value) in set {
+                let result = value.apply(&key, base_dir);
+                self.body += &format!("| [`{key}`](https://nav.tum.de/view/{key}) | {result} |\n");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_discription {
+    use crate::proposed_edits::AppliableEdit;
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn test_description_context() {
+        let mut description = Description {
+            title: "title".to_string(),
+            body: "body\n".to_string(),
+        };
+        description.add_context("context");
+        description.add_context(""); // should be a noop
+        assert_eq!(description.title, "title");
+        assert_eq!(description.body, "body\nAdditional context: context\n");
+    }
+
+    #[derive(Default)]
+    struct TestEdit;
+    impl AppliableEdit for TestEdit {
+        fn apply(&self, _key: &str, _base_dir: &Path) -> String {
+            "applied_value".to_string()
+        }
+    }
+
+    #[test]
+    fn test_apply_set_empty() {
+        let mut description = Description::default();
+        let set: HashMap<String, TestEdit> = HashMap::default();
+        description.appply_set("category", set, Path::new(""));
+        assert_eq!(description.title, "");
+        assert_eq!(description.body, "");
+    }
+
+    #[test]
+    fn test_apply_set() {
+        let mut description = Description::default();
+        let mut set = HashMap::new();
+        set.insert("key".to_string(), TestEdit::default());
+        description.appply_set("category", set, Path::new(""));
+        assert_eq!(description.title, "1 category edits");
+        assert_eq!(description.body, "The following category edits were made:\n| entry | edit | \n| --- | --- | \n| [`key`](https://nav.tum.de/view/key) | applied_value |\n");
+    }
+}

--- a/server/feedback/src/proposed_edits/mod.rs
+++ b/server/feedback/src/proposed_edits/mod.rs
@@ -1,0 +1,104 @@
+use crate::github;
+use crate::proposed_edits::tmp_repo::TempRepo;
+use crate::tokens::RecordedTokens;
+use actix_web::web::{Data, Json};
+use actix_web::{post, HttpResponse};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+mod discription;
+mod tmp_repo;
+
+#[derive(Deserialize, Clone)]
+struct Edit {}
+pub trait AppliableEdit {
+    fn apply(&self, key: &str, base_dir: &Path) -> String;
+}
+
+#[derive(Deserialize)]
+pub struct EditRequest {
+    token: String,
+    edits: HashMap<String, Edit>,
+    additional_context: String,
+    privacy_checked: bool,
+}
+
+const GIT_URL: &str = "git@github.com:TUM-Dev/NavigaTUM.git";
+impl EditRequest {
+    async fn apply_changes_and_generate_description(
+        &self,
+        branch_name: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let repo = TempRepo::clone_and_checkout(GIT_URL, branch_name).await?;
+        let desc = repo.apply_and_gen_description(self)?;
+        repo.commit(&desc.title).await?;
+        repo.push().await?;
+        Ok(desc.body)
+    }
+    fn edits_for<T: AppliableEdit>(&self, extractor: fn(Edit) -> Option<T>) -> HashMap<String, T> {
+        self.edits
+            .clone()
+            .into_iter()
+            .filter_map(|(k, edit)| extractor(edit).map(|coord| (k, coord)))
+            .collect()
+    }
+
+    fn extract_labels(&self) -> Vec<String> {
+        vec!["webform".to_string()]
+    }
+    fn extract_subject(&self) -> String {
+        "No Edits".to_string()
+    }
+}
+
+#[post("/api/feedback/propose_edit")]
+pub async fn propose_edits(
+    recorded_tokens: Data<RecordedTokens>,
+    req_data: Json<EditRequest>,
+) -> HttpResponse {
+    // auth
+    if let Some(e) = recorded_tokens.validate(&req_data.token).await {
+        return e;
+    }
+
+    // validate request
+    if !req_data.privacy_checked {
+        return HttpResponse::UnavailableForLegalReasons()
+            .content_type("text/plain")
+            .body("Using this endpoint without accepting the privacy policy is not allowed");
+    };
+    if !req_data.edits.is_empty() {
+        return HttpResponse::UnprocessableEntity()
+            .content_type("text/plain")
+            .body("Not enough edits provided");
+    };
+    if req_data.edits.len() > 500 {
+        return HttpResponse::InsufficientStorage()
+            .content_type("text/plain")
+            .body("Too many edits provided");
+    };
+
+    let branch_name = format!("usergenerated/request-{}", rand::random::<u16>());
+    match req_data
+        .apply_changes_and_generate_description(&branch_name)
+        .await
+    {
+        Ok(description) => {
+            github::open_pr(
+                branch_name,
+                &format!(
+                    "[User-Provided] {subject}",
+                    subject = req_data.extract_subject()
+                ),
+                &description,
+                req_data.extract_labels(),
+            )
+            .await
+        }
+        Err(e) => {
+            log::error!("Error while applying changes: {e}", e = e);
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}

--- a/server/feedback/src/proposed_edits/tmp_repo.rs
+++ b/server/feedback/src/proposed_edits/tmp_repo.rs
@@ -1,0 +1,129 @@
+use crate::proposed_edits::EditRequest;
+use log::{debug, info};
+use std::{error, io};
+use tokio::process::Command;
+
+use crate::proposed_edits::discription::Description;
+
+pub(crate) struct TempRepo {
+    dir: tempfile::TempDir,
+    branch_name: String,
+}
+impl TempRepo {
+    pub async fn clone_and_checkout(
+        url: &'static str,
+        branch_name: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        let dir = tempfile::tempdir()?;
+
+        info!("Cloning {url} into {dir:?}");
+        let out = Command::new("git")
+            .current_dir(&dir)
+            .arg("clone")
+            .arg(url)
+            .arg(dir.path())
+            .output()
+            .await?;
+        debug!("commit output: {out:?}");
+        if out.status.code() != Some(0) {
+            return Err(format!("git status failed with output: {out:?}").into());
+        }
+
+        // checkout + create branch
+        let out = Command::new("git")
+            .current_dir(&dir)
+            .arg("checkout")
+            .arg("-b")
+            .arg(branch_name)
+            .arg("main")
+            .output()
+            .await?;
+        debug!("checkout output: {out:?}");
+        match out.status.code() {
+            Some(0) => Ok(Self {
+                dir,
+                branch_name: branch_name.to_string(),
+            }),
+            _ => Err(format!("git commit failed with output: {out:?}").into()),
+        }
+    }
+
+    pub fn apply_and_gen_description(&self, edits: &EditRequest) -> Result<Description, io::Error> {
+        let mut description = Description::default();
+        description.add_context(&edits.additional_context);
+
+        Ok(description)
+    }
+
+    pub async fn commit(&self, title: &str) -> Result<(), Box<dyn error::Error>> {
+        let out = Command::new("git")
+            .current_dir(&self.dir)
+            .arg("commit")
+            .arg("--allow-empty") // TODO: remove once the need for empty commits is gone (images+coodinates)
+            .arg("--all") // run git add . before commit
+            .arg("-m")
+            .arg(title)
+            .output()
+            .await?;
+        debug!("commit output: {out:?}");
+        match out.status.code() {
+            Some(0) => Ok(()),
+            _ => Err(format!("git commit failed with output: {out:?}").into()),
+        }
+    }
+    pub async fn push(&self) -> Result<(), Box<dyn error::Error>> {
+        let out = Command::new("git")
+            .current_dir(&self.dir)
+            .arg("status")
+            .output()
+            .await?;
+        debug!("git status: {out:?}");
+        if out.status.code() != Some(0) {
+            return Err(format!("git status failed with output: {out:?}").into());
+        }
+        let out = Command::new("git")
+            .current_dir(&self.dir)
+            .arg("push")
+            .arg("--set-upstream")
+            .arg("origin")
+            .arg(&self.branch_name)
+            .output()
+            .await?;
+        debug!("git push: {out:?}");
+        match out.status.code() {
+            Some(0) => Ok(()),
+            _ => Err(format!("git push failed with output: {out:?}").into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    const GIT_URL: &str = "https://github.com/CommanderStorm/dotfiles.git";
+    #[tokio::test]
+    async fn test_new() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let temp_repo = TempRepo::clone_and_checkout(GIT_URL, "main").await.unwrap();
+        assert!(temp_repo.dir.path().exists());
+        assert!(temp_repo.dir.path().join(".git").exists());
+        assert!(temp_repo.dir.path().join("README.md").exists());
+    }
+
+    #[tokio::test]
+    async fn test_checkout_and_commit() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let temp_repo = TempRepo::clone_and_checkout(GIT_URL, "branch_does_not_exist")
+            .await
+            .unwrap();
+        // test the branch was created
+
+        // test the commit
+        let title = "Test commit";
+        let file_path = temp_repo.dir.path().join("test-file.txt");
+        fs::write(file_path, "test content").unwrap();
+
+        temp_repo.commit(title).await.unwrap();
+    }
+}

--- a/webclient/README.md
+++ b/webclient/README.md
@@ -67,6 +67,7 @@ From the folder of this README, run:
 
 ```sh
 npx openapi-typescript ../openapi.yaml --output ./src/api_types/index.ts --export-type --immutable-types --support-array-length
+npm run lint
 ```
 
 ## Build files & Serving release build


### PR DESCRIPTION
PR in the https://github.com/TUM-Dev/NavigaTUM/issues/501 PR-Train

## Proposed Changes (include Screenshots if possible)

- Added the basic draft for an api with with we can automatically propose edit-PRs instead of issues


## How to test this PR

1. Code Review
2. POST to `http://localhost:XXXX:/api/feedback/propose_edit`
3. See the new PR

## How has this been tested?

- [x] Adding unit tests

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
