### PR TITLE
feat(webclient): show empty-state when search returns no results

### DIFF
--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { mdiMagnify } from "@mdi/js";
+import { mdiMagnify, mdiMagnifyClose } from "@mdi/js";
 import type { components } from "~/api_types";
 import SearchResultItemLink from "~/components/SearchResultItemLink.vue";
 import { useStagedSearchFilters } from "~/composables/searchFilters";
@@ -36,6 +36,10 @@ const visibleElements = computed<string[]>(() => {
   }
   return visible;
 });
+
+const hasNoResults = computed(
+  () => !!data.value && data.value.sections.every((s) => s.estimatedTotalHits === 0)
+);
 
 function searchFocus(): void {
   searchBarFocused.value = true;
@@ -214,38 +218,66 @@ const { data, error } = useFetch<SearchResponse>(url, {
         <p class="text-sm">{{ t("error.call_to_action") }}</p>
       </Toast>
       <template v-if="data">
-        <ul v-for="s in data.sections" v-cloak :key="s.facet" class="flex flex-col gap-2">
-          <div class="flex items-center">
-            <span class="text-md text-zinc-800 me-4 flex-shrink">{{ t(`sections.${s.facet}`) }}</span>
-            <div class="border-zinc-800 flex-grow border-t" />
-          </div>
+        <div
+          v-if="hasNoResults"
+          role="status"
+          class="flex flex-col items-center gap-1 px-2 py-6 text-center"
+        >
+          <MdiIcon :path="mdiMagnifyClose" :size="32" class="text-zinc-400" />
+          <p class="text-zinc-800 text-sm font-semibold">{{ t("no_results.title") }}</p>
+          <p class="text-zinc-500 text-xs">
+            {{ filters.hasActiveFilters.value ? t("no_results.hint_filtered") : t("no_results.hint") }}
+          </p>
+          <Btn
+            v-if="filters.hasActiveFilters.value"
+            variant="linkButton"
+            size="sm"
+            @mousedown="keep_focus = true"
+            @click="filters.clearAll()"
+          >
+            {{ t("no_results.clear_filters") }}
+          </Btn>
+        </div>
+        <ul
+          v-for="s in data.sections"
+          v-else
+          v-cloak
+          :key="s.facet"
+          class="flex flex-col gap-2"
+        >
+          <template v-if="s.estimatedTotalHits > 0">
+            <div class="flex items-center">
+              <span class="text-md text-zinc-800 me-4 flex-shrink">{{ t(`sections.${s.facet}`) }}</span>
+              <div class="border-zinc-800 flex-grow border-t" />
+            </div>
 
-          <template v-for="(e, i) in s.entries" :key="e.id">
-            <SearchResultItemLink
-              v-if="i < s.n_visible"
-              :highlighted="e.id === visibleElements[highlighted ?? -1]"
-              :item="e"
-              @click="searchBarFocused = false"
-              @mousedown="keep_focus = true"
-              @mouseover="highlighted = undefined"
-            />
+            <template v-for="(e, i) in s.entries" :key="e.id">
+              <SearchResultItemLink
+                v-if="i < s.n_visible"
+                :highlighted="e.id === visibleElements[highlighted ?? -1]"
+                :item="e"
+                @click="searchBarFocused = false"
+                @mousedown="keep_focus = true"
+                @mouseover="highlighted = undefined"
+              />
+            </template>
+            <li class="-mt-2">
+              <Btn
+                v-if="s.facet === 'sites_buildings' && !sites_buildings_expanded && s.n_visible < s.entries.length"
+                variant="linkButton"
+                size="sm"
+                @mousedown="keep_focus = true"
+                @click="sites_buildings_expanded = true"
+              >
+                {{ t("show_hidden", s.entries.length - s.n_visible) }}
+              </Btn>
+              <span class="text-zinc-400 text-sm">
+                {{
+                  s.estimatedTotalHits > 20 ? t("approx_results", s.estimatedTotalHits) : t("results", s.estimatedTotalHits)
+                }}
+              </span>
+            </li>
           </template>
-          <li class="-mt-2">
-            <Btn
-              v-if="s.facet === 'sites_buildings' && !sites_buildings_expanded && s.n_visible < s.entries.length"
-              variant="linkButton"
-              size="sm"
-              @mousedown="keep_focus = true"
-              @click="sites_buildings_expanded = true"
-            >
-              {{ t("show_hidden", s.entries.length - s.n_visible) }}
-            </Btn>
-            <span class="text-zinc-400 text-sm">
-              {{
-                s.estimatedTotalHits > 20 ? t("approx_results", s.estimatedTotalHits) : t("results", s.estimatedTotalHits)
-              }}
-            </span>
-          </li>
         </ul>
       </template>
     </div>
@@ -265,6 +297,11 @@ de:
     rooms: Räume
   results: 1 Ergebnis | {count} Ergebnisse
   approx_results: ca. {count} Ergebnisse
+  no_results:
+    title: Keine Ergebnisse gefunden
+    hint: Versuche es mit anderen Suchbegriffen.
+    hint_filtered: Keine Treffer mit den aktiven Filtern.
+    clear_filters: Filter entfernen
 en:
   input:
     placeholder: Search
@@ -277,4 +314,9 @@ en:
     rooms: Rooms
   results: 1 result | {count} results
   approx_results: approx. {count} results
+  no_results:
+    title: No results found
+    hint: Try different keywords.
+    hint_filtered: No matches with the active filters.
+    clear_filters: Clear filters
 </i18n>

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -302,6 +302,10 @@ de:
     hint: Versuche es mit anderen Suchbegriffen.
     hint_filtered: Keine Treffer mit den aktiven Filtern.
     clear_filters: Filter entfernen
+  error:
+    header: Bei der Suche ist ein Fehler aufgetreten
+    reason: Der Grund für diesen Fehler ist
+    call_to_action: Wenn dieses Problem weiterhin besteht, kontaktiere uns bitte über das Feedback-Formular.
 en:
   input:
     placeholder: Search
@@ -319,4 +323,8 @@ en:
     hint: Try different keywords.
     hint_filtered: No matches with the active filters.
     clear_filters: Clear filters
+  error:
+    header: Something went wrong while searching
+    reason: Reason for this error is
+    call_to_action: If this issue persists, please contact us via the feedback form.
 </i18n>

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -294,6 +294,10 @@ de:
     addresses: Adressen
   results: 1 Ergebnis | {count} Ergebnisse
   approx_results: ca. {count} Ergebnisse
+  error:
+    header: Bei der Suche ist ein Fehler aufgetreten
+    reason: Der Grund für diesen Fehler ist
+    call_to_action: Wenn dieses Problem weiterhin besteht, kontaktiere uns bitte über das Feedback-Formular.
   gps:
     use_current_location: Aktuellen Standort verwenden (GPS)
     my_location: Mein Standort
@@ -319,6 +323,10 @@ en:
     addresses: Adresses
   results: 1 result | {count} results
   approx_results: approx. {count} results
+  error:
+    header: Something went wrong while searching
+    reason: Reason for this error is
+    call_to_action: If this issue persists, please contact us via the feedback form.
   gps:
     use_current_location: Use current location (GPS)
     my_location: My location

--- a/webclient/app/components/SearchSectionList.vue
+++ b/webclient/app/components/SearchSectionList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { mdiMagnifyClose } from "@mdi/js";
 import type { components } from "~/api_types";
 import SearchResultItemLink from "~/components/SearchResultItemLink.vue";
 import { useSearchFilters } from "~/composables/searchFilters";
@@ -14,6 +15,10 @@ const { t } = useI18n({ useScope: "local" });
 const route = useRoute();
 const filters = useSearchFilters();
 
+const hasNoResults = computed(() =>
+  props.data.sections.every((s) => s.estimatedTotalHits === 0)
+);
+
 function viewMoreQuery(facet: string) {
   return {
     q: route.query.q,
@@ -25,25 +30,41 @@ function viewMoreQuery(facet: string) {
 </script>
 
 <template>
-  <div v-for="s in data.sections" :key="s.facet">
-    <section class="flex flex-col gap-2">
-      <h2 class="text-md text-zinc-500 font-semibold">{{ t(`sections.${s.facet}`) }}</h2>
-      <ul v-for="(e, i) in s.entries" :key="e.id" class="flex flex-col gap-3">
-        <SearchResultItemLink v-if="i < s.n_visible" :highlighted="false" :item="e" />
-      </ul>
-      <p v-if="s.estimatedTotalHits > 10" class="text-zinc-500 text-sm">
-        {{ t("approx_results", s.estimatedTotalHits) }}
-        <NuxtLinkLocale
-          :to="{ path: '/search', query: viewMoreQuery(s.facet) }"
-          class="focusable text-blue-500 rounded-sm visited:text-blue-500 hover:text-blue-600 hover:underline"
-          >{{ t("view_more") }}
-        </NuxtLinkLocale>
-      </p>
-      <p v-else class="text-zinc-500 text-sm">
-        {{ t("results", s.estimatedTotalHits) }}
-      </p>
-    </section>
+  <div
+    v-if="hasNoResults"
+    role="status"
+    class="bg-zinc-50 border-zinc-200 flex flex-col items-center gap-2 rounded-sm border px-4 py-10 text-center"
+  >
+    <MdiIcon :path="mdiMagnifyClose" :size="40" class="text-zinc-400" />
+    <p class="text-zinc-800 text-md font-semibold">{{ t("no_results.title") }}</p>
+    <p class="text-zinc-500 text-sm">
+      {{ filters.hasActiveFilters.value ? t("no_results.hint_filtered") : t("no_results.hint") }}
+    </p>
+    <Btn v-if="filters.hasActiveFilters.value" variant="linkButton" size="sm" @click="filters.clearAll()">
+      {{ t("no_results.clear_filters") }}
+    </Btn>
   </div>
+  <template v-else>
+    <div v-for="s in data.sections" :key="s.facet">
+      <section v-if="s.estimatedTotalHits > 0" class="flex flex-col gap-2">
+        <h2 class="text-md text-zinc-500 font-semibold">{{ t(`sections.${s.facet}`) }}</h2>
+        <ul v-for="(e, i) in s.entries" :key="e.id" class="flex flex-col gap-3">
+          <SearchResultItemLink v-if="i < s.n_visible" :highlighted="false" :item="e" />
+        </ul>
+        <p v-if="s.estimatedTotalHits > 10" class="text-zinc-500 text-sm">
+          {{ t("approx_results", s.estimatedTotalHits) }}
+          <NuxtLinkLocale
+            :to="{ path: '/search', query: viewMoreQuery(s.facet) }"
+            class="focusable text-blue-500 rounded-sm visited:text-blue-500 hover:text-blue-600 hover:underline"
+            >{{ t("view_more") }}
+          </NuxtLinkLocale>
+        </p>
+        <p v-else class="text-zinc-500 text-sm">
+          {{ t("results", s.estimatedTotalHits) }}
+        </p>
+      </section>
+    </div>
+  </template>
 </template>
 
 <i18n lang="yaml">
@@ -54,6 +75,11 @@ de:
   view_more: mehr anzeigen
   approx_results: ca. {count} Ergebnisse, bitte grenze die Suche weiter ein
   results: 1 Ergebnis | {count} Ergebnisse
+  no_results:
+    title: Keine Ergebnisse gefunden
+    hint: Versuche es mit anderen Suchbegriffen.
+    hint_filtered: Keine Treffer für diese Suche mit den aktiven Filtern. Versuche, Filter zu entfernen oder andere Suchbegriffe zu verwenden.
+    clear_filters: Alle Filter entfernen
 en:
   sections:
     sites_buildings: Buildings / Sites
@@ -61,4 +87,9 @@ en:
   view_more: view more
   approx_results: approx. {count} results, please narrow the search further
   results: 1 result | {count} results
+  no_results:
+    title: No results found
+    hint: Try different keywords.
+    hint_filtered: No matches for this query with the active filters. Try removing filters or using different keywords.
+    clear_filters: Clear all filters
 </i18n>


### PR DESCRIPTION
## Summary
- Added a clear empty-state to the search page and the navbar autocomplete dropdown when a query has no matches, replacing the previous silent "nothing renders" behavior.
- The empty-state shows a distinct message when filters are active, with a one-click "Clear filters" action.
- Hides individual sections (Buildings / Rooms) that have 0 hits so partial-match queries don't show stub "0 results" headers.

## Test plan
- [ ] Search for a string that matches nothing (e.g. `zzqxq`) on `/search` — empty-state with "Try different keywords." appears.
- [ ] Same search with a type/usage filter active — message switches to the filtered variant and the "Clear filters" button removes filters and re-runs the search.
- [ ] Search that matches only rooms (e.g. a room number) — Buildings section header is no longer rendered.
- [ ] Same checks via the navbar autocomplete dropdown.
- [ ] Both `de` and `en` locales render their respective copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)