### PR TITLE
fix(): fixed typo in openapi spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -40,7 +40,7 @@ paths:
 
         Some fields support highlighting the query terms and it uses \x19 and \x17 to mark the beginning/end of a highlighted sequence.  
         (See [Wikipedia](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Modified_C0_control_code_sets)).  
-        Some text-renderers will ignore them, but in case you do not want to use them, you might want to remove them from the responses via empty `pre_highlight` and `pre_highlight` query parameters.
+        Some text-renderers will ignore them, but in case you do not want to use them, you might want to remove them from the responses via empty `pre_highlight` and `post_highlight` query parameters.
       parameters:
         - name: q
           in: query


### PR DESCRIPTION
Fixes typo that I just discovered randomly

## Proposed Changes (include Screenshots if possible)
- use correct word

## How to test this PR

- /

## How has this been tested?
- /

## Checklist

- [X] I have updated the documentation / No need to update the documentation
- [X] I have run the linter
