### PR TITLE
test if cypress stops e2e pipeline tests

### DIFF
--- a/webclient/package.json
+++ b/webclient/package.json
@@ -39,7 +39,7 @@
     "@vue/eslint-config-typescript": "12.0.0",
     "@vue/tsconfig": "0.4.0",
     "autoprefixer": "^10.4.16",
-    "cypress": "13.5.1",
+    "cypress": "13.6.1",
     "eslint": "8.56.0",
     "eslint-plugin-vue": "9.19.2",
     "isomorphic-fetch": "3.0.0",

--- a/webclient/pnpm-lock.yaml
+++ b/webclient/pnpm-lock.yaml
@@ -62,8 +62,8 @@ devDependencies:
     specifier: ^10.4.16
     version: 10.4.16(postcss@8.4.31)
   cypress:
-    specifier: 13.5.1
-    version: 13.5.1
+    specifier: 13.6.1
+    version: 13.6.1
   eslint:
     specifier: 8.56.0
     version: 8.56.0
@@ -1669,8 +1669,8 @@ packages:
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
-  /cypress@13.5.1:
-    resolution: {integrity: sha512-yqLViT0D/lPI8Kkm7ciF/x/DCK/H/DnogdGyiTnQgX4OVR2aM30PtK+kvklTOD1u3TuItiD9wUQAF8EYWtyZug==}
+  /cypress@13.6.1:
+    resolution: {integrity: sha512-k1Wl5PQcA/4UoTffYKKaxA0FJKwg8yenYNYRzLt11CUR0Kln+h7Udne6mdU1cUIdXBDTVZWtmiUjzqGs7/pEpw==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
one of the dependencies of https://github.com/TUM-Dev/NavigaTUM/pull/894 stops the e2e tests