### PR TITLE
Addition of Sentry for Frontend Observabiltiy

### DIFF
--- a/webclient/package.json
+++ b/webclient/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint . --ext .vue,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
+    "@sentry/tracing": "^7.53.1",
+    "@sentry/vue": "^7.53.1",
     "maplibre-gl": "^3.0.0",
     "pinia": "^2.0.28",
     "spectre.css": "github:Valexr/spectre#dfe3bc2c59d23cd4bfd43c690aae3655576ff708",

--- a/webclient/src/main.ts
+++ b/webclient/src/main.ts
@@ -10,6 +10,8 @@ import de from "./locales/de.yaml";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import en from "./locales/en.yaml";
+import * as Sentry from "@sentry/vue";
+import { BrowserTracing } from "@sentry/tracing";
 
 const i18n = createI18n({
   locale: localStorage.getItem("lang") || "de",
@@ -23,6 +25,24 @@ const i18n = createI18n({
 const app = createApp(App);
 
 app.use(createPinia());
+
+if (import.meta.env.PROD) {
+  Sentry.init({
+    app,
+    dsn: "https://e7192dffa92c4f4cbfb8cf8967c83583@sentry.mm.rbg.tum.de/6",
+    integrations: [
+      new BrowserTracing({
+        routingInstrumentation: Sentry.vueRouterInstrumentation(router),
+        tracePropagationTargets: ["nav.tum.de"],
+      }),
+    ],
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for performance monitoring.
+    // We recommend adjusting this value in production
+    tracesSampleRate: 1.0,
+  });
+}
+
 app.use(router);
 app.use(i18n);
 


### PR DESCRIPTION
Added sentry for gathering intel on the frontend deployment

## Proposed Changes (include Screenshots if possible)

- This adds the ability to know if something is failing before users complain
- This adds the ability to know how good/bad the 

## How to test this PR

- Discuss if this is already covered in the currently deployed data protection policy (I think it is covered)
- Discuss if this needs a change to the documentation (I think it is not worthy to be documented)

## How has this been tested?

- remove the if statement indicating sentry only happens in prod
- Replace `nav.tum.de` with `localhost`
- ![image](https://github.com/TUM-Dev/NavigaTUM/assets/26258709/7747ecb8-5bf4-4168-96a6-fee66e9da61c)
- (other dashboards are mostly empty, as no current errors)

## Checklist:

- [ ] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
