### PR TITLE
[Coordinate-picker-rework 1] extracted feedbackTokens to their own file

### DIFF
--- a/webclient/src/components/AppFeedbackModal.vue
+++ b/webclient/src/components/AppFeedbackModal.vue
@@ -2,7 +2,7 @@
 import { useGlobalStore } from "@/stores/global";
 import { ref } from "vue";
 import { Translation, useI18n } from "vue-i18n";
-import {useFeedbackToken} from "@/composables/feedbackToken";
+import { useFeedbackToken } from "@/composables/feedbackToken";
 const { t } = useI18n({ inheritLocale: true, useScope: "global" });
 
 const global = useGlobalStore();

--- a/webclient/src/components/AppFeedbackModal.vue
+++ b/webclient/src/components/AppFeedbackModal.vue
@@ -1,69 +1,17 @@
 <script setup lang="ts">
 import { useGlobalStore } from "@/stores/global";
-import { reactive, ref, watch } from "vue";
+import { ref } from "vue";
 import { Translation, useI18n } from "vue-i18n";
-import { useLocalStorage } from "@vueuse/core";
+import {useFeedbackToken} from "@/composables/feedbackToken";
 const { t } = useI18n({ inheritLocale: true, useScope: "global" });
 
 const global = useGlobalStore();
 const loading = ref(false);
 const successUrl = ref("");
-const error = reactive({
-  message: "",
-  blockSend: false,
-});
-type Token = {
-  readonly created_at: number;
-  readonly token: string;
-};
-
-const token = useLocalStorage<Token | null>("feedback-token", null, {
-  serializer: {
-    read: (v) => (v ? JSON.parse(v) : null),
-    write: (v) => JSON.stringify(v),
-  },
-});
+const { error, token } = useFeedbackToken();
 
 const privacyChecked = ref(false);
 const deleteIssueRequested = ref(false);
