### PR TITLE
Made sure that Meilisearch initalisation does not have gaps

### DIFF
--- a/server/main-api/src/calendar/mod.rs
+++ b/server/main-api/src/calendar/mod.rs
@@ -133,6 +133,8 @@ async fn get_from_db(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use actix_web::http::header::ContentType;
     use actix_web::test;
     use actix_web::App;
@@ -279,6 +281,7 @@ mod tests {
             App::new()
                 .app_data(web::Data::new(AppData {
                     pool: pg.pool.clone(),
+                    meilisearch_initialised: Arc::new(Default::default()),
                 }))
                 .service(calendar_handler),
         )

--- a/server/main-api/src/calendar/mod.rs
+++ b/server/main-api/src/calendar/mod.rs
@@ -50,14 +50,14 @@ pub async fn calendar_handler(
         Ok(ids) => ids,
         Err(e) => return e,
     };
-    let locations = match get_locations(&data.db, &ids).await {
+    let locations = match get_locations(&data.pool, &ids).await {
         Ok(l) => l.0,
         Err(e) => return e,
     };
     if let Err(e) = validate_locations(&ids, &locations) {
         return e;
     }
-    match get_from_db(&data.db, &locations, &args.start_after, &args.end_before).await {
+    match get_from_db(&data.pool, &locations, &args.start_after, &args.end_before).await {
         Ok(events) => HttpResponse::Ok().json(events),
         Err(e) => {
             error!("could not get entries from the db for {ids:?} because {e:?}");
@@ -278,7 +278,7 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(AppData {
-                    db: pg.pool.clone(),
+                    pool: pg.pool.clone(),
                 }))
                 .service(calendar_handler),
         )

--- a/server/main-api/src/details.rs
+++ b/server/main-api/src/details.rs
@@ -15,16 +15,16 @@ pub async fn get_handler(
     let id = params
         .into_inner()
         .replace(|c: char| c.is_whitespace() || c.is_control(), "");
-    let Some((probable_id, redirect_url)) = get_alias_and_redirect(&data.db, &id).await else {
+    let Some((probable_id, redirect_url)) = get_alias_and_redirect(&data.pool, &id).await else {
         return HttpResponse::NotFound().body("Not found");
     };
     let result = if args.should_use_english() {
         sqlx::query_scalar!("SELECT data FROM en WHERE key = $1", probable_id)
-            .fetch_optional(&data.db)
+            .fetch_optional(&data.pool)
             .await
     } else {
         sqlx::query_scalar!("SELECT data FROM de WHERE key = $1", probable_id)
-            .fetch_optional(&data.db)
+            .fetch_optional(&data.pool)
             .await
     };
     match result {

--- a/server/main-api/src/maps/mod.rs
+++ b/server/main-api/src/maps/mod.rs
@@ -201,12 +201,12 @@ pub async fn maps_handler(
     let id = params
         .into_inner()
         .replace(|c: char| c.is_whitespace() || c.is_control(), "");
-    if let Some(redirect_url) = get_possible_redirect_url(&data.db, &id, &args).await {
+    if let Some(redirect_url) = get_possible_redirect_url(&data.pool, &id, &args).await {
         let mut res = HttpResponse::PermanentRedirect();
         res.insert_header((LOCATION, redirect_url));
         return res.finish();
     }
-    let data = match get_localised_data(&data.db, &id, args.lang.should_use_english()).await {
+    let data = match get_localised_data(&data.pool, &id, args.lang.should_use_english()).await {
         Ok(data) => data,
         Err(e) => {
             return e;

--- a/server/main-api/src/search/mod.rs
+++ b/server/main-api/src/search/mod.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+use crate::AppData;
 use actix_web::{get, web, HttpResponse};
 use cached::proc_macro::cached;
 use serde::{Deserialize, Serialize};
@@ -78,8 +79,12 @@ impl From<&SearchQueryArgs> for Highlighting {
     }
 }
 #[get("/api/search")]
-pub async fn search_handler(web::Query(args): web::Query<SearchQueryArgs>) -> HttpResponse {
+pub async fn search_handler(
+    data: web::Data<AppData>,
+    web::Query(args): web::Query<SearchQueryArgs>,
+) -> HttpResponse {
     let start_time = Instant::now();
+    let _ = data.meilisearch_initialised.read().await; // otherwise we could return empty results during initialisation
 
     let limits = Limits::from(&args);
     let highlighting = Highlighting::from(&args);


### PR DESCRIPTION
Current meilisearch initialisation logic has a gap (~2-5s) where we might serve out EMPTY search results.
The client treats these as valid => won't retry them and might cache them

Related to @AntonMC-Github's discoveries (thanks for the report) in #1274 

## Proposed Changes (include Screenshots if possible)

- Made sure that a `tokyo::RWLock` prevents the database to be in an invalid stat during searches
- renamed `db` -> `pool` to relflect the usage 

## How to test this PR

1. See if it initalises
2. Unittests

## How has this been tested?

- See if it initalises
- Unittests

## Checklist

- [x] I have updated the documentation / No need to update the documentation
- [x] I have run the linter
