### PR TITLE
chore(data): expand ruff lint coverage

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -5,7 +5,6 @@ from multiprocessing import Process
 from typing import Any
 
 import polars as pl
-
 import processors.areatree.process as areatree
 from processors import (
     aliases,
@@ -21,9 +20,11 @@ from processors import (
     structure,
     tumonline,
 )
-from processors.sitemap import SimplifiedSitemaps
 from processors.df_utils import ensure_columns
+from processors.sitemap import SimplifiedSitemaps
 from utils import DEV_MODE, setup_logging
+
+_logger = logging.getLogger(__name__)
 
 # All columns that may be referenced by downstream processors.
 # Ensures they exist (as null) before any processor tries to read them.
@@ -96,7 +97,7 @@ _ALL_NULLABLE_COLUMNS: dict[str, pl.DataType] = {
 
 def main() -> None:
     """Process data and generate output."""
-    logging.info("-- (Parallel) Convert, resize and crop the images for different resolutions and formats")
+    _logger.info("-- (Parallel) Convert, resize and crop the images for different resolutions and formats")
     resizer = Process(target=images.resize_and_crop)
     resizer.start()
 
@@ -127,16 +128,16 @@ def _run_pipeline(
     fut_web_sitemap: Future[dict[str, datetime]],
 ) -> None:
     # --- Read base data ---
-    logging.info("-- 00 areatree")
+    _logger.info("-- 00 areatree")
     df = areatree.read_areatree()
 
-    logging.info("-- 01 areas extended")
+    _logger.info("-- 01 areas extended")
     df = merge.patch_areas(df)
 
     # --- Decomposed CSV overrides that create/patch entries ---
     # Applied early (before source annotation and merges) so entries exist
     # for TUMonline/Roomfinder matching, matching original patch_rooms behavior
-    logging.info("-- 02 room overrides (names, usages, ranking)")
+    _logger.info("-- 02 room overrides (names, usages, ranking)")
     df = merge.add_names(df)
     df = merge.add_usages(df)
     df = merge.add_ranking(df)
@@ -148,28 +149,28 @@ def _run_pipeline(
     df = df.with_columns(pl.col("sources_base_json").fill_null('[{"name":"NavigaTUM"}]'))
 
     # --- Buildings (eager: Python dict lookups) ---
-    logging.info("-- 10 Roomfinder buildings")
+    _logger.info("-- 10 Roomfinder buildings")
     df = roomfinder.merge_roomfinder_buildings(df)
 
-    logging.info("-- 11 TUMonline buildings")
+    _logger.info("-- 11 TUMonline buildings")
     df = tumonline.merge_tumonline_buildings(df)
 
     # --- Rooms (eager: Python dict lookups, concat) ---
-    logging.info("-- 15 TUMonline rooms")
+    _logger.info("-- 15 TUMonline rooms")
     df = tumonline.merge_tumonline_rooms(df)
 
-    logging.info("-- 16 Roomfinder rooms")
+    _logger.info("-- 16 Roomfinder rooms")
     df = roomfinder.merge_roomfinder_rooms(df)
 
     # --- POIs (eager: Python dict lookups, concat) ---
-    logging.info("-- 21 POIs")
+    _logger.info("-- 21 POIs")
     df = poi.merge_poi(df)
 
     # Re-ensure columns after concat (new rows from rooms/POIs may lack some columns)
     df = ensure_columns(df, _ALL_NULLABLE_COLUMNS)
 
     # --- Decomposed CSV/YAML overrides (metadata only, entries already created at step 02) ---
-    logging.info("-- 22 Decomposed overrides (comments, links)")
+    _logger.info("-- 22 Decomposed overrides (comments, links)")
     df = merge.add_comments(df)
     df = merge.add_links(df)
 
@@ -202,33 +203,33 @@ def _run_pipeline(
 
     # --- Structure: lazy block for children + type_common_name,
     #     eager for stats + addresses (need .height / logging) ---
-    logging.info("-- 30 Add children properties")
+    _logger.info("-- 30 Add children properties")
     lf = df.lazy()
     lf = structure.add_children_properties(lf)
     df = lf.collect()
 
-    logging.info("-- 33 Add (structural) stats")
+    _logger.info("-- 33 Add (structural) stats")
     df = structure.add_stats(df)
 
-    logging.info("-- 34 Infer more props")
+    _logger.info("-- 34 Infer more props")
     df = structure.infer_addresses(df)
 
-    logging.info("-- 35 Infer the common_name for every type")
+    _logger.info("-- 35 Infer the common_name for every type")
     lf = df.lazy()
     lf = structure.infer_type_common_name(lf)
     df = lf.collect()
 
     # --- Coordinates (eager: map_elements, error checks) ---
-    logging.info("-- 40 Coordinates")
+    _logger.info("-- 40 Coordinates")
     df = merge.add_coordinates(df)
     df = coords.add_and_check_coords(df)
 
     # --- Images (eager: file IO, set lookup) ---
-    logging.info("-- 51 Add image information")
+    _logger.info("-- 51 Add image information")
     df = images.add_img(df)
 
     # --- Sections: lazy for extract_tumonline_props, eager for the rest ---
-    logging.info("-- 80 Generate info card")
+    _logger.info("-- 80 Generate info card")
     lf = df.lazy()
     lf = sections.extract_tumonline_props(lf)
     df = lf.collect()
@@ -236,26 +237,26 @@ def _run_pipeline(
     df = sections.compute_props(df)
     df = sections.localize_links(df)
 
-    logging.info("-- 81 Generate overview sections")
+    _logger.info("-- 81 Generate overview sections")
     df = sections.generate_buildings_overview(df)
     df = sections.generate_rooms_overview(df)
 
     # --- Search + Aliases: lazy block (pure expressions) ---
-    logging.info("-- 90 Search: Build base ranking")
+    _logger.info("-- 90 Search: Build base ranking")
     lf = df.lazy()
     lf = search.add_ranking_base(lf)
 
-    logging.info("-- 97 Search: Get combined ranking")
+    _logger.info("-- 97 Search: Get combined ranking")
     lf = search.add_ranking_combined(lf)
 
-    logging.info("-- 98 Aliases: extract aliases")
+    _logger.info("-- 98 Aliases: extract aliases")
     lf = aliases.add_aliases(lf)
 
     # Filter root and collect for export
     lf = lf.filter(pl.col("id") != "root")
     df = lf.collect()
 
-    logging.info("-- 100 Export and generate Sitemap")
+    _logger.info("-- 100 Export and generate Sitemap")
     data = export.reconstruct_data(df)
     export.export_for_search(data)
     export.export_for_api(data)

--- a/data/compile.py
+++ b/data/compile.py
@@ -189,10 +189,9 @@ def _run_pipeline(
             links_data = yaml_mod.safe_load(f) or {}
         comment_ids.update(str(k) for k in links_data)
     if comment_ids:
-        ids_series = pl.Series("_cid", list(comment_ids))
         df = df.with_columns(
             pl.when(
-                pl.col("id").is_in(ids_series)
+                pl.col("id").is_in(list(comment_ids))
                 & pl.col("sources_base_json").is_not_null()
                 & ~pl.col("sources_base_json").str.contains("NavigaTUM")
             )

--- a/data/external/schemas/roomfinder.py
+++ b/data/external/schemas/roomfinder.py
@@ -1,5 +1,4 @@
 import dataframely as dy
-import polars as pl
 
 # Value sets for the Roomfinder Enums. The Roomfinder dataset is frozen upstream so these lists
 # act both as documentation and as a strict drift gate at load time.

--- a/data/external/scrapers/public_transport.py
+++ b/data/external/scrapers/public_transport.py
@@ -1,12 +1,14 @@
-import logging
-from math import prod
-from zipfile import ZipFile
-import polars as pl
 import datetime as dt
+import logging
+from zipfile import ZipFile
+
+import polars as pl
+from utils import setup_logging
 
 from external.schemas.public_transport import StationsSchema
-from external.scraping_utils import _download_file, CACHE_PATH
-from utils import setup_logging
+from external.scraping_utils import CACHE_PATH
+
+_logger = logging.getLogger(__name__)
 
 HST_REPORT_URL = "https://www.opendata-oepnv.de/fileadmin/datasets/delfi/20250310_zHV_gesamt.zip"
 OPEN_DATA_OEPNV_URL = "https://www.opendata-oepnv.de/ht/de/organisation/delfi/startseite?tx_vrrkit_view%5Baction%5D=details&tx_vrrkit_view%5Bcontroller%5D=View&tx_vrrkit_view%5Bdataset_name%5D=deutschlandweite-haltestellendaten&cHash=02aa95607cd0164111fcf703f749a2ee"
@@ -27,7 +29,7 @@ def _load_stations() -> pl.DataFrame:
         assert len(files) == 1, f"Expected 1 CSV file, but found {len(files)}: {files}"
         file_name = files[0]
         file_zip.extract(file_name, PUBLIC_TRANSPORT_CACHE_PATH)
-    logging.info(f"Extracted the zip file to {file_name}")
+    _logger.info(f"Extracted the zip file to {file_name}")
     df = pl.read_csv(PUBLIC_TRANSPORT_CACHE_PATH / file_name, separator=";", decimal_comma=True)
 
     # datatype cleanup
@@ -39,7 +41,7 @@ def _load_stations() -> pl.DataFrame:
         )
         .cast(pl.Date),
     )
-    df = df.with_columns(pl.when(pl.col("SEV") == "ja").then(True).otherwise(False).name.keep())
+    df = df.with_columns(pl.when(pl.col("SEV") == "ja").then(value=True).otherwise(value=False).name.keep())
     with pl.StringCache():
         df = df.with_columns(pl.col("Authority").cast(pl.Categorical).name.keep())
     # P: "boarding_postion
@@ -57,7 +59,7 @@ def _load_stations() -> pl.DataFrame:
         pl.when(pl.col("DelfiName").is_in(["-", "", None]))
         .then(pl.col("Name"))
         .otherwise(pl.col("DelfiName"))
-        .name.map(lambda x: "Name")
+        .name.map(lambda _: "Name")
     )
     df.drop_in_place("DelfiName")
     df = df.with_columns(pl.col("Latitude").cast(pl.Float32).name.keep())
@@ -74,21 +76,21 @@ def _load_stations() -> pl.DataFrame:
     valid_coordinates &= ~df["Latitude"].is_nan()
     invalid_coordinates = ~valid_coordinates
     if invalid_coordinates.any():
-        logging.warning(f"Dropped {invalid_coordinates.sum()} / {df['DHID'].count()} rows due to invalid coordinates")
+        _logger.warning(f"Dropped {invalid_coordinates.sum()} / {df['DHID'].count()} rows due to invalid coordinates")
         df = df.filter(valid_coordinates)
 
     if df["DHID"].is_null().any():
-        logging.warning(f"Dropped {df['DHID'].is_null().sum()} / {df['DHID'].count()} rows due to missing DHID")
+        _logger.warning(f"Dropped {df['DHID'].is_null().sum()} / {df['DHID'].count()} rows due to missing DHID")
         df = df.filter(~(df["DHID"].is_null()))
 
     if df["Name"].is_null().any():
-        logging.warning(f"Dropped {df['Name'].is_null().sum()} / {df['Name'].count()} rows due to missing Name")
+        _logger.warning(f"Dropped {df['Name'].is_null().sum()} / {df['Name'].count()} rows due to missing Name")
         df = df.filter(~(df["Name"].is_null()))
 
     last_operation_date = df.drop_in_place("LastOperationDate")
-    had_last_operation_date = ~last_operation_date.is_null() & (last_operation_date < dt.datetime.now())
+    had_last_operation_date = ~last_operation_date.is_null() & (last_operation_date < dt.datetime.now(tz=dt.UTC))
     if had_last_operation_date.any():
-        logging.warning(
+        _logger.warning(
             f"Dropped {had_last_operation_date.sum()} / {df['DHID'].count()} rows due to having had the LastOperationDate"
         )
         df = df.filter(~had_last_operation_date)
@@ -110,7 +112,7 @@ def _load_stations() -> pl.DataFrame:
         ],
         strict=True,
     )
-    df = df.rename(
+    return df.rename(
         {
             "DHID": "dhid",
             "Parent": "parent",
@@ -121,12 +123,11 @@ def _load_stations() -> pl.DataFrame:
         },
         strict=True,
     )
-    return df
 
 
 def scrape_stations() -> None:
     """Scrape the stations from the MVV GTFS data and return them as a list of dicts"""
-    logging.info("Scraping the bus and train stations of the MVV")
+    _logger.info("Scraping the bus and train stations of the MVV")
     df = StationsSchema.cast(_load_stations())
     StationsSchema.write_parquet(df, CACHE_PATH / "public_transport.parquet")
 

--- a/data/external/scrapers/public_transport.py
+++ b/data/external/scrapers/public_transport.py
@@ -41,7 +41,9 @@ def _load_stations() -> pl.DataFrame:
         )
         .cast(pl.Date),
     )
-    df = df.with_columns(pl.when(pl.col("SEV") == "ja").then(value=True).otherwise(value=False).name.keep())
+    df = df.with_columns(
+        pl.when(pl.col("SEV") == "ja").then(True).otherwise(False).name.keep(),  # noqa: FBT003
+    )
     with pl.StringCache():
         df = df.with_columns(pl.col("Authority").cast(pl.Categorical).name.keep())
     # P: "boarding_postion

--- a/data/external/scrapers/tumonline.py
+++ b/data/external/scrapers/tumonline.py
@@ -7,10 +7,12 @@ import polars as pl
 import requests
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
+from utils import setup_logging
 
 from external.schemas.tumonline import BuildingsSchema, OrgsSchema, RoomsSchema, UsagesSchema
 from external.scraping_utils import CACHE_PATH
-from utils import setup_logging
+
+_logger = logging.getLogger(__name__)
 
 TUMONLINE_URL = "https://campus.tum.de/tumonline"
 CONNECTUM_URL = f"{TUMONLINE_URL}/co/connectum"
@@ -46,7 +48,7 @@ OAUTH_HEADERS = _generate_oauth_headers()
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException)
 def scrape_buildings() -> None:
     """Retrieve the buildings as in TUMonline"""
-    logging.info("Downloading the buildings of tumonline")
+    _logger.info("Downloading the buildings of tumonline")
 
     payload = requests.get(f"{CONNECTUM_URL}/api/rooms/buildings", headers=OAUTH_HEADERS, timeout=30).json()
     rows = [
@@ -69,7 +71,7 @@ def scrape_buildings() -> None:
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException)
 def scrape_rooms() -> None:
     """Retrieve the rooms as in TUMonline"""
-    logging.info("Downloading the rooms of tumonline")
+    _logger.info("Downloading the rooms of tumonline")
 
     payload = requests.get(f"{CONNECTUM_URL}/api/rooms", headers=OAUTH_HEADERS, timeout=30).json()
     rows = [
@@ -107,7 +109,7 @@ def _clean_spaces(_string: str) -> str:
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException)
 def scrape_usages() -> None:
     """Retrieve all usage types available in TUMonline."""
-    logging.info("Downloading the usage types of tumonline")
+    _logger.info("Downloading the usage types of tumonline")
 
     payload = requests.get(f"{CONNECTUM_URL}/api/rooms/usages", headers=OAUTH_HEADERS, timeout=30).json()
 
@@ -123,7 +125,7 @@ def scrape_orgs(lang: typing.Literal["de", "en"]) -> None:
 
     :params lang: 'en' or 'de'
     """
-    logging.info("Scraping the orgs of tumonline")
+    _logger.info("Scraping the orgs of tumonline")
 
     # There is also this URL, which is used to retrieve orgs that have courses,
     # but this is not merged in at the moment:

--- a/data/processors/aliases.py
+++ b/data/processors/aliases.py
@@ -30,11 +30,9 @@ def add_aliases(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
     # aliases_json: JSON array string with arch_name if present, else empty array
-    lf = lf.with_columns(
+    return lf.with_columns(
         pl.when(pl.col("arch_name").is_not_null())
         .then(pl.lit('["') + pl.col("arch_name") + pl.lit('"]'))
         .otherwise(pl.lit("[]"))
         .alias("aliases_json"),
     )
-
-    return lf

--- a/data/processors/areatree/process.py
+++ b/data/processors/areatree/process.py
@@ -1,11 +1,13 @@
 import logging
-from pathlib import Path
 from collections.abc import Iterator
+from pathlib import Path
 
 import polars as pl
 
 from processors.areatree import models
 from processors.df_utils import to_json_or_none
+
+_logger = logging.getLogger(__name__)
 
 AREATREE_FILE = Path(__file__).parent / "config.areatree"
 
@@ -158,7 +160,7 @@ def _extract_names(names: list[str]) -> models.Names:
     building_data: models.Names = {"name": names[0]}
     if len(names) == 2:
         if len(names[1]) > 20:
-            logging.warning(f"'{names[1]}' is very long for a short name (>20 chars)")
+            _logger.warning(f"'{names[1]}' is very long for a short name (>20 chars)")
 
         building_data["short_name"] = names[1]
     elif len(names) > 2:

--- a/data/processors/areatree/test_areatree.py
+++ b/data/processors/areatree/test_areatree.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 from external.loaders.tumonline import load_buildings
+
 from processors import areatree
 from processors.areatree.process import (
     _areatree_lines,

--- a/data/processors/coords.py
+++ b/data/processors/coords.py
@@ -2,8 +2,11 @@ import logging
 
 import polars as pl
 import utm
-from processors.df_utils import ensure_columns
 from utils import distance_via_great_circle
+
+from processors.df_utils import ensure_columns
+
+_logger = logging.getLogger(__name__)
 
 MAX_DISTANCE_METERS_FROM_PARENT = 400
 
@@ -20,7 +23,7 @@ def assert_buildings_have_coords(df: pl.DataFrame) -> None:
     if buildings_without.height > 0:
         ids = buildings_without["id"].to_list()
         names = buildings_without["name"].to_list()
-        msg = "\n".join(f"{i}: {n}" for i, n in zip(ids, names))
+        msg = "\n".join(f"{i}: {n}" for i, n in zip(ids, names, strict=True))
         raise RuntimeError(f"No coordinates known for the following buildings:\n{msg}")
 
 
@@ -106,13 +109,13 @@ def assign_coordinates(df: pl.DataFrame) -> pl.DataFrame:
         bad_counts = parent_counts.filter(pl.col("len") != 1)
         if bad_counts.height > 0:
             for row in bad_counts.iter_rows(named=True):
-                logging.error(f"Could not find distinct parent building for {row['id']}")
+                _logger.error(f"Could not find distinct parent building for {row['id']}")
             error = True
 
         no_parent = needs_coords.join(parent_buildings.select("id").unique(), on="id", how="anti")
         if no_parent.height > 0:
             for rid in no_parent["id"].to_list():
-                logging.error(f"Could not find distinct parent building for {rid}")
+                _logger.error(f"Could not find distinct parent building for {rid}")
             error = True
 
         parent_buildings = parent_buildings.group_by("id").agg(
@@ -143,7 +146,7 @@ def assign_coordinates(df: pl.DataFrame) -> pl.DataFrame:
         no_children = needs_avg.filter(pl.col("children_flat").is_null() | (pl.col("children_flat").list.len() == 0))
         if no_children.height > 0:
             for rid in no_children["id"].to_list():
-                logging.error(f"Cannot infer coordinate of '{rid}' because it has no children")
+                _logger.error(f"Cannot infer coordinate of '{rid}' because it has no children")
             error = True
 
         exploded = (
@@ -179,7 +182,7 @@ def assign_coordinates(df: pl.DataFrame) -> pl.DataFrame:
     )
     if unknown.height > 0:
         for row in unknown.iter_rows(named=True):
-            logging.error(f"Don't know how to infer coordinate for entry type '{row['type']}'")
+            _logger.error(f"Don't know how to infer coordinate for entry type '{row['type']}'")
         error = True
 
     if error:

--- a/data/processors/df_utils.py
+++ b/data/processors/df_utils.py
@@ -1,12 +1,13 @@
-import orjson
 from typing import Any
 
+import orjson
 import polars as pl
-
 from utils import TranslatableStr
 
+_DEFAULT_DTYPE: pl.DataType = pl.Utf8()
 
-def ensure_column(df: pl.DataFrame, col_name: str, dtype: pl.DataType = pl.Utf8()) -> pl.DataFrame:
+
+def ensure_column(df: pl.DataFrame, col_name: str, dtype: pl.DataType = _DEFAULT_DTYPE) -> pl.DataFrame:
     """Ensure a column exists in the DataFrame, adding it as null if missing."""
     if col_name not in df.columns:
         df = df.with_columns(pl.lit(None).cast(dtype).alias(col_name))

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -1,4 +1,3 @@
-import csv
 import re
 from pathlib import Path
 from typing import Any
@@ -7,11 +6,11 @@ import orjson
 import polars as pl
 import xxhash
 import yaml
-
 from external.models.common import PydanticConfiguration
-from processors.df_utils import unflatten_row
 from utils import TranslatableStr
 from utils import TranslatableStr as _
+
+from processors.df_utils import unflatten_row
 
 
 def _orjson_default(o: Any) -> Any:
@@ -186,7 +185,7 @@ def export_for_api(data: dict[str, Any]) -> None:
 
 def extract_exported_item(data, entry):
     """Extract the item that will be finally exported to the api"""
-    parent_names = [data[p]["name"] if not p == "root" else _("Standorte", "Sites") for p in entry["parents"]]
+    parent_names = [data[p]["name"] if p != "root" else _("Standorte", "Sites") for p in entry["parents"]]
     result = {
         "parent_names": parent_names,
         **entry,
@@ -198,7 +197,7 @@ def extract_exported_item(data, entry):
         result.pop(key, None)
     if "props" in result:
         prop_keys_to_keep = {"computed", "floors", "links", "comment", "calendar_url", "tumonline_room_nr", "operator"}
-        to_delete = [e for e in result["props"].keys() if e not in prop_keys_to_keep]
+        to_delete = [e for e in result["props"] if e not in prop_keys_to_keep]
         for k in to_delete:
             del result["props"][k]
     # Stable, deterministic content hash. Python's built-in `hash()` is salted by PYTHONHASHSEED

--- a/data/processors/images.py
+++ b/data/processors/images.py
@@ -1,5 +1,4 @@
 import hashlib
-import orjson
 import logging
 import os
 import shutil
@@ -8,15 +7,16 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, NamedTuple
 
+import orjson
 import polars as pl
-import pydantic
+import utils
 import yaml
+from external.models.common import PydanticConfiguration
 from PIL import Image
 from pydantic import Field
 from pydantic.networks import HttpUrl
 
-import utils
-from external.models.common import PydanticConfiguration
+_logger = logging.getLogger(__name__)
 
 
 class UrlStr(PydanticConfiguration):
@@ -69,13 +69,13 @@ def add_img(df: pl.DataFrame) -> pl.DataFrame:
         _id, _index = parse_image_filename(image_path.name)
 
         if _id not in img_sources or _index not in img_sources[_id]:
-            logging.warning(f"No source information for image '{image_path}', it will not be used")
+            _logger.warning(f"No source information for image '{image_path}', it will not be used")
 
     # Build imgs data per id
     imgs_rows = []
     for _id, _source_data in img_sources.items():
         if _id not in existing_ids:
-            logging.warning(f"There are images for '{_id}', but it was not found in the provided data, ignoring")
+            _logger.warning(f"There are images for '{_id}', but it was not found in the provided data, ignoring")
             continue
 
         img_data = []
@@ -83,7 +83,7 @@ def add_img(df: pl.DataFrame) -> pl.DataFrame:
             if image_path.name.startswith(f"{_id}_"):
                 source_info = _add_source_info(image_path.name, _source_data)
                 if not source_info:
-                    logging.warning(
+                    _logger.warning(
                         f"possibly skipped adding images for '{image_path}', a image was skipped because of missing "
                         f"source information. Adding more images would violate the enumeration-consistency",
                     )
@@ -121,7 +121,7 @@ def _add_source_info(fname, source_data):
     required_fields = ["author", "license"]
     for field in required_fields:
         if field not in source_data[_index]:
-            logging.warning(f"No {field} information for image '{fname}', it will not be used")
+            _logger.warning(f"No {field} information for image '{fname}', it will not be used")
             return None
 
     def _parse(obj):
@@ -181,7 +181,7 @@ class Resizer:
             if target != self.source:
                 # since we are already smaller than the max_size, we can copy the original image.
                 if target.is_file():
-                    os.remove(target)
+                    target.unlink()
                 shutil.copy(self.source, target)
             return
         if width < height:
@@ -213,20 +213,20 @@ def _refresh_for_all_resolutions(order: RefreshResolutionOrder) -> None:
         resizer.resize_to_fixed_size(IMAGE_BASE_PATH / "header" / order.source.name, (512, 210), order.offsets.header)
     # pylint: disable-next=broad-exception-caught
     except Exception as error:
-        logging.error(error)  # otherwise we would not see if an error occurs
+        _logger.error(error)  # otherwise we would not see if an error occurs
 
 
 def _extract_offsets(_id: str, _index: int, img_path: Path, img_sources: dict[str, list[ImageSource]]) -> ImageOffset:
     """Extract the offsets for the given image. Offsets are only available for the images, we crop"""
     if _id not in img_sources or _index >= len(img_sources[_id]):
-        logging.warning(f"No source information for image '{img_path}', default crop-offset 0 is used")
+        _logger.warning(f"No source information for image '{img_path}', default crop-offset 0 is used")
         return ImageOffset()
     return img_sources[_id][_index].offsets
 
 
 def _get_hash_lut() -> dict[str, str]:
     """Get a lookup table for the hash of the image files content and offset if present"""
-    logging.info("Only files, with sha256(file-content)_sha256(offset) not present in the .hash_lut.json will be used")
+    _logger.info("Only files, with sha256(file-content)_sha256(offset) not present in the .hash_lut.json will be used")
     if HASH_LUT_FILE_PATH.is_file():
         return orjson.loads(HASH_LUT_FILE_PATH.read_bytes())  # type: ignore
     return {}
@@ -259,7 +259,7 @@ def resize_and_crop() -> None:
 
     This will overwrite any existing thumbs/header-small's.
     """
-    logging.info(f"convert {IMAGE_BASE_PATH} to webp")
+    _logger.info(f"convert {IMAGE_BASE_PATH} to webp")
     utils.convert_to_webp(IMAGE_BASE_PATH)
 
     # in DEV, we can save some time by not resizing the images, if they have not changed
@@ -274,8 +274,8 @@ def resize_and_crop() -> None:
             if actual_hash == expected_hashes_lut.get(img_path.name, ""):
                 continue  # skip this image, since it (and its offsets) have not changed
             if DEV_MODE:
-                logging.debug(f"Image '{img_path.name}' has changed, resizing and cropping...")
+                _logger.debug(f"Image '{img_path.name}' has changed, resizing and cropping...")
             executor.submit(_refresh_for_all_resolutions, RefreshResolutionOrder(img_path, offsets))
     _save_hash_lut(img_sources)
     resize_and_crop_time = time.time() - start_time
-    logging.info(f"Resize and crop took {resize_and_crop_time:.2f}s")
+    _logger.info(f"Resize and crop took {resize_and_crop_time:.2f}s")

--- a/data/processors/merge.py
+++ b/data/processors/merge.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from typing import Any
 
+import orjson
 import polars as pl
 import yaml
-from processors.df_utils import flatten_entry, to_json_or_none
 from utils import TranslatableStr
-import orjson
+
+from processors.df_utils import flatten_entry
 
 BASE_PATH = Path(__file__).parent.parent
 SOURCES_PATH = BASE_PATH / "sources"
@@ -79,9 +80,7 @@ def add_coordinates(df: pl.DataFrame) -> pl.DataFrame:
     ]
 
     result = result.with_columns(coalesce_exprs)
