### PR TITLE
[Search-Refactoring-2] `reqwest` based main api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1540,7 +1540,7 @@ components:
         time_ms:
           description: |
             Time the search took in the server side, not including network delay
-            Maximum as by awc timeout. other timeouts (browser, your client) may be smaller
+            Maximum as timeout. other timeouts (browser, your client) may be smaller
             Expected average is 10..50 for uncached, regular requests
           type: integer
           format: int32

--- a/server/calendar/Cargo.toml
+++ b/server/calendar/Cargo.toml
@@ -21,10 +21,10 @@ path = "src/scraper.rs"
 # shared
 log.workspace = true
 env_logger.workspace = true
-actix-web-prometheus.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
+actix-web-prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/feedback/Cargo.toml
+++ b/server/feedback/Cargo.toml
@@ -17,10 +17,10 @@ path = "src/main.rs"
 # shared
 log.workspace = true
 env_logger.workspace = true
-actix-web-prometheus.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
+actix-web-prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/main-api/Cargo.toml
+++ b/server/main-api/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 # shared
 log.workspace = true
 env_logger.workspace = true
-actix-web-prometheus.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
+actix-web-prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/main-api/Cargo.toml
+++ b/server/main-api/Cargo.toml
@@ -25,8 +25,6 @@ actix-cors.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-rustls = "0.21.1"
-awc = { version = "3.1.1", features = ["rustls"] }
 cached = "0.43.0"
 futures = "0.3.28"
 unicode-truncate = "0.2.0"
@@ -36,6 +34,8 @@ meilisearch-sdk = "0.23.1"
 diesel = { version = "2.1.0", features = ["default", "sqlite"] }
 
 # maps
+rustls = "0.21.1"
+reqwest = { version= "0.11.17", features = ["rustls"] }
 image = "0.24.6"
 imageproc = "0.23.0"
 rusttype = "0.9.3"

--- a/server/main-api/src/core/search/mod.rs
+++ b/server/main-api/src/core/search/mod.rs
@@ -41,14 +41,13 @@ pub async fn search_handler(
     let (q, highlighting, sanitised_args) = sanitise_args(args);
     let results_sections =
         search_executor::do_geoentry_search(q, highlighting, sanitised_args).await;
-    let time_ms = start_time.elapsed().as_millis();
 
     if results_sections.len() != 2 {
         return HttpResponse::InternalServerError().body("Internal error");
     }
     let search_results = SearchResults {
         sections: results_sections,
-        time_ms,
+        time_ms: start_time.elapsed().as_millis(),
     };
     HttpResponse::Ok().json(search_results)
 }


### PR DESCRIPTION
This PR is similar in content as #453
In https://github.com/TUM-Dev/NavigaTUM/pull/452 I noticed, that the API of awc can be simplified with slightly a less performant library.


- Performance for the scraper is not an issue, as we scrape with a scrape-budget anyway
- `awc` has requirements, from the tokio environment, which would look very ugly => imo this is way better

## Proposed Changes (include Screenshots if possible)

- migrated from awc to reqwest

## How to test this PR

1. Code review

## How has this been tested?

- Ran the code

## Checklist:

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
