### PR TITLE
fix:Improper paths and multiprocessing error handling

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Process
 
 import processors.areatree.process as areatree
@@ -124,11 +123,13 @@ def main() -> None:
     search.add_ranking_combined(data)
 
     logging.info("-- 100 Export and generate Sitemap")
-    with ThreadPoolExecutor(max_workers=3) as executor:
-        executor.submit(export.export_for_search, data, "output/search_data.json")
-        executor.submit(export.export_for_api, data, "output/api_data.json")
-        executor.submit(sitemap.generate_sitemap)  # only for deployments
+    export.export_for_search(data, "output/search_data.json")
+    export.export_for_api(data, "output/api_data.json")
+    sitemap.generate_sitemap()  # only for deployments
+
     resizer.join(timeout=60 * 4)
+    if resizer.exitcode != 0:
+        raise RuntimeError("Resizer process during the execution of the script")
 
 
 if __name__ == "__main__":

--- a/data/processors/nat.py
+++ b/data/processors/nat.py
@@ -1,13 +1,16 @@
 import dataclasses
-import json
 import logging
 from collections import Counter
+from pathlib import Path
 from typing import Any
 
 import yaml
 from external.models import nat
 
-with open("sources/12_nat_excluded_buildings.yaml", encoding="utf-8") as excluded_buildings_raw:
+BASE = Path(__file__).parent.parent
+SOURCES = BASE / "sources"
+
+with open(SOURCES / "12_nat_excluded_buildings.yaml", encoding="utf-8") as excluded_buildings_raw:
     EXCLUDED_BUILDINGS = set(yaml.safe_load(excluded_buildings_raw.read()))
 
 
@@ -97,8 +100,7 @@ def merge_nat_rooms(_data):
     This will not overwrite the existing data, but act directly on the provided data.
     """
 
-    with open("external/results/rooms_nat.json", encoding="utf-8") as file:
-        _rooms = json.load(file)  # noqa: F841
+    _rooms = nat.Room.load_all()  # noqa: F841
 
     # TODO: implement the merging of NAT rooms
     logging.warning("Merging NAT rooms is not yet implemented")

--- a/data/processors/roomfinder.py
+++ b/data/processors/roomfinder.py
@@ -1,10 +1,14 @@
 import logging
 import re
+from pathlib import Path
 from typing import Any
 
 import utm
 import yaml
 from external.models import roomfinder
+
+BASE = Path(__file__).parent.parent
+SOURCES = BASE / "sources"
 
 
 def merge_roomfinder_buildings(data: dict[str, dict[str, Any]]) -> None:
@@ -12,7 +16,7 @@ def merge_roomfinder_buildings(data: dict[str, dict[str, Any]]) -> None:
     Merge the buildings in Roomfinder with the existing data.
     This will not overwrite the existing data, but act directly on the provided data.
     """
-    with open("sources/10_patches-roomfinder-buildings.yaml", encoding="utf-8") as file:
+    with open(SOURCES / "10_patches-roomfinder-buildings.yaml", encoding="utf-8") as file:
         patches = yaml.safe_load(file.read())
 
     error = False
@@ -78,7 +82,7 @@ def merge_roomfinder_rooms(data: dict[str, dict[str, Any]]) -> None:
     This will not overwrite the existing data, but act directly on the provided data.
     """
 
-    with open("sources/16_roomfinder-merge-patches.yaml", encoding="utf-8") as file:
+    with open(SOURCES / "16_roomfinder-merge-patches.yaml", encoding="utf-8") as file:
         patches = yaml.safe_load(file.read())
 
     # It is significantly faster to first generate a lookup to the rooms in the

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import string
+from pathlib import Path
 from typing import Any
 
 import pydantic
@@ -13,6 +14,9 @@ from utils import TranslatableStr as _
 ALLOWED_ROOMCODE_CHARS = set(string.ascii_letters) | set(string.digits) | {".", "-"}
 OPERATOR_STRIP_CHARS = "[ ]"
 OPERATOR_WEBNAV_LINK_PREFIX = "webnav.navigate_to?corg="
+
+BASE = Path(__file__).parent.parent
+SOURCES = BASE / "sources"
 
 
 def merge_tumonline_buildings(data: dict[str, dict[str, Any]]) -> None:
@@ -197,7 +201,7 @@ def _clean_tumonline_rooms():
         rooms = json.load(file)
     roomcode_lookup: dict[str, dict] = {r["roomcode"]: r for r in rooms}
 
-    with open("sources/15_patches-rooms_tumonline.yaml", encoding="utf-8") as file:
+    with open(SOURCES / "15_patches-rooms_tumonline.yaml", encoding="utf-8") as file:
         patches = yaml.safe_load(file.read())
 
     patched_rooms = apply_roomcode_patch(rooms, patches["patches"])

--- a/server/main-api/load_api_data_to_db.py
+++ b/server/main-api/load_api_data_to_db.py
@@ -1,9 +1,11 @@
 import dataclasses
 import json
 import sqlite3
+from pathlib import Path
 from typing import Any, TypeAlias, Union
 
 TranslatedList: TypeAlias = list[tuple[str, str, Any]]
+BASE_DIR = Path(__file__).parent
 
 
 def save_entries_to_database(de_data: TranslatedList, en_data: TranslatedList) -> None:
@@ -72,7 +74,7 @@ def localise(value: Union[str, list[Any], dict[str, Any]], language: str) -> Any
 
 def get_localised_data() -> tuple[TranslatedList, TranslatedList]:
     """get all data from the json dump and convert it to a list of tuples"""
-    with open("data/api_data.json", encoding="utf-8") as file:
+    with open(BASE_DIR / "data" / "api_data.json", encoding="utf-8") as file:
         data = json.load(file)
     split_data: list[tuple[str, Any, Any]] = [
         (key, localise(value, "de"), localise(value, "en")) for key, value in data.items()
@@ -101,7 +103,7 @@ class Alias:
 
 def extract_aliases() -> set[Alias]:
     """Extracts all aliases from the api_data.json file and returns them as a dict"""
-    with open("data/api_data.json", encoding="utf-8") as file:
+    with open(BASE_DIR / "data" / "api_data.json", encoding="utf-8") as file:
         data = json.load(file)
     aliases = set()
     for key, value in data.items():


### PR DESCRIPTION
Unblocks a part of #673

## Proposed Changes (include Screenshots if possible)

- We were using improper paths
- and invalid error handling which became obvious during designing a dev container

## How to test this PR

- a sitemap is now again exported
- the devcontainer no longer errors out because of pathing issues

## How has this been tested?

- see above

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