-    result = result.drop(["coords_lat__csv", "coords_lon__csv"])
-
-    return result
+    return result.drop(["coords_lat__csv", "coords_lon__csv"])
 
 
 def _apply_patch_df(df: pl.DataFrame, patch_df: pl.DataFrame) -> pl.DataFrame:
@@ -94,11 +93,11 @@ def _apply_patch_df(df: pl.DataFrame, patch_df: pl.DataFrame) -> pl.DataFrame:
         return df
 
     # Align dtypes: cast patch columns to match df where they overlap
-    cast_exprs = []
-    for col in patch_df.columns:
-        if col != "id" and col in df.columns:
-            if patch_df.schema[col] != df.schema[col]:
-                cast_exprs.append(pl.col(col).cast(df.schema[col]))
+    cast_exprs = [
+        pl.col(col).cast(df.schema[col])
+        for col in patch_df.columns
+        if col != "id" and col in df.columns and patch_df.schema[col] != df.schema[col]
+    ]
     if cast_exprs:
         patch_df = patch_df.with_columns(cast_exprs)
 
@@ -112,18 +111,14 @@ def _apply_patch_df(df: pl.DataFrame, patch_df: pl.DataFrame) -> pl.DataFrame:
     result = df.join(renamed, on="id", how="full", coalesce=True)
 
     # Coalesce: patch wins over original
