### PR TITLE
chore(ci): run cargo-audit only on schedule

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -27,6 +27,9 @@ jobs:
         - name: Run zizmor
           uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
   cargo-audit:
+    # Only run on the daily schedule. Advisories still file issues, but PRs
+    # aren't blocked when a transitive dep gets a new RUSTSEC entry.
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `if: github.event_name == 'schedule'` to the `cargo-audit` job in `.github/workflows/security.yaml` so it only runs on the daily cron.
- New advisories still file GitHub issues (the job retains `issues: write` and the rustsec/audit-check action), but PRs are no longer broken whenever a transitive dependency picks up a new RUSTSEC entry we can't immediately upgrade.
- The `done` aggregate job already only depends on `zizmor` and `codeql`, so removing cargo-audit from per-PR runs has no effect on merge gating.

## Test plan
- [ ] Confirm the workflow still parses (no syntax errors) once it lands on `main`.
- [ ] On the next scheduled run (`0 0 * * *` UTC), verify the `cargo-audit` job executes and that the issue-creation behaviour for new advisories is unchanged.
- [ ] Open a follow-up PR and confirm the `cargo-audit` job is skipped while `zizmor` / `codeql` / `done` still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)