### PR TITLE
Calendar darker on hover

### DIFF
--- a/webclient/README.md
+++ b/webclient/README.md
@@ -78,15 +78,15 @@ Our CSS framework is [Tailwind](https://tailwindcss.com/).
 
 ```plain
 webclient
-├── public/        # 🠔 Static assets such as icons, which cannot get inlined
-├── api_types/     # 🠔 code generated via openapi.yaml for typechecking reasons
+├── public/        # 🠔 Static assets such as icons, which cannot get inlined.
+├── api_types/     # 🠔 Code generated via openapi.yaml for typechecking reasons.
 ├── content/       # 🠔 Static pages written in markdown. Served at `/about/<filename>`.
-├── assets/        # 🠔 Static assets such as icons
-│   └── logos      # 🠔 The Logos used by the app
+├── assets/        # 🠔 Static assets such as icons.
+│   └── logos      # 🠔 The Logos used by the app.
 ├── components/    # 🠔 Vue components, which are used in views.
 ├── pages/         # 🠔 The pages are parts of App.vue, which are loaded based their file names.
-├── nuxt.config.ts # 🠔 core configuration of nuxt
-└── package.json   # 🠔 Node package definition and dependencies
+├── nuxt.config.ts # 🠔 Core configuration of nuxt.
+└── package.json   # 🠔 Node package definition and dependencies.
 ```
 
 ## Testing

--- a/webclient/app/pages/[view]/[id].vue
+++ b/webclient/app/pages/[view]/[id].vue
@@ -170,7 +170,7 @@ useSeoMeta({
               :title="t('header.calendar')"
               @click="calendar = [...new Set([...calendar, route.params.id?.toString() ?? '404'])]"
             >
-              <CalendarDaysIcon class="text-blue-600 mt-0.5 h-4 w-4" />
+              <CalendarDaysIcon class="text-blue-600 mt-0.5 h-4 w-4 hover:text-blue-900" />
             </button>
             <ShareButton :coords="data.coords" :name="data.name" />
             <DetailsFeedbackButton />


### PR DESCRIPTION
Fixes # Not a specific issue
Now the "Calendar" Icon gets darker (and lighter accordingly while using the dark theme) when the user hovers over it, just like the "Share" and the "Report" Icons. It is not really significant but once I noticed it, it was always quite irritating.
In the README.md I just corrected some small lower/upper case inconsistencies and added some full stops wherever they should be at.
## Proposed Change(s)

- It is a very small fix, I do not think there is something else that should be changed for this.

## Checklist

- Documentation
    - [ ] I have updated the documentation
    - [x] No need to update the documentation

Before

![image](https://github.com/user-attachments/assets/3e1a2cbe-2a00-44d1-a541-8aba3ff2cfb7)

After

![image](https://github.com/user-attachments/assets/fdd5e71a-da8a-4b53-8224-06225eb79b8f)

