### PR TITLE
made sure that `aws_lc_rs` crypto provider is correctly installed

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -36,7 +36,7 @@ serde_yaml = "0.9.34"
 tokio = { version = "1.39", default-features = false, features = ["rt-multi-thread", "time", "sync", "process"] }
 actix-web = { version = "4.9.0", default-features = false, features = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies", "http2", "macros"] }
 actix-cors = "0.7.0"
-rustls = { version = "0.23.12", default-features = false, features = ["ring"] } # the aws' fips complient libary has weird bingen issues which require deeper looking into
+rustls = "0.23.14"
 
 cached = { version = "0.53.1", features = ["default", "async", "disk_store"] }
 futures = "0.3.30"
@@ -109,8 +109,3 @@ opt-level = 3
 [profile.dev.package]
 insta.opt-level = 3
 similar.opt-level = 3
-
-[package.metadata.cargo-machete]
-ignored = [
-    "rustls", # we need to configure between ring and aws crypto library
-]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,8 +8,9 @@ FROM    rust:1.81-alpine AS compiler
 # Descriptions:
 # - musl-dev is needed for musl to compile the binary
 # - mold is used to link faster
-# - I somehow could not get openssl to cooperate => we are contibuing with libpq-dev
-RUN     apk --update add --quiet --update-cache --no-cache musl-dev libpq-dev mold
+# - I somehow could not get openssl to cooperate => we are continuing with libpq-dev
+# - clang is needed for rustls to use the aws' fips complient library
+RUN     apk --update add --quiet --update-cache --no-cache musl-dev libpq-dev mold clang
 
 WORKDIR /compiler
 ENV     USER=root

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -117,7 +117,7 @@ pub fn setup_logging() {
 
 fn main() -> anyhow::Result<()> {
     setup_logging();
-    rustls::crypto::aws_lc_rs::default_provider().install_default();
+    rustls::crypto::aws_lc_rs::default_provider().install_default().expect("no provider was set as default beforehand");
     let release = match option_env!("GIT_COMMIT_SHA") {
         Some(s) => Some(Cow::Borrowed(s)),
         None => sentry::release_name!(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -117,6 +117,7 @@ pub fn setup_logging() {
 
 fn main() -> anyhow::Result<()> {
     setup_logging();
+    rustls::crypto::aws_lc_rs::default_provider().install_default();
     let release = match option_env!("GIT_COMMIT_SHA") {
         Some(s) => Some(Cow::Borrowed(s)),
         None => sentry::release_name!(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -117,7 +117,9 @@ pub fn setup_logging() {
 
 fn main() -> anyhow::Result<()> {
     setup_logging();
-    rustls::crypto::aws_lc_rs::default_provider().install_default().expect("no provider was set as default beforehand");
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("no provider was set as default beforehand");
     let release = match option_env!("GIT_COMMIT_SHA") {
         Some(s) => Some(Cow::Borrowed(s)),
         None => sentry::release_name!(),


### PR DESCRIPTION
Thanks to a headsup via mail, we were notified that we should change this.
Rationale is that without `rustls::crypto::aws_lc_rs::default_provider().install_default()` the feedback api does not work.

This also migrates `ring` -> `aws_lc_rs` because of its fips-compliance.
This might be nessesary for the ISO 127001 audits.. (who knows really what we need..)