### PR TITLE
chore(data): add image for `muc`

### DIFF
--- a/data/sources/img/img-sources.yaml
+++ b/data/sources/img/img-sources.yaml
@@ -1217,6 +1217,12 @@ mri:
     author: Klinikums rechts der Isar
     license:
       text: Verwendung frei für Berichterstattung über die TU München und das Klinikums rechts der Isarunter Nennung des Copyrights / Free for use in reporting on TU München and Klinikums rechts der Isar with the copyright noted.
+muc:
+  0:
+    author: TUM CST
+    license:
+      text: CC BY 4.0
+      url: https://creativecommons.org/licenses/by/4.0/
 mw:
   0:
     author: Renardo la vulpo


### PR DESCRIPTION
## Batched Edits

### Edit #1
## Additional context:
> Das Gebäude heißt TUMorrow Hub

The following image edits were made:
| entry | edit |
| ---   | ---  |
| [`muc`](https://nav.tum.de/view/muc) | ![image showing muc](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/usergenerated/request-50631/data/sources/img/lg/muc_0.webp) |
