### PR TITLE
chore(renovate): enable lockfile maintenance with automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,13 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": [
+      "before 5am on monday"
+    ]
+  },
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary
- Enable Renovate's `lockFileMaintenance` so transitive dependencies in lockfiles get refreshed regularly without waiting for explicit version bumps.
- Automerge the resulting PRs (consistent with the existing automerge policy for grouped non-major updates).
- Run weekly (Monday before 5am Europe/Berlin) to keep noise low.

## Test plan
- [ ] Renovate dry-run / dashboard shows a `lockFileMaintenance` PR queued on the next run.
- [ ] CI on the resulting PR is green and it automerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)