### PR TITLE
Add floor patch for 0507.03.750

### DIFF
--- a/data/sources/02_rooms-extended.yaml
+++ b/data/sources/02_rooms-extended.yaml
@@ -8,6 +8,14 @@
   comment:
     de: Unter dieser Treppe existiert ein WC, dessen Raumnummer und designierung (men/women/unisex) unklar ist
     en: Under this staircase there is a toilet whose room number and designation (men/women/unisex) is unclear
+"0507.03.750":  # Karl Max von Bauernfeind Hörsaal
+  props:
+    comment:
+      de: Dieser Hörsaal ist in TUMonline 0507.03.750 statt 0507.02.750, obwohl der Hörsaal im 2. Stock ist. Aus Konsistenzgründen übernehmen wir diese ID.
+      en: This lecture hall is 0507.03.750 in TUMonline instead of 0507.02.750, although the lecture hall is on the 2nd floor. For consistency, we also use this ID.
+  generators:
+    floors:
+      floor_patch: "02"
 "0509.EG.980":
   name: Audimax, Werner-von-Siemens-Hörsaal
   ranking_factors:


### PR DESCRIPTION
Resolves #560

(as PR so we can discuss)

## Proposed Changes (include Screenshots if possible)

- Patch the floor of this lecture hall to 2
- Add an informational comment like for [MW1801](https://nav.tum.de/room/5508.02.801). If you consider it unnecessary we can remove the comment though

## How to test this PR

1. Open 0507.03.750 in a patched instance

## How has this been tested?

- 

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [ ] I have run the linter
