### PR TITLE
feat(data): add usage_id to known_usages.json

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -215,16 +215,13 @@ def export_known_usages(df: pl.DataFrame) -> None:
     data_dir = Path(__file__).parent.parent
     translations = yaml.safe_load((data_dir / "translations.yaml").read_text(encoding="utf-8"))
 
-    usages_df = (
-        pl.read_csv(
-            data_dir / "external" / "results" / "usages_tumonline.csv",
-            schema_overrides={"din277_id": pl.String, "name": pl.String},
-        )
-        .select(
-            pl.col("name").alias("name_de"),
-            pl.col("din277_id").alias("din_277"),
-        )
-        .unique()
+    usages_df = pl.read_csv(
+        data_dir / "external" / "results" / "usages_tumonline.csv",
+        schema_overrides={"din277_id": pl.String, "name": pl.String},
+    ).select(
+        pl.col("usage_id"),
+        pl.col("name").alias("name_de"),
+        pl.col("din277_id").alias("din_277"),
     )
 
     counts_df = (
@@ -244,8 +241,8 @@ def export_known_usages(df: pl.DataFrame) -> None:
             pl.col("name_de").replace_strict(translations, default=pl.col("name_de")).alias("name_en"),
             pl.col("len").fill_null(0).alias("occurrences"),
         )
-        .select("name_de", "name_en", "din_277", "occurrences")
-        .sort("occurrences", descending=True)
+        .select("usage_id", "name_de", "name_en", "din_277", "occurrences")
+        .sort(["occurrences", "name_de"], descending=[True, False])
     )
 
     (OUTPUT_DIR_PATH / "known_usages.json").write_bytes(

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -20,7 +20,7 @@ const runtimeConfig = useRuntimeConfig();
 const { data: knownUsages } = useAsyncData(
   "known_usages",
   () =>
-    $fetch<{ name_de: string; name_en: string; din_277: string }[]>(
+    $fetch<{ usage_id: number; name_de: string; name_en: string; din_277: string }[]>(
       `${runtimeConfig.public.cdnURL}/cdn/known_usages.json`
     ),
   { default: () => [] }

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -20,7 +20,7 @@ const runtimeConfig = useRuntimeConfig();
 const { data: knownUsages } = useAsyncData(
   "known_usages",
   () =>
-    $fetch<{ usage_id: number; name_de: string; name_en: string; din_277: string }[]>(
+    $fetch<{ usage_id: number; occurrences: number; name_de: string; name_en: string; din_277: string }[]>(
       `${runtimeConfig.public.cdnURL}/cdn/known_usages.json`
     ),
   { default: () => [] }


### PR DESCRIPTION
## Summary
- Project `usage_id` from `usages_tumonline.csv` into `known_usages.json` so the frontend has a stable, precise key per category.
- Drop the `(name_de, din_277)` `.unique()` — `din_277` collides (55 distinct codes across 185 rows), so it isn't a valid key. `usage_id` is.
- Sort the export by `occurrences DESC, name_de ASC` (deterministic tiebreak).
- Update `EditProposalModal.vue`'s typed `$fetch` shape to include `usage_id: number`.

## Test plan
- [ ] Re-run the data export and confirm `known_usages.json` contains `usage_id` on every entry.
- [ ] Verify the row count matches `usages_tumonline.csv` (no rows lost from the dropped `.unique()`).
- [ ] Open the edit-proposal modal in the webclient and confirm the category dropdown still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)