### PR TITLE
fix:  add traefik's network for valhalla

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,8 @@ services:
       - "traefik.http.services.navigatum-valhalla.loadbalancer.server.port=8002"
     environment:
       TZ: Europe/Berlin
+    networks:
+      - traefik_traefik
     expose:
       - 8002
     depends_on:


### PR DESCRIPTION
If this is not added, routing to valhalla does not work correctly