-    coalesce_exprs = []
-    for col in common_cols:
-        coalesce_exprs.append(pl.coalesce(pl.col(f"{col}__patch"), pl.col(col)).alias(col))
+    coalesce_exprs = [pl.coalesce(pl.col(f"{col}__patch"), pl.col(col)).alias(col) for col in common_cols]
 
     if coalesce_exprs:
         result = result.with_columns(coalesce_exprs)
 
     # Drop the __patch columns
     drop_cols = [f"{c}__patch" for c in common_cols]
-    result = result.drop(drop_cols)
-
-    return result
+    return result.drop(drop_cols)
 
 
 def _yaml_to_patch_df(yaml_data: dict[str, dict[str, Any]]) -> pl.DataFrame:
@@ -247,7 +242,6 @@ def add_links(df: pl.DataFrame) -> pl.DataFrame:
 
     links_df = pl.DataFrame(rows, infer_schema_length=None)
     result = df.join(links_df, on="id", how="left")
-    result = result.with_columns(
+    return result.with_columns(
         pl.coalesce(pl.col("props_links_json__yaml"), pl.col("props_links_json")).alias("props_links_json"),
     ).drop("props_links_json__yaml")
-    return result

--- a/data/processors/patch.py
+++ b/data/processors/patch.py
@@ -5,6 +5,8 @@ from typing import Any, TypedDict
 # python 3.11 feature => move to typing when 3.11 is mainstream
 from typing_extensions import NotRequired
 
+_logger = logging.getLogger(__name__)
+
 
 class Patch(TypedDict):
     if_room_code: str
@@ -48,6 +50,6 @@ def apply_roomcode_patch(objects: dict[str, dict[str, Any]], patches: list[Patch
 
     for patch_check, _ in compiled_patches:
         if patch_check not in applied_patches:
-            logging.warning(
+            _logger.warning(
                 f"The patch for roomcode: r'{patch_check.pattern}' was never applied. Make sure it is still required.",
             )

--- a/data/processors/poi.py
+++ b/data/processors/poi.py
@@ -1,12 +1,12 @@
-import orjson
 from pathlib import Path
 from typing import Any
 
+import orjson
 import polars as pl
+from utils import TranslatableStr as _
 
 from processors import merge
 from processors.df_utils import translatable_to_columns
-from utils import TranslatableStr as _
 
 BASE_PATH = Path(__file__).parent.parent
 SOURCES_PATH = BASE_PATH / "sources"
@@ -19,7 +19,7 @@ def merge_poi(df: pl.DataFrame) -> pl.DataFrame:
 
     existing_ids = set(df["id"].to_list())
     # Build parent lookup: id -> parents list
-    parent_lookup = dict(zip(df["id"].to_list(), df["parents"].to_list()))
+    parent_lookup = dict(zip(df["id"].to_list(), df["parents"].to_list(), strict=True))
 
     new_rows: list[dict[str, Any]] = []
     for _id, poi in poi_data.items():

--- a/data/processors/roomfinder.py
+++ b/data/processors/roomfinder.py
@@ -1,14 +1,17 @@
-import orjson
 import logging
 import re
 from pathlib import Path
 from typing import Any
 
+import orjson
 import polars as pl
 import yaml
 from external.loaders.roomfinder import load_buildings as load_rf_buildings
 from external.loaders.roomfinder import load_rooms as load_rf_rooms
+
 from processors.df_utils import ensure_column
+
+_logger = logging.getLogger(__name__)
 
 BASE_PATH = Path(__file__).parent.parent
 SOURCES_PATH = BASE_PATH / "sources"
@@ -41,10 +44,10 @@ def merge_roomfinder_buildings(df: pl.DataFrame) -> pl.DataFrame:
             # The Roomfinder appears to be no longer maintained, so sometimes there are still
             # buildings in it that no longer exist. Previously this was an error, but for this
             # reason now it is a warning.
-            logging.warning(f"building '{b_id}' not found in base data. It may be missing in the areatree.")
+            _logger.warning(f"building '{b_id}' not found in base data. It may be missing in the areatree.")
             continue
         if len(matches) > 1:
-            logging.error(f"building id '{b_id}' more than once in base data")
+            _logger.error(f"building id '{b_id}' more than once in base data")
             error = True
             continue
 
@@ -121,10 +124,9 @@ def merge_roomfinder_buildings(df: pl.DataFrame) -> pl.DataFrame:
         .alias("sources_base_json"),
     )
 
-    result = result.drop(
+    return result.drop(
         ["roomfinder_data_json_new", "sources_rf_json", "coords_lat_rf", "coords_lon_rf", "props_ids_b_id_rf"]
     )
-    return result
 
 
 def _rf_source_json(r_id: str) -> str:
@@ -180,14 +182,14 @@ def merge_roomfinder_rooms(df: pl.DataFrame) -> pl.DataFrame:
             r_id = _find_room_id(room, id_lookup, arch_name_lookup, patches)
             if r_id is None:
                 continue
-        except RoomNotFoundException as exc:
+        except RoomNotFoundError as exc:
             if not exc.known_issue:
-                logging.warning(exc.message)
+                _logger.warning(exc.message)
                 continue
             r_id = patches["known_issues"]["not_in_tumonline"][room["r_id"]]
             parent_row = id_lookup.get(room["b_id"])
             if parent_row is None:
-                logging.warning(f"Parent building '{room['b_id']}' not found for room '{room['r_id']}'")
+                _logger.warning(f"Parent building '{room['b_id']}' not found for room '{room['r_id']}'")
                 continue
             parents = parent_row["parents"] + [room["b_id"]]
             name = r_id if len(room["r_alias"]) == 0 else f"{r_id} ({room['r_alias']})"
@@ -298,7 +300,7 @@ def _find_room_id(
         return str(patches["known_issues"]["mapping"][room["r_id"]])
 
     if room["r_id"] in patches["known_issues"]["not_in_tumonline"]:
-        raise RoomNotFoundException(known_issue=True)
+        raise RoomNotFoundError(known_issue=True)
 
     # Verify first, that the building is included in the data.
     # Buildings not in the data are ignored.
@@ -315,10 +317,12 @@ def _find_room_id(
         if search_result := arch_name_lookup.get(search):
             return search_result
 
-    raise RoomNotFoundException(False, f"Could not find roomfinder room in TUMonline data: {room['r_id']}")
+    raise RoomNotFoundError(
+        known_issue=False, message=f"Could not find roomfinder room in TUMonline data: {room['r_id']}"
+    )
 
 
-class RoomNotFoundException(Exception):
+class RoomNotFoundError(Exception):
     def __init__(self, known_issue, message=None):
         self.known_issue = known_issue
         self.message = message

--- a/data/processors/search.py
+++ b/data/processors/search.py
@@ -55,7 +55,7 @@ def add_ranking_base(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
     # Type-specific boosts
-    lf = lf.with_columns(
+    return lf.with_columns(
         pl.when((pl.col("type") == "room") & pl.col("props_stats_n_seats").is_not_null())
         .then((pl.col("props_stats_n_seats") // 10).clip(0, 99))
         .when(pl.col("type").is_in(["building", "joined_building"]) & pl.col("props_stats_n_rooms_reg").is_not_null())
@@ -67,8 +67,6 @@ def add_ranking_base(lf: pl.LazyFrame) -> pl.LazyFrame:
         .alias("ranking_rank_boost"),
     )
 
-    return lf
-
 
 def add_ranking_combined(lf: pl.LazyFrame) -> pl.LazyFrame:
     """
@@ -76,7 +74,7 @@ def add_ranking_combined(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     Returns a LazyFrame with a ranking_rank_combined column added.
     """
-    lf = lf.with_columns(
+    return lf.with_columns(
         pl.when(pl.col("ranking_rank_type").is_not_null())
         .then(
             (pl.col("ranking_rank_type") * pl.col("ranking_rank_usage")) // 100
@@ -87,4 +85,3 @@ def add_ranking_combined(lf: pl.LazyFrame) -> pl.LazyFrame:
         .cast(pl.Int64)
         .alias("ranking_rank_combined"),
     )
-    return lf

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -69,7 +69,7 @@ def extract_tumonline_props(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
 
-_FLOOR_PROP_PARENT_TYPES = pl.Series(["building", "joined_building", "site", "campus"])
+_FLOOR_PROP_PARENT_TYPES = ["building", "joined_building", "site", "campus"]
 
 
 def compute_floor_prop(df: pl.DataFrame) -> pl.DataFrame:
@@ -453,7 +453,7 @@ def localize_links(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-_BUILDINGS_OVERVIEW_PARENT_TYPES = pl.Series(["area", "site", "campus"])
+_BUILDINGS_OVERVIEW_PARENT_TYPES = ["area", "site", "campus"]
 _BUILDINGS_OVERVIEW_CHILD_TYPES = {"area", "site", "campus", "building", "joined_building"}
 
 
@@ -545,16 +545,14 @@ def generate_buildings_overview(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-_ROOMS_OVERVIEW_PARENT_TYPES = pl.Series(
-    [
-        "area",
-        "site",
-        "campus",
-        "building",
-        "joined_building",
-        "virtual_room",
-    ]
-)
+_ROOMS_OVERVIEW_PARENT_TYPES = [
+    "area",
+    "site",
+    "campus",
+    "building",
+    "joined_building",
+    "virtual_room",
+]
 
 
 def generate_rooms_overview(df: pl.DataFrame) -> pl.DataFrame:

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,11 +1,12 @@
-import orjson
 import logging
 import typing
 from typing import Any
 
+import orjson
 import polars as pl
-
 from utils import TranslatableStr
+
+_logger = logging.getLogger(__name__)
 
 _ = TranslatableStr
 
@@ -54,7 +55,7 @@ def extract_tumonline_props(lf: pl.LazyFrame) -> pl.LazyFrame:
     )
 
     # operator_name (de/en)
-    lf = lf.with_columns(
+    return lf.with_columns(
         [
             pl.when(_json_not_null("operator_name"))
             .then(pl.col("tumonline_data_json").str.json_path_match("$.operator_name.de"))
@@ -66,8 +67,6 @@ def extract_tumonline_props(lf: pl.LazyFrame) -> pl.LazyFrame:
             .alias("props_operator_name_en"),
         ]
     )
-
-    return lf
 
 
 _FLOOR_PROP_PARENT_TYPES = pl.Series(["building", "joined_building", "site", "campus"])
@@ -89,7 +88,7 @@ def compute_floor_prop(df: pl.DataFrame) -> pl.DataFrame:
         pl.col("children_flat").is_null() | (pl.col("children_flat").list.len() == 0),
     )
     for parent_id in no_children["id"].to_list():
-        logging.warning(f"Entry {parent_id} has no children")
+        _logger.warning(f"Entry {parent_id} has no children")
 
     parents = parents.filter(
         pl.col("children_flat").is_not_null() & (pl.col("children_flat").list.len() > 0),
@@ -242,10 +241,7 @@ def _get_floor_name_and_type(f_id: int, floor: str, mezzanine_shift: int) -> tup
             floor_name = _(f"{floor[1:]}. ") + _("Untergeschoss")
             return "basement", f"-{floor[1:]}", floor_name
         case floor if floor.startswith("Z"):
-            if f_id == 1:
-                floor_name = _("1. Zwischengeschoss, über EG")
-            else:
-                floor_name = _(f"{floor[1:]}. ") + _("Zwischengeschoss")
+            floor_name = _("1. Zwischengeschoss, über EG") if f_id == 1 else _(f"{floor[1:]}. ") + _("Zwischengeschoss")
             return "mezzanine", floor, floor_name
     # default case, but mypy doesn't recognize `case _:`
     og_floor = int(floor[1:])
@@ -390,17 +386,16 @@ def _gen_computed_props(
         _append_if_present(props["ids"], computed, "roomcode", _("Raumkennung"))
         if "arch_name" in props["ids"]:
             computed.append({_("Architekten-Name"): props["ids"]["arch_name"].split("@")[0]})
-    if floors := props.get("floors"):
-        if len(floors) == 1:
-            floor = floors[0]
-            floor_name = floor["name"]
-            # floor_name may be a dict {de:..., en:...} from JSON deserialization
-            if isinstance(floor_name, dict):
-                floor_name = TranslatableStr(floor_name["de"], floor_name.get("en"))
-            if floor["trivial"]:
-                computed.append({_("Stockwerk"): floor_name})
-            else:
-                computed.append({_("Stockwerk"): f"{floor['floor']} (" + floor_name + ")"})
+    if (floors := props.get("floors")) and len(floors) == 1:
+        floor = floors[0]
+        floor_name = floor["name"]
+        # floor_name may be a dict {de:..., en:...} from JSON deserialization
+        if isinstance(floor_name, dict):
+            floor_name = TranslatableStr(floor_name["de"], floor_name.get("en"))
+        if floor["trivial"]:
+            computed.append({_("Stockwerk"): floor_name})
+        else:
+            computed.append({_("Stockwerk"): f"{floor['floor']} (" + floor_name + ")"})
     b_prefix_raw: Any = entry.get("b_prefix_list") or entry.get("b_prefix")
     if b_prefix_raw and b_prefix_raw != _id:
         if isinstance(b_prefix_raw, list):
@@ -453,10 +448,9 @@ def localize_links(df: pl.DataFrame) -> pl.DataFrame:
                 link["url"] = {"de": link["url"], "en": link["url"]}
         return orjson.dumps(links).decode()
 
-    df = df.with_columns(
+    return df.with_columns(
         pl.col("props_links_json").map_elements(_localize_links_json, return_dtype=pl.Utf8).alias("props_links_json"),
     )
-    return df
 
 
 _BUILDINGS_OVERVIEW_PARENT_TYPES = pl.Series(["area", "site", "campus"])

--- a/data/processors/sitemap.py
+++ b/data/processors/sitemap.py
@@ -1,4 +1,3 @@
-import orjson
 import logging
 import xml.etree.ElementTree as ET  # nosec: used for writing files, defusedxml only supports parse()
 from datetime import datetime, timezone
@@ -6,8 +5,11 @@ from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 import backoff
+import orjson
 import requests
 from defusedxml import ElementTree as defusedET
+
+_logger = logging.getLogger(__name__)
 
 OLD_DATA_URL = "https://nav.tum.de/cdn/api_data.json"
 
@@ -65,7 +67,7 @@ def fetch_old_data() -> list[Any]:
     try:
         return _download_old_data()
     except requests.exceptions.RequestException as error:
-        logging.warning(f"Could not download online data because of {error}. Assuming all entries are new.")
+        _logger.warning(f"Could not download online data because of {error}. Assuming all entries are new.")
         return []
 
 
@@ -82,7 +84,7 @@ def _download_old_data() -> list[Any]:
     """Download the currently online data from the server"""
     req = requests.get(OLD_DATA_URL, headers={"Accept-Encoding": "gzip"}, timeout=120)
     if req.status_code != 200:
-        logging.warning(f"Could not download online data because of {req.status_code=}. Assuming all are new")
+        _logger.warning(f"Could not download online data because of {req.status_code=}. Assuming all are new")
         return []
     old_data = orjson.loads(req.content)
     if isinstance(old_data, dict):
@@ -110,7 +112,7 @@ def _extract_sitemap_data(new_data: list[Any], old_data: list[Any], old_sitemaps
     new_data_dict = {entry["id"]: entry for entry in new_data}
     changed_count = 0
     for _id, entry in new_data_dict.items():
-        sitemap_name: Literal["room"] | Literal["other"] = entry["type"] if entry["type"] in sitemaps else "other"
+        sitemap_name: Literal["room", "other"] = entry["type"] if entry["type"] in sitemaps else "other"
 
         # Just copied from the webclient.
         # The webclient doesn't care about the prefix.
@@ -155,7 +157,7 @@ def _extract_sitemap_data(new_data: list[Any], old_data: list[Any], old_sitemaps
                 "priority": priority,
             },
         )
-    logging.info(f"{changed_count} of {len(new_data) - 1} URLs have been updated.")
+    _logger.info(f"{changed_count} of {len(new_data) - 1} URLs have been updated.")
 
     return sitemaps
 
@@ -165,10 +167,10 @@ def download_online_sitemap(url: str) -> dict[str, datetime]:
     try:
         req = requests.get(url, headers={"Accept-Encoding": "gzip"}, timeout=10)
     except requests.exceptions.RequestException as error:
-        logging.warning(f"Failed to download sitemap '{url}': {error}")
+        _logger.warning(f"Failed to download sitemap '{url}': {error}")
         return {}
     if req.status_code != 200:
-        logging.warning(f"Failed to download sitemap '{url}': Status code {req.status_code}")
+        _logger.warning(f"Failed to download sitemap '{url}': Status code {req.status_code}")
         return {}
 
     xmlns = "{http://www.sitemaps.org/schemas/sitemap/0.9}"

--- a/data/processors/structure.py
+++ b/data/processors/structure.py
@@ -1,9 +1,12 @@
 import logging
 
 import polars as pl
+from utils import TranslatableStr
+from utils import TranslatableStr as _
 
 from processors.df_utils import ensure_column
-from utils import TranslatableStr, TranslatableStr as _
+
+_logger = logging.getLogger(__name__)
 
 
 def add_children_properties(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -42,9 +45,7 @@ def add_children_properties(lf: pl.LazyFrame) -> pl.LazyFrame:
 
     # Join back onto main LazyFrame
     lf = lf.join(children_agg, left_on="id", right_on="parent_id", how="left")
-    lf = lf.join(children_flat_agg, left_on="id", right_on="parent_id", how="left")
-
-    return lf
+    return lf.join(children_flat_agg, left_on="id", right_on="parent_id", how="left")
 
 
 def add_stats(df: pl.DataFrame) -> pl.DataFrame:
@@ -58,7 +59,7 @@ def add_stats(df: pl.DataFrame) -> pl.DataFrame:
         pl.col("type").is_in(["root", "site", "campus", "area"]) & pl.col("children_flat").is_null()
     )
     for row in missing_children.iter_rows(named=True):
-        logging.warning(f"'{row['id']}' ({row['type']}) has no children")
+        _logger.warning(f"'{row['id']}' ({row['type']}) has no children")
 
     # Only process entries that have children_flat
     has_children = df.filter(pl.col("children_flat").is_not_null()).select("id", "children_flat")
@@ -132,11 +133,9 @@ def add_stats(df: pl.DataFrame) -> pl.DataFrame:
         & (pl.col("props_stats_n_rooms") == 0)
     )
     for row in zero_rooms.iter_rows(named=True):
-        logging.warning(f"'{row['id']}' ({row['type']}) has no rooms")
+        _logger.warning(f"'{row['id']}' ({row['type']}) has no rooms")
 
-    df = df.drop(["_n_rooms", "_n_rooms_reg", "_n_buildings"])
-
-    return df
+    return df.drop(["_n_rooms", "_n_rooms_reg", "_n_buildings"])
 
 
 def infer_addresses(df: pl.DataFrame) -> pl.DataFrame:
@@ -180,7 +179,7 @@ def infer_addresses(df: pl.DataFrame) -> pl.DataFrame:
 
     # Join back and fill in missing addresses
     df = df.join(uniform, on="id", how="left")
-    df = df.with_columns(
+    return df.with_columns(
         pl.coalesce(pl.col("props_address_street"), pl.col("inferred_street")).alias("props_address_street"),
         pl.coalesce(pl.col("props_address_plz_place"), pl.col("inferred_plz")).alias("props_address_plz_place"),
         pl.when(pl.col("props_address_source").is_null() & pl.col("inferred_street").is_not_null())
@@ -188,8 +187,6 @@ def infer_addresses(df: pl.DataFrame) -> pl.DataFrame:
         .otherwise(pl.col("props_address_source"))
         .alias("props_address_source"),
     ).drop(["inferred_street", "inferred_plz"])
-
-    return df
 
 
 TYPE_COMMON_NAME_BY_TYPE: dict[str, str | TranslatableStr] = {
@@ -253,6 +250,4 @@ def infer_type_common_name(lf: pl.LazyFrame) -> pl.LazyFrame:
         pl.col("type_common_name_de").alias("type_common_name"),
     )
 
-    lf = lf.drop(["_last_parent", "_parent_type"])
-
-    return lf
+    return lf.drop(["_last_parent", "_parent_type"])

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -215,7 +215,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
                 .otherwise(pl.col("sources_base_json"))
                 .alias("sources_base_json"),
                 pl.when(pl.col("sources_patched_update") == True)  # noqa: E712
-                .then(pl.lit(value=True))
+                .then(pl.lit(True))  # noqa: FBT003
                 .otherwise(pl.col("sources_patched"))
                 .alias("sources_patched"),
             )

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -1,16 +1,18 @@
-import orjson
 import logging
 import string
 from pathlib import Path
 from typing import Any
 
+import orjson
 import polars as pl
 import yaml
-
 from external.loaders.tumonline import load_buildings, load_orgs, load_rooms, load_usages
+from utils import TranslatableStr as _
+
 from processors.df_utils import ensure_column, ensure_columns, to_json_or_none, translatable_to_columns
 from processors.patch import apply_roomcode_patch
-from utils import TranslatableStr as _
+
+_logger = logging.getLogger(__name__)
 
 ALLOWED_ROOMCODE_CHARS = set(string.ascii_letters) | set(string.digits) | {".", "-"}
 OPERATOR_STRIP_CHARS = "[ ]"
@@ -35,12 +37,12 @@ def merge_tumonline_buildings(df: pl.DataFrame) -> pl.DataFrame:
         # Check for duplicates in the DataFrame
         matches = df.filter(pl.col("b_prefix") == b_id)
         if matches.height > 1:
-            logging.warning(f"building id '{b_id}' ('{b_name}') more than once in base data")
+            _logger.warning(f"building id '{b_id}' ('{b_name}') more than once in base data")
             error = True
             continue
         if matches.height == 0:
             # Currently, not an error, because the areatree is built by hand.
-            logging.warning(f"building id '{b_id}' ('{b_name}') not found in base data, ignoring")
+            _logger.warning(f"building id '{b_id}' ('{b_name}') not found in base data, ignoring")
             continue
 
         buildings_rows.append(
@@ -75,9 +77,7 @@ def merge_tumonline_buildings(df: pl.DataFrame) -> pl.DataFrame:
             pl.coalesce(pl.col("props_ids_b_id"), pl.col("props_ids_b_id_new")).alias("props_ids_b_id"),
         ]
     )
-    result = result.drop(["tumonline_data_json_new", "props_ids_b_id_new"])
-
-    return result
+    return result.drop(["tumonline_data_json_new", "props_ids_b_id_new"])
 
 
 _BUILDING_TYPES = pl.Series(["building", "joined_building"])
@@ -119,7 +119,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
             continue
 
         if room["usage_id"] not in usages_lookup:
-            logging.error(f"Unknown usage for room '{room_code}': Id '{room['usage_id']}'")
+            _logger.error(f"Unknown usage for room '{room_code}': Id '{room['usage_id']}'")
             continue
         tumonline_usage = usages_lookup[room["usage_id"]]
         usage_name = _(tumonline_usage["name"])
@@ -173,7 +173,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
         )
 
     if missing_buildings:
-        logging.warning(
+        _logger.warning(
             f"Ignored {sum(missing_buildings.values())} rooms for the following buildings, "
             f"which were not found: {sorted(missing_buildings.keys())}",
         )
@@ -215,7 +215,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
                 .otherwise(pl.col("sources_base_json"))
                 .alias("sources_base_json"),
                 pl.when(pl.col("sources_patched_update") == True)  # noqa: E712
-                .then(pl.lit(True))
+                .then(pl.lit(value=True))
                 .otherwise(pl.col("sources_patched"))
                 .alias("sources_patched"),
             )
@@ -224,8 +224,8 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
     parentless = df.filter(pl.col("parents").is_null())
     if parentless.height > 0:
         for row in parentless.iter_rows(named=True):
-            logging.critical(f"No parents exist for {row['id']}")
-        logging.critical("This is probably the case, because roompatches were renamed upstream")
+            _logger.critical(f"No parents exist for {row['id']}")
+        _logger.critical("This is probably the case, because roompatches were renamed upstream")
         raise RuntimeError("Invariant not preserved")
 
     return df
@@ -249,7 +249,7 @@ def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
     invalid_rooms: list[str] = []
     for room_code, room in rooms.items():
         if not room["arch_name"] or not room["alt_name"]:
-            logging.warning(
+            _logger.warning(
                 f"ignoring {room_code} as it has arch_name={room['arch_name']!r}, alt_name={room['alt_name']!r}"
             )
             invalid_rooms.append(room_code)
@@ -257,12 +257,12 @@ def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
         # Validate the room_code
         roomcode_split = room_code.split(".")
         if len(roomcode_split) != 3:
-            logging.warning(f"Invalid roomcode: Not three '.'-separated parts: {room_code}")
+            _logger.warning(f"Invalid roomcode: Not three '.'-separated parts: {room_code}")
             invalid_rooms.append(room_code)
             continue
         roomcode_parts: tuple[str, str, str] = (roomcode_split[0], roomcode_split[1], roomcode_split[2])
         if len(set(room_code) - ALLOWED_ROOMCODE_CHARS) > 0:
-            logging.warning(
+            _logger.warning(
                 f"Invalid character(s) in roomcode '{room_code}': {set(room_code) - ALLOWED_ROOMCODE_CHARS}",
             )
             invalid_rooms.append(room_code)
@@ -273,12 +273,12 @@ def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
         # Validate the arch_name.
         arch_name_split = room["arch_name"].split("@")
         if len(arch_name_split) != 2:
-            logging.warning(f"Invalid arch_name: No '@' in '{room['arch_name']}' (room {room_code})")
+            _logger.warning(f"Invalid arch_name: No '@' in '{room['arch_name']}' (room {room_code})")
             invalid_rooms.append(room_code)
             continue
         arch_name_parts: tuple[str, str] = (arch_name_split[0], arch_name_split[1])
         if len(arch_name_parts[1]) != 4 or not arch_name_parts[1].isdigit():
-            logging.warning(
+            _logger.warning(
                 f"Invalid building specification in arch_name: Not four digits: "
                 f"'{arch_name_parts[1]}' in '{room['arch_name']}' (room {room_code})",
             )
@@ -287,7 +287,7 @@ def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
         _infer_arch_name(room, arch_name_parts, used_arch_names, roomcode_parts, rooms)
 
     if invalid_rooms:
-        logging.warning(f"Ignored {len(invalid_rooms)} TUMonline rooms because they are invalid.")
+        _logger.warning(f"Ignored {len(invalid_rooms)} TUMonline rooms because they are invalid.")
         for room_code in invalid_rooms:
             rooms.pop(room_code)
 
@@ -324,7 +324,7 @@ def _infer_arch_name(
             pass
         else:
             # TODO: This code section might need to be continued
-            # logging.debug(f"{r["arch_name"]=}, {roomcode_parts[2]=}")
+            # _logger.debug(f"{r["arch_name"]=}, {roomcode_parts[2]=}")
             pass
 
     # Check for duplicate uses of arch names
@@ -383,13 +383,11 @@ def _maybe_set_alt_name(room_code: str, arch_name_parts: tuple[str, str], room: 
         room["arch_name"] = "@".join(arch_name_parts)
         room["alt_name"] = ", ".join(alt_parts[1:])
         room["patched"] = True
-    # The same might appear the other way round (e.g. "N 1070 ZG" and "N1070ZG")
-    elif alt_parts[0][:2] in {"N ", "R "} and arch_name_parts[0] == alt_parts[0].replace(" ", ""):
-        room["alt_name"] = ", ".join(alt_parts[1:])
-        room["patched"] = True
-    # The second most common mismatch is if the roomname in the alt_name is prepended with the abbrev of the building
-    # Example: "MW 1050"
-    elif any(alt_parts[0].startswith(s) for s in ["PH ", "MW ", "WSI ", "CH ", "MI "]):
+    # The same might appear the other way round (e.g. "N 1070 ZG" and "N1070ZG"),
+    # or the roomname in the alt_name is prepended with the abbrev of the building (e.g. "MW 1050").
+    elif (alt_parts[0][:2] in {"N ", "R "} and arch_name_parts[0] == alt_parts[0].replace(" ", "")) or any(
+        alt_parts[0].startswith(s) for s in ["PH ", "MW ", "WSI ", "CH ", "MI "]
+    ):
         room["alt_name"] = ", ".join(alt_parts[1:])
         room["patched"] = True
     # If the roomname has a comma, the comparison by parts fails
@@ -403,7 +401,7 @@ def _maybe_set_alt_name(room_code: str, arch_name_parts: tuple[str, str], room: 
         room["alt_name"] = ", ".join(alt_parts[2:])
         room["patched"] = True
     else:
-        logging.debug(
+        _logger.debug(
             f"(alt_name / arch_name mismatch): {alt_parts[0]=} {arch_name_parts[0]=} {room_code=}",
         )
     if room["alt_name"] is not None:

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -80,7 +80,7 @@ def merge_tumonline_buildings(df: pl.DataFrame) -> pl.DataFrame:
     return result.drop(["tumonline_data_json_new", "props_ids_b_id_new"])
 
 
-_BUILDING_TYPES = pl.Series(["building", "joined_building"])
+_BUILDING_TYPES = ["building", "joined_building"]
 
 
 def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:

--- a/data/utils.py
+++ b/data/utils.py
@@ -111,7 +111,7 @@ def convert_to_webp(source: Path) -> None:
 
     image = Image.open(source)
     image.save(destination, format="webp")
-    os.remove(source)
+    source.unlink()
 
 
 def setup_logging(level: int = logging.INFO) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,46 @@ indent-width = 4
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "W", "RUF", "UP", "D"]
+select = [
+  # pycodestyle / pyflakes / docstrings — fundamentals
+  "E", "W", "F", "D",
+  # ruff-specific, pyupgrade
+  "RUF", "UP",
+  # bug catchers
+  "B",     # flake8-bugbear (mutable defaults, zip-without-strict, …)
+  "DTZ",   # naive datetime usage
+  "PYI",   # type-stub issues
+  "YTT",   # sys.version misuse
+  # imports
+  "I",     # isort (sort imports)
+  "ICN",   # canonical aliases (np, pd, pl, …)
+  "TID",   # tidy-imports (no relative, no banned)
+  "FA",    # `from __future__ import annotations` where it helps
+  # logging
+  "LOG",   # mis-use of the `logging` stdlib module
+  "G",     # logging format (G004 disabled below)
+  # naming
+  "N",     # pep8-naming
+  # comprehensions, performance, simplification
+  "C4",    # flake8-comprehensions
+  "PERF",  # micro-perf foot-guns
+  "SIM",   # flake8-simplify
+  "PIE",   # misc lints
+  "FLY",   # static `str.join` → f-string
+  "RET",   # branches around `return`
+  "RSE",   # `raise Exception()` → `raise Exception`
+  # paths / fs / exec
+  "PTH",   # prefer pathlib over os.path
+  "EXE",   # executable shebang sanity
+  # api ergonomics
+  "ARG",   # unused arguments
+  "FBT",   # boolean-trap (positional bools)
+  "PT",    # pytest style
+  "T20",   # leftover prints
+  # numpy / type-checking placement
+  "NPY",   # numpy-specific
+  "TC",    # type-checking imports placement
+]
 ignore = [
   #### modules
   "EM", # no formatting in exceptions (why is this a rule?)
@@ -115,7 +154,13 @@ ignore = [
 
   #### rules
   "SIM108", # ternary operator should be used without a concearn for the code complexity
-  "G004", # while if all parameters had
+  "G004", # f-strings in logging are fine; lazy %-formatting rarely worth the readability cost
+  "TC001", # runtime imports in TYPE_CHECKING — pydantic/dataframely need the symbols at runtime
+  "TC002",
+  "TC003",
+  "FBT001", # boolean-trap on definitions is too opinionated for internal helpers
+  "FBT002",
+  "PT011", # `pytest.raises(Exception)` without `match=` — too noisy in current tests
 
   # docstrings
   "D100", # Missing docstring in public module => too much work
@@ -151,6 +196,22 @@ unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+# pytest activates fixtures via parameter name; the body may not reference them.
+"**/test_*.py" = ["ARG001", "ARG002"]
+"**/tests/**" = ["ARG001", "ARG002"]
+
+[tool.ruff.lint.pep8-naming]
+# `dataframely` rules and pydantic validators receive the class as first argument.
+classmethod-decorators = [
+  "classmethod",
+  "pydantic.validator",
+  "pydantic.field_validator",
+  "pydantic.root_validator",
+  "dataframely.rule",
+  "dy.rule",
+]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- Broaden the ruff `select` in `pyproject.toml` from 5 rule families to ~30, picking up bug catchers (`B`, `DTZ`, `PYI`, `YTT`), import hygiene (`I`, `ICN`, `TID`, `FA`), logging correctness (`LOG`, `G` — `G004` left disabled per existing intent), naming (`N` with `dy.rule` / pydantic recognised), simplification/perf (`C4`, `PERF`, `SIM`, `PIE`, `FLY`, `RET`, `RSE`), pathlib (`PTH`), and api ergonomics (`ARG`, `FBT003`, `PT`, `T20`, `TC` placement only).
- Add `[tool.ruff.lint.per-file-ignores]` for pytest fixture-style unused args, and `[tool.ruff.lint.pep8-naming]` `classmethod-decorators` so `@dy.rule()` / pydantic validators don't trip `N805`.
- Fix the resulting violations:
  - 73 root-logger calls → module-level `_logger = logging.getLogger(__name__)` per file
  - unused imports removed, imports re-sorted
  - `RoomNotFoundException` → `RoomNotFoundError`
  - `os.remove` → `Path.unlink`; tz-aware `datetime.now`; `zip(..., strict=True)`
  - mutable default `pl.Utf8()` → module-level constant
  - 15 assign-then-return collapses; two append loops → list comprehensions; merged duplicate elif branches; parenthesised mixed `and`/`or` chains

## Test plan
- [x] `uv run ruff check data` — `All checks passed!`
- [x] `uv run ruff format --check data` — clean
- [x] `uv run pytest data` — 43 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)