### PR TITLE
test(data): show duplicated primary keys when drift-gate fails

### DIFF
--- a/data/external/schemas/_drift_gate.py
+++ b/data/external/schemas/_drift_gate.py
@@ -1,0 +1,40 @@
+"""
+Helper for drift-gate tests that surfaces row-level diagnostics on schema failure.
+
+dataframely's default ``ValidationError`` reports failures as ``"<rule> failed for N rows"``
+which is unactionable when an upstream sync introduces duplicate primary keys (a recurring
+TUMonline drift mode). :func:`assert_satisfies_schema` lists the duplicated keys with their
+occurrence counts so the failure can be patched or escalated without re-running the sync.
+"""
+
+import dataframely as dy
+import polars as pl
+
+
+def assert_satisfies_schema(schema: type[dy.Schema], df: pl.DataFrame) -> None:
+    """Validate ``df`` against ``schema``, raising with row-level diagnostics on failure."""
+    _, failure = schema.filter(df)
+    if len(failure) == 0:
+        return
+
+    counts = failure.counts()
+    pk_cols = schema.primary_key()
+    sections: list[str] = []
+    for rule, count in counts.items():
+        if rule == "primary_key" and pk_cols:
+            duplicates = (
+                df.group_by(pk_cols)
+                .agg(pl.len().alias("occurrences"))
+                .filter(pl.col("occurrences") > 1)
+                .sort("occurrences", *pk_cols, descending=[True, *([False] * len(pk_cols))])
+            )
+            with pl.Config(tbl_rows=50, fmt_str_lengths=80):
+                sections.append(
+                    f"- 'primary_key' failed for {count} row(s); "
+                    f"{duplicates.height} duplicated key(s) on ({', '.join(pk_cols)}):\n"
+                    f"{duplicates}"
+                )
+        else:
+            sections.append(f"- {rule!r} failed for {count} row(s)")
+
+    raise AssertionError(f"{schema.__name__} validation failed:\n" + "\n".join(sections))

--- a/data/external/schemas/test_schemas_public_transport.py
+++ b/data/external/schemas/test_schemas_public_transport.py
@@ -3,12 +3,13 @@ import polars as pl
 import pytest
 
 from external.loaders.public_transport import load_stations
+from external.schemas._drift_gate import assert_satisfies_schema
 from external.schemas.public_transport import StationsSchema
 
 
 def test_committed_stations_parquet_satisfies_schema() -> None:
     """The cached `public_transport.parquet` must satisfy `StationsSchema` (drift gate)."""
-    StationsSchema.validate(load_stations())
+    assert_satisfies_schema(StationsSchema, load_stations())
 
 
 def test_stations_schema_rejects_missing_column() -> None:

--- a/data/external/schemas/test_schemas_roomfinder.py
+++ b/data/external/schemas/test_schemas_roomfinder.py
@@ -3,22 +3,23 @@ import polars as pl
 import pytest
 
 from external.loaders.roomfinder import load_buildings, load_maps, load_rooms
+from external.schemas._drift_gate import assert_satisfies_schema
 from external.schemas.roomfinder import BuildingsSchema, MapsSchema, RoomsSchema
 
 
 def test_committed_buildings_csv_satisfies_schema() -> None:
     """The cached `buildings_roomfinder.csv` must satisfy `BuildingsSchema` (drift gate)."""
-    BuildingsSchema.validate(load_buildings())
+    assert_satisfies_schema(BuildingsSchema, load_buildings())
 
 
 def test_committed_rooms_csv_satisfies_schema() -> None:
     """The cached `rooms_roomfinder.csv` must satisfy `RoomsSchema` (drift gate)."""
-    RoomsSchema.validate(load_rooms())
+    assert_satisfies_schema(RoomsSchema, load_rooms())
 
 
 def test_committed_maps_csv_satisfies_schema() -> None:
     """The cached `maps_roomfinder.csv` must satisfy `MapsSchema` (drift gate)."""
-    MapsSchema.validate(load_maps())
+    assert_satisfies_schema(MapsSchema, load_maps())
 
 
 def test_buildings_schema_rejects_missing_column() -> None:

--- a/data/external/schemas/test_schemas_tumonline.py
+++ b/data/external/schemas/test_schemas_tumonline.py
@@ -5,12 +5,13 @@ import polars as pl
 import pytest
 
 from external.loaders.tumonline import load_buildings, load_orgs, load_rooms, load_usages
+from external.schemas._drift_gate import assert_satisfies_schema
 from external.schemas.tumonline import BuildingsSchema, OrgsSchema, RoomsSchema, UsagesSchema
 
 
 def test_committed_usages_csv_satisfies_schema() -> None:
     """The cached `usages_tumonline.csv` must satisfy `UsagesSchema` (drift gate)."""
-    UsagesSchema.validate(load_usages())
+    assert_satisfies_schema(UsagesSchema, load_usages())
 
 
 def test_usages_schema_rejects_non_positive_id() -> None:
@@ -38,7 +39,7 @@ def test_usages_schema_rejects_missing_column() -> None:
 @pytest.mark.parametrize("lang", ["de", "en"])
 def test_committed_orgs_csv_satisfies_schema(lang: typing.Literal["de", "en"]) -> None:
     """The cached `orgs-{lang}_tumonline.csv` must satisfy `OrgsSchema` (drift gate)."""
-    OrgsSchema.validate(load_orgs(lang))
+    assert_satisfies_schema(OrgsSchema, load_orgs(lang))
 
 
 def test_orgs_schema_rejects_non_positive_id() -> None:
@@ -60,7 +61,7 @@ def test_orgs_schema_rejects_missing_column() -> None:
 
 def test_committed_buildings_csv_satisfies_schema() -> None:
     """The cached `buildings_tumonline.csv` must satisfy `BuildingsSchema` (drift gate)."""
-    BuildingsSchema.validate(load_buildings())
+    assert_satisfies_schema(BuildingsSchema, load_buildings())
 
 
 def test_buildings_schema_rejects_non_four_digit_key() -> None:
@@ -91,7 +92,7 @@ def test_buildings_schema_rejects_missing_column() -> None:
 
 def test_committed_rooms_csv_satisfies_schema() -> None:
     """The cached `rooms_tumonline.csv` must satisfy `RoomsSchema` (drift gate)."""
-    RoomsSchema.validate(load_rooms())
+    assert_satisfies_schema(RoomsSchema, load_rooms())
 
 
 def test_rooms_schema_rejects_non_positive_tumonline_id() -> None:


### PR DESCRIPTION
dataframely's default ValidationError just reports "primary_key failed for N rows", which doesn't tell us *which* keys collided when an upstream TUMonline sync introduces duplicates. ``assert_satisfies_schema`` runs the same validation but lists each duplicated key with its occurrence count so we can patch or escalate without rerunning the sync locally.