-
-watch(() => global.feedback.open, assuereTokenValidity, { immediate: true });
-function assuereTokenValidity() {
-  // legacy migration function TODO: remove only after 31.09.2023, to give our users time to migrate to the new token format
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  if (token.value?.expiry) {
-    token.value = null;
-  }
-
-  // Token are renewed after 6 hours here to be sure, even though they may be valid for longer on the server side.
-  if (token.value === null || Date.now() - token.value.created_at > 1000 * 3600 * 6) {
-    fetch(`/api/feedback/get_token`, { method: "POST" })
-      .then((r) => {
-        if (r.status === 201) {
-          r.json()
-            .then((j: Token) => {
-              token.value = j;
-            })
-            .catch((r) => {
-              _showError(t("feedback.error.token_req_failed"), false);
-              console.error(r);
-            });
-        } else if (r.status === 429) {
-          _showError(t("feedback.error.429"), true);
-        } else if (r.status === 503) {
-          _showError(t("feedback.error.503"), true);
-        } else {
-          const unexpectedTS = t("feedback.error.token_unexpected_status");
-          _showError(`${unexpectedTS}${r.status}`, true);
-        }
-      })
-      .catch((r) => {
-        _showError(t("feedback.error.token_req_failed"), false);
-        console.error(r);
-      });
-  }
-}
 
 function _showError(msg: string, blockSend = false) {
   error.message = msg;

--- a/webclient/src/composables/feedbackToken.ts
+++ b/webclient/src/composables/feedbackToken.ts
@@ -2,6 +2,7 @@ import { reactive } from "vue";
 import type { components } from "@/api_types";
 import { useLocalStorage } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
+
 type TokenResponse = components["schemas"]["TokenResponse"];
 
 const { t } = useI18n({ inheritLocale: true, useScope: "global" });
@@ -9,10 +10,13 @@ const { t } = useI18n({ inheritLocale: true, useScope: "global" });
 enum TokenStatus {
   SUCCESSFULLY_CREATED = 201,
   TOO_MANY_REQUESTS = 429,
-  NOT_CONFIGURED=  503,
+  NOT_CONFIGURED = 503,
 }
 
-export function useFeedbackToken() {
+export function useFeedbackToken(): {
+  error: { message: string; blockSend: boolean };
+  token: { value: TokenResponse | null };
+} {
   const token = useLocalStorage<TokenResponse | null>("feedback-token", null, {
     serializer: {
       read: (v) => (v ? JSON.parse(v) : null),

--- a/webclient/src/composables/feedbackToken.ts
+++ b/webclient/src/composables/feedbackToken.ts
@@ -24,9 +24,10 @@ export function useFeedbackToken() {
     token.value = null;
   }
 
-  // Token are renewed after 6 hours here to be sure, even though they may be valid for longer on the server side.
-  const SECONDS_PER_HOUR = 1000 * 3600;
-  if (token.value === null || Date.now() - token.value.created_at > SECONDS_PER_HOUR * 6) {
+  // Token are renewed much before being invalid on the server.
+  const MS_PER_HOUR = 3600000;
+  const TOKEN_VALIDITY_MS = MS_PER_HOUR * 6;
+  if (token.value === null || Date.now() - token.value.created_at > TOKEN_VALIDITY_MS) {
     fetch(`/api/feedback/get_token`, { method: "POST" })
       .then((r) => {
         if (r.status === 201) {

--- a/webclient/src/composables/feedbackToken.ts
+++ b/webclient/src/composables/feedbackToken.ts
@@ -1,0 +1,58 @@
+import { reactive } from "vue";
+import type { components } from "@/api_types";
+import { useLocalStorage } from "@vueuse/core";
+import { useI18n } from "vue-i18n";
+type TokenResponse = components["schemas"]["TokenResponse"];
+
+const { t } = useI18n({ inheritLocale: true, useScope: "global" });
+export function useFeedbackToken() {
+  const token = useLocalStorage<TokenResponse | null>("feedback-token", null, {
+    serializer: {
+      read: (v) => (v ? JSON.parse(v) : null),
+      write: (v) => JSON.stringify(v),
+    },
+  });
+  const error = reactive({
+    message: "",
+    blockSend: false,
+  });
+
+  // legacy migration function TODO: remove only after 31.09.2023, to give our users time to migrate to the new token format
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (token.value?.expiry) {
+    token.value = null;
+  }
+
+  // Token are renewed after 6 hours here to be sure, even though they may be valid for longer on the server side.
+  const SECONDS_PER_HOUR = 1000 * 3600;
+  if (token.value === null || Date.now() - token.value.created_at > SECONDS_PER_HOUR * 6) {
+    fetch(`/api/feedback/get_token`, { method: "POST" })
+      .then((r) => {
+        if (r.status === 201) {
+          r.json()
+            .then((j: TokenResponse) => {
+              token.value = j;
+            })
+            .catch((r) => {
+              error.message = t("feedback.error.token_req_failed");
+              console.error(r);
+            });
+        } else if (r.status === 429) {
+          error.message = t("feedback.error.429");
+          error.blockSend = true;
+        } else if (r.status === 503) {
+          error.message = t("feedback.error.503");
+          error.blockSend = true;
+        } else {
+          error.message = `${t("feedback.error.token_unexpected_status")}${r.status}`;
+          error.blockSend = true;
+        }
+      })
+      .catch((r) => {
+        error.message = t("feedback.error.token_req_failed");
+        console.error(r);
+      });
+  }
+  return { error, token };
+}

--- a/webclient/src/locales/de.yaml
+++ b/webclient/src/locales/de.yaml
@@ -24,8 +24,8 @@ feedback:
     title: Koordinate auswählen
   delete: Das zugehörige GitHub Issue löschen, sobald es gelöst wurde.
   error:
-    '429': Feedback senden ist aktuell nicht möglich aufgrund von rate-limiting. Bitte versuche es später nochmal oder schreibe eine Mail.
-    '503': Das Senden von Feedback ist auf dem Server aktuell nicht konfiguriert.
+    too_many_requests: Feedback senden ist aktuell nicht möglich aufgrund von rate-limiting. Bitte versuche es später nochmal oder schreibe eine Mail.
+    feedback_not_configured: Das Senden von Feedback ist auf dem Server aktuell nicht konfiguriert.
     privacy_not_checked:
       other_contact_options: Es gibt andere Möglichkeiten uns zu kontaktieren, welche im Impressum aufgelistet sind.
       please_accept_privcacy_statement: Du musst die Datenschutzerklärung akzeptiert haben, damit wir dein Feedback via GitHub verarbeiten können.

--- a/webclient/src/locales/en.yaml
+++ b/webclient/src/locales/en.yaml
@@ -24,8 +24,8 @@ feedback:
     title: Select coordinate
   delete: Delete this GitHub issue when resolved.
   error:
-    '429': Sending feedback is currently not possible due to rate-limiting. Please try again in a while or send a mail.
-    '503': Sending feedback is currently not configured on the server.
+    too_many_requests: Sending feedback is currently not possible due to rate-limiting. Please try again in a while or send a mail.
+    feedback_not_configured: Sending feedback is currently not configured on the server.
     privacy_not_checked:
       other_contact_options: There are other means of contact listed at in our impressum.'
       please_accept_privcacy_statement: You have to accept the privacy statement for us to process the feedback via GitHub.


### PR DESCRIPTION
## Proposed Changes (include Screenshots if possible)

- extracted `useFeedbackToken` to its own composable, to make further modifications more simple

## How to test this PR

1. Launch the feedback system (including prod configuration)
2. Launch the webclient
3. send feedback via the webclient

## How has this been tested?

- see above

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
