### PR TITLE
feat(webclient): SEO descriptions, skip link, error-page i18n

### DIFF
--- a/webclient/app/error.vue
+++ b/webclient/app/error.vue
@@ -13,9 +13,15 @@ const { t } = useI18n({ useScope: "local" });
 
 const currentPath = computed(() => props.error?.url || route.fullPath);
 
+const pageTitle = computed(() =>
+  is404.value
+    ? `${t("title_404")} - NavigaTUM`
+    : `${props.error?.statusCode || t("title_generic")} - NavigaTUM`
+);
+
 useSeoMeta({
   robots: "noindex, nofollow",
-  title: is404.value ? "404 - Page Not Found" : `${props.error?.statusCode || "Error"} - NavigaTUM`,
+  title: pageTitle,
 });
 </script>
 
@@ -54,12 +60,14 @@ useSeoMeta({
     </div>
     <div v-else class="mx-auto max-w-xl pt-4">
       <div class="flex flex-col items-center gap-4 p-5">
-        <h5 class="text-zinc-800 text-xl font-bold">{{ error?.statusCode || "Error" }}</h5>
-        <p class="text-md text-zinc-600">{{ error?.statusMessage || "An error occurred" }}</p>
+        <h5 class="text-zinc-800 text-xl font-bold">{{ error?.statusCode || t("title_generic") }}</h5>
+        <p class="text-md text-zinc-600">{{ error?.statusMessage || t("generic_error") }}</p>
         <p v-if="error?.message" class="text-sm text-zinc-500 mt-2">
           {{ error.message }}
         </p>
-        <Btn @click="clearError({ redirect: '/' })" variant="primary" class="mt-4"> Go home </Btn>
+        <Btn @click="clearError({ redirect: '/' })" variant="primary" class="mt-4">
+          {{ t("go_home") }}
+        </Btn>
       </div>
     </div>
   </NuxtLayout>
@@ -73,6 +81,9 @@ de:
   img_alt: Illustration einer männlichen Person, die auf großen '404'-Buchstaben sitzt und einer weiblichen person vor dem TUM Hauptgebäude
   go_home: Zur Startseite
   call_to_action: Feedback geben
+  generic_error: Ein Fehler ist aufgetreten.
+  title_404: 404 - Seite nicht gefunden
+  title_generic: Fehler
 en:
   description: This could be because we made a mistake.
   got_here: "I have found the error by:\r\n1. ..."
@@ -80,4 +91,7 @@ en:
   img_alt: illustration of a female and male person sitting on large '404'-letters in front of the tum main building
   go_home: Go home
   call_to_action: Give Feedback
+  generic_error: An error occurred.
+  title_404: 404 - Page Not Found
+  title_generic: Error
 </i18n>

--- a/webclient/app/layouts/default.vue
+++ b/webclient/app/layouts/default.vue
@@ -63,9 +63,17 @@ useHead({
   link: [...(i18nHead.value.link || [])],
   meta: [...(i18nHead.value.meta || [])],
 });
+
+const { t } = useI18n({ useScope: "local" });
 </script>
 
 <template>
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-30 focus:rounded focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:shadow-md focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+  >
+    {{ t("skip_to_content") }}
+  </a>
   <AppNavHeader>
     <AppSearchBar v-model:search-bar-focused="searchBarFocused" />
   </AppNavHeader>
@@ -75,7 +83,7 @@ useHead({
     class="mx-auto mt-16 min-h-[calc(100vh-360px)] max-w-4xl pb-10 transition-opacity"
     :class="{ 'opacity-70': searchBarFocused }"
   >
-    <main class="mx-5">
+    <main id="main-content" class="mx-5" tabindex="-1">
       <slot />
     </main>
   </div>
@@ -85,3 +93,10 @@ useHead({
     <LazyFeedbackModal v-if="feedback.open" />
   </ClientOnly>
 </template>
+
+<i18n lang="yaml">
+de:
+  skip_to_content: Zum Hauptinhalt springen
+en:
+  skip_to_content: Skip to main content
+</i18n>

--- a/webclient/app/layouts/fullscreen.vue
+++ b/webclient/app/layouts/fullscreen.vue
@@ -9,14 +9,29 @@ useHead({
   link: [...(i18nHead.value.link || [])],
   meta: [...(i18nHead.value.meta || [])],
 });
+
+const { t } = useI18n({ useScope: "local" });
 </script>
 
 <template>
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-30 focus:rounded focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:shadow-md focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+  >
+    {{ t("skip_to_content") }}
+  </a>
   <AppNavHeader>
     <AppSearchBar v-model:search-bar-focused="searchBarFocused" />
   </AppNavHeader>
   <!-- Page content container -->
-  <main :class="{ 'opacity-70': searchBarFocused }">
+  <main id="main-content" tabindex="-1" :class="{ 'opacity-70': searchBarFocused }">
     <slot />
   </main>
 </template>
+
+<i18n lang="yaml">
+de:
+  skip_to_content: Zum Hauptinhalt springen
+en:
+  skip_to_content: Skip to main content
+</i18n>

--- a/webclient/app/layouts/navigation.vue
+++ b/webclient/app/layouts/navigation.vue
@@ -11,13 +11,21 @@ useHead({
   link: [...(i18nHead.value.link || [])],
   meta: [...(i18nHead.value.meta || [])],
 });
+
+const { t } = useI18n({ useScope: "local" });
 </script>
 
 <template>
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-30 focus:rounded focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:shadow-md focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+  >
+    {{ t("skip_to_content") }}
+  </a>
   <AppNavHeader />
 
   <!-- Page content container -->
-  <main class="mx-auto mt-[60px] min-h-[calc(100vh-150px)] transition-opacity">
+  <main id="main-content" tabindex="-1" class="mx-auto mt-[60px] min-h-[calc(100vh-150px)] transition-opacity">
     <slot />
   </main>
 
@@ -26,3 +34,10 @@ useHead({
     <LazyFeedbackModal v-if="feedback.open" />
   </ClientOnly>
 </template>
+
+<i18n lang="yaml">
+de:
+  skip_to_content: Zum Hauptinhalt springen
+en:
+  skip_to_content: Skip to main content
+</i18n>

--- a/webclient/app/pages/about/[name].vue
+++ b/webclient/app/pages/about/[name].vue
@@ -12,14 +12,19 @@ const { data: page } = await useAsyncData(route.path, () => {
   return queryCollection("content").path(route.path).first();
 });
 
-// Extract title from the markdown frontmatter
+// Extract title and description from the markdown frontmatter
 const pageTitle = computed(() => {
   return page.value?.title ? `${page.value.title} - NavigaTUM` : "NavigaTUM";
 });
+const pageDescription = computed(() => page.value?.description ?? undefined);
 
 useSeoMeta({
   title: pageTitle,
   ogTitle: pageTitle,
+  description: pageDescription,
+  ogDescription: pageDescription,
+  ogType: "website",
+  twitterCard: "summary_large_image",
 });
 </script>
 

--- a/webclient/content/about/datenschutz.md
+++ b/webclient/content/about/datenschutz.md
@@ -1,5 +1,6 @@
 ---
 title: Datenschutzerklärung
+description: Datenschutzerklärung von NavigaTUM. Welche Daten werden erhoben, wie werden sie verarbeitet und welche Rechte haben Nutzende nach der DSGVO.
 ---
 
 # Datenschutzerklärung

--- a/webclient/content/about/impressum.md
+++ b/webclient/content/about/impressum.md
@@ -1,5 +1,6 @@
 ---
 title: Impressum
+description: Impressum von NavigaTUM mit Angaben zum Herausgeber, Verantwortlichen und Kontaktdaten gemäß den gesetzlichen Anforderungen.
 ---
 
 # Impressum

--- a/webclient/content/about/ueber-uns.md
+++ b/webclient/content/about/ueber-uns.md
@@ -1,5 +1,6 @@
 ---
 title: Über NavigaTUM
+description: NavigaTUM ist ein von Studierenden für Studierende entwickeltes Open-Source-Tool, um sich an der Technischen Universität München (TUM) zurechtzufinden.
 ---
 
 # Über NavigaTUM

--- a/webclient/content/en/about/about-us.md
+++ b/webclient/content/en/about/about-us.md
@@ -1,5 +1,6 @@
 ---
 title: About NavigaTUM
+description: NavigaTUM is an open-source tool developed by students for students to help you find your way around the Technical University of Munich (TUM).
 ---
 
 # About NavigaTUM

--- a/webclient/content/en/about/imprint.md
+++ b/webclient/content/en/about/imprint.md
@@ -1,5 +1,6 @@
 ---
 title: Imprint
+description: Legal notice for NavigaTUM, including publisher information, the responsible party, and contact details required under German law.
 ---
 
 # Imprint

--- a/webclient/content/en/about/privacy.md
+++ b/webclient/content/en/about/privacy.md
@@ -1,5 +1,6 @@
 ---
 title: Privacy Policy
+description: NavigaTUM's privacy policy. What data we collect, how it is processed, and the rights of users under the EU General Data Protection Regulation (GDPR).
 ---
 
 # Privacy Policy


### PR DESCRIPTION
## Summary
- **SEO** — All six about pages (Imprint/Privacy/About-Us, de+en) now ship a per-page `description` frontmatter that flows through `useSeoMeta` as `description`/`ogDescription`, and the page now also sets `ogType` and `twitterCard: summary_large_image` so social previews actually show our 1200×630 OG image.
- **a11y** — Added a localized "Skip to main content" link to the `default`, `fullscreen` and `navigation` layouts (`sr-only` until keyboard-focused). `<main>` now has `id="main-content"` + `tabindex="-1"` so keyboard users can jump past the fixed nav header and search bar.
- **i18n** — `app/error.vue` no longer hardcodes English on the non-404 branch: page title, generic-error fallback, and the "Go home" button now use translation keys (`title_404`, `title_generic`, `generic_error`, `go_home`). German users no longer see raw English on server errors.

## Test plan
- [ ] `pnpm run type-check` passes (verified locally)
- [ ] `pnpm run lint` / Biome passes (verified locally)
- [ ] Visit `/about/impressum`, `/en/about/imprint`, etc. and confirm `<meta name="description">` and `og:description` are present in page source
- [ ] Tab from a fresh page load — first focusable element should be the skip link; activating it should jump focus to the main content
- [ ] Trigger a non-404 error in German locale and confirm the title, body text, and button are German
- [ ] No regressions on the 404 page (still localized as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)