### PR TITLE
chore:Openssl replacement

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -216,18 +216,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-web-prometheus"
-version = "0.1.2"
+name = "actix-web-prom"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5228fd1a6b5d0f60d636776c2a70acc9fc667034bb4ac02ec4259f0eeeab6c"
+checksum = "f23f332a652836b8f3a6876103c70c9ed436d0e69fa779ab5d7f57b1d5c8d488"
 dependencies = [
- "actix-service",
  "actix-web",
- "futures-lite",
- "pin-project",
+ "futures-core",
+ "pin-project-lite",
  "prometheus",
- "quanta 0.10.1",
- "thiserror",
+ "regex",
 ]
 
 [[package]]
@@ -1179,7 +1177,7 @@ dependencies = [
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
- "quanta 0.9.3",
+ "quanta",
  "rand 0.8.5",
  "smallvec",
 ]
@@ -1892,7 +1890,7 @@ version = "1.0.0"
 dependencies = [
  "actix-cors",
  "actix-web",
- "actix-web-prometheus",
+ "actix-web-prom",
  "chrono",
  "diesel",
  "diesel_migrations",
@@ -1919,7 +1917,7 @@ dependencies = [
  "actix-cors",
  "actix-governor",
  "actix-web",
- "actix-web-prometheus",
+ "actix-web-prom",
  "base64 0.21.3",
  "chrono",
  "env_logger",
@@ -1944,7 +1942,7 @@ version = "1.0.0"
 dependencies = [
  "actix-cors",
  "actix-web",
- "actix-web-prometheus",
+ "actix-web-prom",
  "cached",
  "diesel",
  "env_logger",
@@ -2367,22 +2365,6 @@ name = "quanta"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach",
- "once_cell",
- "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "quanta"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
 dependencies = [
  "crossbeam-utils",
  "libc",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 # logging/obeservability
 log = "0.4.20"
 env_logger = "0.10.0"
-actix-web-prometheus = "0.1.2"
+actix-web-prom = { version = "0.7.0", default-features = false, features = [] }
 
 # runtime + webserver
 tokio = { version = "1.32", features = ["full"] }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@ FROM    rust:1.72-alpine AS compiler
 
 # to ache the build this line inludes all the dependencys all servers need
 # this is not an issue since we copy the generated binary to a more minimal envornment
-RUN     apk add -q --update-cache --no-cache build-base openssl-dev libpq-dev libwebp-dev
+RUN     apk add -q --update-cache --no-cache build-base libpq-dev libwebp-dev
 
 WORKDIR /compiler
 ENV     USER=root

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,11 @@ FROM    rust:1.72-alpine AS compiler
 
 # to ache the build this line inludes all the dependencys all servers need
 # this is not an issue since we copy the generated binary to a more minimal envornment
-RUN     apk add -q --update-cache --no-cache build-base libpq-dev libwebp-dev
+# Descriptions:
+# - musl-dev is needed fpr musl to compile the binary
+# - libpq-dev is needed for diesel (sigh)
+# - libwebp-dev is until the `image` has finsihed the refactoring effort
+RUN     apk add -q --update-cache --no-cache musl-dev libpq-dev libwebp-dev
 
 WORKDIR /compiler
 ENV     USER=root

--- a/server/calendar/Cargo.toml
+++ b/server/calendar/Cargo.toml
@@ -42,7 +42,7 @@ prometheus = { version = "0.13.3", features = ["default", "push"] }
 rand = "0.8.5"
 futures = "0.3.28"
 rustls = "0.21.7"
-reqwest = { version = "0.11.20", features = ["rustls", "json"] }
+reqwest = { version = "0.11.20", default-features = false, features = ["rustls", "json"] }
 minidom = "0.15.2"
 regex = "1.9.5"
 

--- a/server/calendar/Cargo.toml
+++ b/server/calendar/Cargo.toml
@@ -24,7 +24,7 @@ env_logger.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
-actix-web-prometheus.workspace = true
+actix-web-prom.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/calendar/src/main.rs
+++ b/server/calendar/src/main.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use actix_cors::Cors;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
-use actix_web_prometheus::PrometheusMetricsBuilder;
+use actix_web_prom::PrometheusMetricsBuilder;
 use std::collections::HashMap;
 
 const MAX_JSON_PAYLOAD: usize = 1024 * 1024; // 1 MB

--- a/server/feedback/Cargo.toml
+++ b/server/feedback/Cargo.toml
@@ -20,7 +20,7 @@ env_logger.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
-actix-web-prometheus.workspace = true
+actix-web-prom.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/feedback/src/main.rs
+++ b/server/feedback/src/main.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::tokens::RecordedTokens;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
-use actix_web_prometheus::PrometheusMetricsBuilder;
+use actix_web_prom::PrometheusMetricsBuilder;
 mod github;
 mod post_feedback;
 mod proposed_edits;

--- a/server/main-api/Cargo.toml
+++ b/server/main-api/Cargo.toml
@@ -21,7 +21,7 @@ env_logger.workspace = true
 tokio.workspace = true
 actix-web.workspace = true
 actix-cors.workspace = true
-actix-web-prometheus.workspace = true
+actix-web-prom.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/server/main-api/Cargo.toml
+++ b/server/main-api/Cargo.toml
@@ -39,7 +39,7 @@ logos="0.13.0"
 
 # maps
 rustls = "0.21.7"
-reqwest = { version= "0.11.20", features = ["rustls"] }
+reqwest = { version= "0.11.20", default-features = false, features = ["rustls"] }
 image = "0.24.7"
 imageproc = "0.23.0"
 rusttype = "0.9.3"

--- a/server/main-api/src/main.rs
+++ b/server/main-api/src/main.rs
@@ -1,6 +1,6 @@
 use actix_cors::Cors;
 use actix_web::{get, middleware, web, App, HttpResponse, HttpServer};
-use actix_web_prometheus::PrometheusMetricsBuilder;
+use actix_web_prom::PrometheusMetricsBuilder;
 use std::collections::HashMap;
 mod entries;
 mod maps;


### PR DESCRIPTION
## Proposed Changes (include Screenshots if possible)

- Replaced `openssl` with `rustls` where nessesary to drop this additional libary

## How to test this PR

1. run the ci
2. run the docker image to see if it works
3. merge + moniotr

## How has this been tested?

- see above

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
