### PR TITLE
ci: keep workflow runs on main from being cancelled

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,7 +1,7 @@
 name: Create and publish a Docker image
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   workflow_call:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,7 +2,7 @@ name: autofix.ci
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-openapi
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:

--- a/.github/workflows/data-cicd.yml
+++ b/.github/workflows/data-cicd.yml
@@ -2,7 +2,7 @@ name: Data CI/CD
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-data
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-server
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:

--- a/.github/workflows/martin-cicd.yml
+++ b/.github/workflows/martin-cicd.yml
@@ -2,7 +2,7 @@ name: Martin CI/CD
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-data
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,7 +2,7 @@ name: Security audit
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-server
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   schedule:

--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -2,7 +2,7 @@ name: Server CI/CD
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-server
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -2,7 +2,7 @@ name: Update data from upstream
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-dataupdate
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   schedule:

--- a/.github/workflows/webclient-cicd.yml
+++ b/.github/workflows/webclient-cicd.yml
@@ -2,7 +2,7 @@ name: Webclient CI/CD
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-webclient
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Make `cancel-in-progress` conditional on the ref (`github.ref != 'refs/heads/main'`) across all 9 workflows.
- Pushes to `main` now always run to completion instead of being cancelled by a follow-up push.
- PR branches keep their existing cancel-on-new-push behavior to save CI minutes.

## Test plan
- [ ] After merge: push two commits to `main` in quick succession and confirm the first run keeps going instead of being cancelled.
- [ ] Push to a PR branch and confirm the prior run is still cancelled as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)