### PR TITLE
fix(search): include POIs in search results

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -115,6 +115,7 @@ def export_for_search(data: dict[str, Any]) -> None:
                     "building": "building",
                     "room": "room",
                     "virtual_room": "room",
+                    "poi": "room",
                 }.get(entry["type"]),
                 "operator_name": _de(entry.get("props", {}).get("operator", {}).get("name", None)),
                 "parent_building_names": parent_building_names,

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -70,7 +70,9 @@ pub(super) fn merge_search_results(
                         parsed_id: None,
                     });
                 }
-                "room" | "virtual_room" if section_rooms.entries.len() < limits.rooms_count => {
+                "room" | "virtual_room" | "poi"
+                    if section_rooms.entries.len() < limits.rooms_count =>
+                {
                     section_rooms.entries.push(super::ResultEntry {
                         hit: hit.clone(),
                         id: hit.room_code.to_string(),

--- a/server/src/search_executor/test-queries.good.yaml
+++ b/server/src/search_executor/test-queries.good.yaml
@@ -108,3 +108,7 @@
     zeroes are in the room number
 - target: 5510.EG.026M
   query: 26m@5510
+# poi queries
+- target: validierungsautomat-1
+  query: Validierungsautomat
+  comment: 'Regression: #1868 — POIs were silently dropped from search results'

--- a/webclient/app/pages/embed/[id].vue
+++ b/webclient/app/pages/embed/[id].vue
@@ -35,7 +35,8 @@ const detailsUrl = computed(() => {
   // Prefer the canonical URL the API gives us (e.g. /building/mi); fall back to
   // type/id when no redirect_url is set. data.value.type can be a non-routable
   // value like "joined_building", so we never construct from it directly.
-  const path = (data.value.redirect_url as string | undefined) || `/${data.value.type}/${data.value.id}`;
+  const path =
+    (data.value.redirect_url as string | undefined) || `/${data.value.type}/${data.value.id}`;
   return `https://nav.tum.de${localePath(path)}`;
 });
 


### PR DESCRIPTION
## Summary

Fixes #1868. Searching for `Validierungsautomat` (or any POI name) returned no results because POIs were categorically excluded from the search subsystem in two places:

- `data/processors/export.py` — the `type → facet` lookup table had no `"poi"` entry, so POI documents reached Meilisearch with `facet: null`.
- `server/src/search_executor/merger.rs` — the merger only emitted hits whose `type` was in the buildings or rooms allowlists; the `_ => {}` arm silently dropped POIs.

The Meilisearch index was already indexing POI `name` and `usage` — the data was there, just unreachable.

This change groups POIs into the existing rooms section. POIs typically live inside a room (parent), and the map overlay (`server/src/overlays/map.rs:33`) already groups `room | virtual_room | poi` together. The public `/api/search` contract (sections: `sites_buildings | rooms | addresses`) is unchanged; per-hit `type: "poi"` flows through to the client untouched.

## Deploy ordering

The fix has two halves that must ship together:

1. **Data CI** rebuilds `search_data.json` so POIs land in Meilisearch with `facet: "room"`.
2. **Server redeploy** picks up the merger change.

Until both are live, POIs will keep getting dropped (old data → `facet: null`, or old server → merger drops them).

## Test plan

- [x] `cargo check -p navigatum-server`
- [ ] Run `data/compile.py` and inspect `data/output/search_data.json` for `"facet":"room"` on POI documents
- [ ] Local: `docker compose up`, then `curl 'http://localhost:3003/api/search?q=Validierungsautomat'` returns at least one `validierungsautomat-*` entry in the `rooms` section
- [ ] Check the new `validierungsautomat-1` entry in `server/src/search_executor/test-queries.good.yaml` against the (currently `#[ignore]`-d) `test_good_queries` after data is regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)