### PR TITLE
added normalised roomcodes to search for

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -41,6 +41,18 @@ def unlocalise(value: str | list[Any] | dict[str, Any]) -> Any:
     raise ValueError(f"Unhandled type {type(value)}")
 
 
+def normalise_id(_id: str) -> str:
+    parts=_id.split(".")
+    for i in range(0, len(parts)):
+        parts[i]=parts[i] .lstrip('0')
+        if not parts[i]:
+            parts[i]="0"
+    result: str = "";
+    for part in parts:
+        result+=part;
+    return ".".join(parts)
+
+
 def export_for_search(data: dict) -> None:
     """Export a subset of the data for the /search api"""
     export = []
@@ -75,9 +87,12 @@ def export_for_search(data: dict) -> None:
                 # MeiliSearch requires an id without "."
                 # also this puts more emphasis on the order (because "." counts as more distance)
                 "ms_id": _id.replace(".", "-"),
+                "room_code": _id,
+                "room_code_normalised": normalise_id(_id),
                 "id": _id,  # not searchable
                 "name": entry["name"],
                 "arch_name": entry.get("arch_name"),
+                "arch_name_normalised": normalise_id(entry.get("arch_name")),
                 "type": entry["type"],
                 "type_common_name": entry["type_common_name"],
                 "facet": {

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -43,14 +43,7 @@ def unlocalise(value: str | list[Any] | dict[str, Any]) -> Any:
 
 def normalise_id(_id: str) -> str:
     """Remove leading zeros from all point-separated parts of input string"""
-    parts = _id.split(".")
-    for i in range(0, len(parts)):
-        parts[i] = parts[i].lstrip("0")
-        if not parts[i]:
-            parts[i] = "0"
-    result: str = ""
-    for part in parts:
-        result += part
+    parts = [part.lstrip("0") or "0" for part in _id.split(".")]
     return ".".join(parts)
 
 

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -40,8 +40,8 @@ def unlocalise(value: str | list[Any] | dict[str, Any]) -> Any:
         return {k: unlocalise(v) for k, v in value.items()}
     raise ValueError(f"Unhandled type {type(value)}")
 
-
 def normalise_id(_id: str) -> str:
+    """removes leading zeros from all point-separated parts of input string"""
     parts=_id.split(".")
     for i in range(0, len(parts)):
         parts[i]=parts[i] .lstrip('0')

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -40,16 +40,17 @@ def unlocalise(value: str | list[Any] | dict[str, Any]) -> Any:
         return {k: unlocalise(v) for k, v in value.items()}
     raise ValueError(f"Unhandled type {type(value)}")
 
+
 def normalise_id(_id: str) -> str:
-    """removes leading zeros from all point-separated parts of input string"""
-    parts=_id.split(".")
+    """Remove leading zeros from all point-separated parts of input string"""
+    parts = _id.split(".")
     for i in range(0, len(parts)):
-        parts[i]=parts[i] .lstrip('0')
+        parts[i] = parts[i].lstrip("0")
         if not parts[i]:
-            parts[i]="0"
-    result: str = "";
+            parts[i] = "0"
+    result: str = ""
     for part in parts:
-        result+=part;
+        result += part
     return ".".join(parts)
 
 

--- a/server/src/search_executor/lexer.rs
+++ b/server/src/search_executor/lexer.rs
@@ -18,7 +18,7 @@ fn irregular_split(lex: &mut Lexer<Token>) -> (String, String) {
 }
 
 /// Removes the specified prefix and additional whitespace from the token
-/// e.g used to remove the "in:" and "@" prefixes from filters
+/// e.g. used to remove the "in:" and "@" prefixes from filters
 fn remove_prefix(lex: &mut Lexer<Token>, prefix: &'static str) -> String {
     lex.slice()[prefix.len()..].trim().to_string()
 }

--- a/server/src/setup/meilisearch.rs
+++ b/server/src/setup/meilisearch.rs
@@ -79,9 +79,11 @@ pub async fn setup(client: &Client) -> anyhow::Result<()> {
         ])
         .with_sortable_attributes(["_geo"])
         .with_searchable_attributes([
-            "ms_id",
+            "room_code",
+            "room_code_normalised",
             "name",
             "arch_name",
+            "arch_name_normalised",
             "type",
             "type_common_name",
             "parent_building_names",


### PR DESCRIPTION
Fixes #1733 

## Proposed Change(s)

- added room_code, room_code_normalised and arch_name_normalised to the exported room data
- added these attributes to the searchable attributes in meilisearch.rs, removed ms_id (now replaced with room_code containing '.' as separator instead of '-')
- added normalise_id to export.py to calculate the normalised room_code_normalised and arch_name_normalised
- fixed a tiny typo in the lexer

## Checklist

- Documentation
    - [x] I have updated the documentation
    - [ ] No need to update the documentation
