### PR TITLE
fix(webclient): merge duplicate useI18n call in PreferencesPopup

### DIFF
--- a/webclient/app/components/PreferencesPopup.vue
+++ b/webclient/app/components/PreferencesPopup.vue
@@ -20,10 +20,9 @@ import {
 } from "@mdi/js";
 
 const colorMode = useColorMode();
-const { t } = useI18n({ useScope: "local" });
+const { t, locale } = useI18n({ useScope: "local" });
 const { preferences, updatePreference } = useUserPreferences();
 
-const { locale } = useI18n();
 const switchLocalePath = useSwitchLocalePath();
 
 const isOpen = ref(false);


### PR DESCRIPTION
## Summary
- Fixes the runtime warning `[intlify] Duplicate \`useI18n\` calling by local scope. Please don't call it on local scope, due to it does not work properly in component` originating from `PreferencesPopup.vue`.
- The component called `useI18n` twice in the same `<script setup>` (once with `useScope: "local"` for `t`, once globally for `locale`). Now both are destructured from a single local-scope call.

## Test plan
- [ ] `pnpm dev` in `webclient/`, open the preferences popup, confirm the intlify duplicate-scope warning is gone from the console.
- [ ] Switch language via the popup and verify the locale change still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)