### PR TITLE
Minor-Only server dependencys if often released

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -326,9 +326,9 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -913,9 +913,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "exr"
-version = "1.6.5"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7b44a196573e272e0cf0bcf130281c71e9a0c67062954b3323fd364bfdac9"
+checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
 dependencies = [
  "bit_field",
  "flume",
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaecc05d5c4b5f7da074b9a0d1a0867e71fd36e7fc0482d8bcfe8e8fc56290"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3710,9 +3710,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9482fe6ceabdf32f3966bfdd350ba69256a97c30253dc616fe0005af24f164e"
+checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,13 +12,13 @@ env_logger = "0.10.0"
 actix-web-prometheus = "0.1.2"
 
 # runtime + webserver
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.29", features = ["full"] }
 actix-web = "4.3.1"
 actix-cors = "0.6.4"
 
 #serialisation
-serde = { version = "1.0.167", features = ["derive"] }
-serde_json = "1.0.100"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 # testing
 pretty_assertions = "1.4.0"


### PR DESCRIPTION
Fixes Renovate spamming me with patch releases for very frequently released libraries

## Proposed Changes (include Screenshots if possible)

- often released server dependencies to only be dependency-bumped on minor releases instead of patch releases

## How to test this PR

1. Run the CI
2. Wait for renovate to propose another PR 

## How has this been tested?

- CI

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
