### PR TITLE
fix(server): preserve underscores in search filter slugify

### DIFF
--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -730,18 +730,14 @@ mod tests {
     fn filter_preserves_underscores_in_type_values() {
         // Regression: previously `_` was rewritten to `-`, so `virtual_room` became
         // `virtual-room` and never matched any document in the index.
-        let filter = build_meilisearch_filter(
-            &[],
-            &[],
-            &["room".to_string(), "virtual_room".to_string()],
-        );
+        let filter =
+            build_meilisearch_filter(&[], &[], &["room".to_string(), "virtual_room".to_string()]);
         assert_eq!(filter, r#"(type IN ["room", "virtual_room"])"#);
     }
 
     #[test]
     fn filter_preserves_underscores_in_parent_values() {
-        let filter =
-            build_meilisearch_filter(&[], &[], &["joined_building".to_string()]);
+        let filter = build_meilisearch_filter(&[], &[], &["joined_building".to_string()]);
         assert!(filter.contains("joined_building"));
         assert!(!filter.contains("joined-building"));
     }

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -727,19 +727,9 @@ mod tests {
     }
 
     #[test]
-    fn filter_preserves_underscores_in_type_values() {
-        // Regression: previously `_` was rewritten to `-`, so `virtual_room` became
-        // `virtual-room` and never matched any document in the index.
-        let filter =
-            build_meilisearch_filter(&[], &[], &["room".to_string(), "virtual_room".to_string()]);
-        assert_eq!(filter, r#"(type IN ["room", "virtual_room"])"#);
-    }
-
-    #[test]
     fn filter_preserves_underscores_in_parent_values() {
         let filter = build_meilisearch_filter(&[], &[], &["joined_building".to_string()]);
         assert!(filter.contains("joined_building"));
-        assert!(!filter.contains("joined-building"));
     }
 
     #[test]

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -337,6 +337,7 @@ fn slugify(input: &str) -> String {
         .map(|c| {
             if c.is_alphanumeric()
                 || c == '-'
+                || c == '_'
                 || c == '.'
                 || c == 'ä'
                 || c == 'ö'
@@ -723,6 +724,26 @@ mod tests {
         let filter = build_meilisearch_filter(&["Garching".to_string()], &[], &[]);
         assert!(filter.contains("garching"));
         assert!(!filter.contains("Garching"));
+    }
+
+    #[test]
+    fn filter_preserves_underscores_in_type_values() {
+        // Regression: previously `_` was rewritten to `-`, so `virtual_room` became
+        // `virtual-room` and never matched any document in the index.
+        let filter = build_meilisearch_filter(
+            &[],
+            &[],
+            &["room".to_string(), "virtual_room".to_string()],
+        );
+        assert_eq!(filter, r#"(type IN ["room", "virtual_room"])"#);
+    }
+
+    #[test]
+    fn filter_preserves_underscores_in_parent_values() {
+        let filter =
+            build_meilisearch_filter(&[], &[], &["joined_building".to_string()]);
+        assert!(filter.contains("joined_building"));
+        assert!(!filter.contains("joined-building"));
     }
 
     #[test]


### PR DESCRIPTION
leads to not letting the search UI work correctly