### PR TITLE
improved the transaction handling on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       test: wget -q --spider http://localhost:3003/api/status
       retries: 5
       interval: 10s
-      start_period: 30s
+      start_period: 60s
   meilisearch:
     image: getmeili/meilisearch:v1.4.2
     restart: always

--- a/server/main-api/src/setup/database/mod.rs
+++ b/server/main-api/src/setup/database/mod.rs
@@ -2,19 +2,29 @@ mod alias;
 mod data;
 
 use log::info;
-use sqlx::PgPool;
 
-pub(crate) async fn setup_database(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) async fn setup_database(pool: &sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     sqlx::migrate!("./migrations").run(pool).await?;
+    info!("migrations complete");
 
-    info!("database setup complete, deleting old data");
-    sqlx::query!("DELETE FROM aliases").execute(pool).await?;
-    sqlx::query!("DELETE FROM en").execute(pool).await?;
-    sqlx::query!("DELETE FROM de").execute(pool).await?;
+    let mut tx = pool.begin().await?;
+    load_data(&mut tx).await?;
+    tx.commit().await?;
+    Ok(())
+}
+async fn load_data(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("deleting old data");
+    sqlx::query!("DELETE FROM aliases")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query!("DELETE FROM en").execute(&mut **tx).await?;
+    sqlx::query!("DELETE FROM de").execute(&mut **tx).await?;
 
     info!("loading new data");
-    data::load_all_to_db(pool).await?;
+    data::load_all_to_db(tx).await?;
     info!("loading new aliases");
-    alias::load_all_to_db(pool).await?;
+    alias::load_all_to_db(tx).await?;
     Ok(())
 }


### PR DESCRIPTION
## Proposed Changes (include Screenshots if possible)

- previously, the transactions on startup had the feature to leave the db in a state without data for a few seconds on redeploy

## How to test this PR

1. docker compose up --build
1. docker compose down
1. docker compose up

## How has this been tested?

- see above

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [ ] I have run the linter
