### PR TITLE
chore: add tempoary override for currrent FSEI offices

### DIFF
--- a/data/sources/02_rooms-extended.yaml
+++ b/data/sources/02_rooms-extended.yaml
@@ -16,6 +16,38 @@
       en: Office
     din_277: NF2.1
     din_277_desc: Büroräume
+"0104.U1.403":
+    name: Fachschaft EI (aktuell im N0128)
+    usage:
+      name:
+        de: Fachschaft EI
+        en: Student Council EI
+      din_277: NF2.1
+      din_277_desc: Büroräume
+    props:
+      links:
+        - text:
+            de: Homepage
+            en: Homepage
+          url: https://www.fs.ei.tum.de/
+      comment:
+        de: Aktuell im N0128 wegen Sanierungsarbeiten
+        en: Currently in N0128 due to construction work
+"0101.EG.128":
+    name: Fachschaft EI
+    short_name: FSEI
+    usage:
+      name:
+        de: Fachschaft EI
+        en: Student Council EI
+      din_277: NF2.1
+      din_277_desc: Büroräume
+    props:
+      links:
+        - text:
+            de: Homepage
+            en: Homepage
+          url: https://www.fs.ei.tum.de/
 # StudiTUM Innenstadt switched to only-unisex toilets
 # previous WC-Damen:
 "0201.EG.004":


### PR DESCRIPTION
## Proposed Change(s)

- Added metadata for the FSEI offices in NavigaTUM (Link to Homepage)
- Added override for room N0128 as the currently used student council office 
- Added information about the current unavailability of N-1403 as a student council office

## Checklist

- Documentation
    - [ ] I have updated the documentation
    - [x] No need to update the documentation
