### PR TITLE
fix(data): retry tumonline OAuth token fetch on transient failures

### DIFF
--- a/data/external/scrapers/tumonline.py
+++ b/data/external/scrapers/tumonline.py
@@ -5,7 +5,7 @@ import typing
 import backoff
 import polars as pl
 import requests
-from oauthlib.oauth2 import BackendApplicationClient
+from oauthlib.oauth2 import BackendApplicationClient, OAuth2Error
 from requests_oauthlib import OAuth2Session
 from utils import setup_logging
 
@@ -18,6 +18,7 @@ TUMONLINE_URL = "https://campus.tum.de/tumonline"
 CONNECTUM_URL = f"{TUMONLINE_URL}/co/connectum"
 
 
+@backoff.on_exception(backoff.expo, (requests.exceptions.RequestException, OAuth2Error), max_tries=8)
 def _generate_oauth_headers() -> dict[str, str]:
     """
     Generate the OAuth token and packs it into a header form for easier consumption.


### PR DESCRIPTION
## Summary
- Wrap `_generate_oauth_headers()` with `backoff.on_exception` (expo, max_tries=8) catching both `RequestException` and `OAuth2Error` (parent of `MissingTokenError`).
- Motivation: today's [scheduled run](https://github.com/TUM-Dev/NavigaTUM/actions/runs/25035829870/job/73327226514) crashed in `Download tumonline data` with `MissingTokenError: Missing access token parameter` — i.e. the connectum token endpoint responded with a body that did not contain `access_token`. Re-running by hand worked, so the failure is transient (server flake, not a credential or code problem).
- Because the OAuth call lived at module import, one bad response took down the whole scraper, the results dir ended up empty, and the workflow's "fail obvious" guardrail dutifully proposed a PR (#2930) deleting all 5 tumonline CSVs. With backoff in place a brief blip no longer cascades into a destructive auto-PR.

## Test plan
- [ ] Manually dispatch `update-data.yml` once this lands and confirm the download step still succeeds in the happy path.
- [ ] Next time the token endpoint flakes, verify the retry kicks in (look for `backoff` log lines instead of an immediate exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)