### PR TITLE
Better 404 handling for missing rooms

### DIFF
--- a/webclient/src/composables/fetch.ts
+++ b/webclient/src/composables/fetch.ts
@@ -1,7 +1,11 @@
 import { shallowRef } from "vue";
 import { useGlobalStore } from "@/stores/global";
 
-export function useFetch<T>(url: string, successHandler: (d: T) => void, options: RequestInit = {}) {
+export function useFetch<T>(
+  url: string,
+  successHandler: (d: T) => void,
+  errorHandler: ((e: string) => void) | undefined = undefined
+) {
   const data = shallowRef<T | null>(null);
   // for some of our endpoints, we might want to have access to the lang/theme cookies
 
@@ -10,7 +14,8 @@ export function useFetch<T>(url: string, successHandler: (d: T) => void, options
   url += (url.indexOf("?") != -1 ? "&lang=" : "?lang=") + lang;
 
   const global = useGlobalStore();
-  fetch(url, options)
+  const fetchErrorHandler = errorHandler || ((err: string) => (global.error_message = err));
+  fetch(url)
     .then((res) => {
       if (res.status < 200 || res.status >= 300) throw res.statusText;
       return res.json();
@@ -20,7 +25,7 @@ export function useFetch<T>(url: string, successHandler: (d: T) => void, options
       data.value = json;
       successHandler(json);
     })
-    .catch((err) => (global.error_message = err));
+    .catch(fetchErrorHandler);
 
   return { data };
 }

--- a/webclient/src/locales/de.yaml
+++ b/webclient/src/locales/de.yaml
@@ -119,7 +119,7 @@ view_404:
   header: "Die angeforderte Seite wurde nicht gefunden."
   description: "Dies könnte sein, weil wir einen Fehler gemacht haben."
   call_to_action: "Falls du denkst, dass dies ein Fehler ist, teile es uns doch hier mit"
-  got_here: # "\\\\n" renders to "\n" "Ich habe diesen Fehler so gefunden:\\\\n1. ..."
+  got_here: "Ich habe diesen Fehler so gefunden:\r\n1. ..."
 view_api:
   title: "NavigaTUMs API Documentation"
 view_main:

--- a/webclient/src/locales/en.yaml
+++ b/webclient/src/locales/en.yaml
@@ -119,7 +119,7 @@ view_404:
   header: "The requested website could not to be found."
   description: "This could be because we made a mistake."
   call_to_action: "If you think this is a mistake, please let us know here"
-  got_here: # "\\\\n" renders to "\n" "I have found the error by:\\\\n1. ..."
+  got_here: "I have found the error by:\r\n1. ..."
 view_api:
   title: "NavigaTUMs API Documentation"
 view_main:

--- a/webclient/src/router.ts
+++ b/webclient/src/router.ts
@@ -22,7 +22,7 @@ const routes = [
     component: () => import("./views/AboutView.vue"),
   },
   {
-    path: "/:catchAll(.*)",
+    path: "/:catchAll(.*)*",
     name: "404",
     component: NotFoundView,
   },

--- a/webclient/src/views/DetailsView.vue
+++ b/webclient/src/views/DetailsView.vue
@@ -64,7 +64,7 @@ function update() {
     router.push({
       name: "404",
       // preserve current path and remove the first char to avoid the target URL starting with `//`
-      params: { catchAll: route.path.substring(1) },
+      params: { catchAll: route.path.substring(1).split('/') },
       query: route.query,
       hash: route.hash,
     });

--- a/webclient/src/views/NotFoundView.vue
+++ b/webclient/src/views/NotFoundView.vue
@@ -2,7 +2,6 @@
 import { useGlobalStore } from "@/stores/global";
 
 const global = useGlobalStore();
-const href = window.location.href;
 </script>
 
 <template>
@@ -10,7 +9,7 @@ const href = window.location.href;
   <h5 style="margin-top: 25px">{{ $t("view_404.header") }}</h5>
   <p>{{ $t("view_404.description") }}</p>
   <button
-    @click="global.openFeedback('bug', `404 on ${href}`, $t('view_404.got_here'))"
+    @click="global.openFeedback('bug', `404 on ${window.location.href}`, $t('view_404.got_here'))"
     class="btn btn-link p-0"
     aria-label="Open the feedback-form"
   >

--- a/webclient/src/views/NotFoundView.vue
+++ b/webclient/src/views/NotFoundView.vue
@@ -2,6 +2,7 @@
 import { useGlobalStore } from "@/stores/global";
 
 const global = useGlobalStore();
+const href = window.location.href;
 </script>
 
 <template>
@@ -9,7 +10,7 @@ const global = useGlobalStore();
   <h5 style="margin-top: 25px">{{ $t("view_404.header") }}</h5>
   <p>{{ $t("view_404.description") }}</p>
   <button
-    @click="global.openFeedback('bug', `404 on ${window.location.href}`, $t('view_404.got_here'))"
+    @click="global.openFeedback('bug', `404 on ${href}`, $t('view_404.got_here'))"
     class="btn btn-link p-0"
     aria-label="Open the feedback-form"
   >


### PR DESCRIPTION
Fixes #519 
The current implementation has the downside of urlencoding the path, but I think this shuld be acceptable

## Proposed Changes (include Screenshots if possible)

- Removes unused `options` option
- Adds a handler for routes which should show 404 which shows 404

## How to test this PR

1. (once #200 is merged) look at it in the staging
2. code review

## How has this been tested?

- with local staging going to http://localhost:8000/room/2906.05.016d
- get redirected to http://localhost:8000/room%2F2906.05.016d and see 
  ![image](https://user-images.githubusercontent.com/26258709/233139024-29091f21-706d-4370-b084-87e32d1237b3.png)


## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
