### PR TITLE
Maintain language preference from building -> room

### DIFF
--- a/webclient/app/components/DetailsRoomOverviewSection.vue
+++ b/webclient/app/components/DetailsRoomOverviewSection.vue
@@ -17,6 +17,9 @@ const props = defineProps<{
   readonly rooms?: RoomsOverviewResponse | null;
 }>();
 
+// Keep language preference when going from building page to room page
+const localePath = useLocalePath();
+
 const { t } = useI18n({ useScope: "local" });
 const selectedUsage = ref(-1);
 const search = ref("");
@@ -171,7 +174,7 @@ const { list, containerProps, wrapperProps } = useVirtualList<RoomsOverviewUsage
             <NuxtLinkLocale
               v-for="(room, index) in list"
               :key="index"
-              :to="`/view/${room.data.id}`"
+              :to="localePath(`/view/${room.data.id}`)"
               class="flex h-[36px] max-h-[36px] min-h-[36px] flex-row gap-2 p-1.5 px-3 hover:text-white hover:bg-blue-500"
               external
             >

--- a/webclient/app/components/DetailsRoomOverviewSection.vue
+++ b/webclient/app/components/DetailsRoomOverviewSection.vue
@@ -17,9 +17,6 @@ const props = defineProps<{
   readonly rooms?: RoomsOverviewResponse | null;
 }>();
 
-// Keep language preference when going from building page to room page
-const localePath = useLocalePath();
-
 const { t } = useI18n({ useScope: "local" });
 const selectedUsage = ref(-1);
 const search = ref("");
@@ -174,9 +171,8 @@ const { list, containerProps, wrapperProps } = useVirtualList<RoomsOverviewUsage
             <NuxtLinkLocale
               v-for="(room, index) in list"
               :key="index"
-              :to="localePath(`/view/${room.data.id}`)"
+              :to="`/view/${room.data.id}`"
               class="flex h-[36px] max-h-[36px] min-h-[36px] flex-row gap-2 p-1.5 px-3 hover:text-white hover:bg-blue-500"
-              external
             >
               <MapPinIcon class="my-auto h-4 w-4" aria-hidden="true" />
               {{ room.data.name }}


### PR DESCRIPTION
## The Issue
If the default language (German) is switched, when navigating through the app (specifically during visiting a room page from its corresponding building page), the language automatically switches back to the default and it has to be manually switched again. (Ex. Image 1)

This proposed change fixes this issue so that the language preference is kept and doesn't need to be configured constantly.
(Ex. Image 2)


## Before
https://github.com/user-attachments/assets/61c58581-e7f6-4f0b-ba13-24007676fe89

## After
https://github.com/user-attachments/assets/e19fdbe4-a59d-48a0-befd-c5071a483dc7

## Checklist





- Documentation
    - [ ] I have updated the documentation
    - [x] No need to update the documentation
