### PR TITLE
fix(data): move Lärmschutzhalle 344 from MUC to Oberpfaffenhofen

### DIFF
--- a/data/processors/areatree/config.areatree
+++ b/data/processors/areatree/config.areatree
@@ -503,9 +503,10 @@
     9110:Geigergebäude|GP:
   9201:TUM FZ Friedrich N. Schwarz Berchtesgaden:
   :München Flughafen|MUC:muc[site]
-    9344:Lärmschutzhalle 344:
     9510:LabCampus 48 (AM):
     9511:LabCampus 52 (AM):
+  :Sonderflughafen Oberpfaffenhofen|OBF:oberpfaffenhofen[site]
+    9344:Lärmschutzhalle 344:
   93:Taufkirchen / Ottobrunn (Luftfahrt, Raumfahrt und Geodäsie)|Taufkirchen/Ottobr.:taufkirchen-ottobrunn[campus]
     9377:Lise-Meitner-Straße 9-11:
     9378:TUM Panasonic (Caroline-Herschel-Straße 100):

--- a/data/sources/01_areas-extended.yaml
+++ b/data/sources/01_areas-extended.yaml
@@ -982,8 +982,8 @@ taufkirchen-ottobrunn:
     lon: 11.061414
 9344:
   coords:
-    lat: 48.344112
-    lon: 11.746225
+    lat: 48.0843
+    lon: 11.2970
 9377:
   coords:
     lat: 48.05453


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary

- Building `9344` (*Lärmschutzhalle 344*) was previously parented under `muc` (München Flughafen) with coordinates at Munich Airport, but the registered address is *Claude-Dornier-Str. 1, 82234 Weßling* — the DLR Special Airport Oberpfaffenhofen site.
- Added a new top-level site `oberpfaffenhofen` (`Sonderflughafen Oberpfaffenhofen|OBF`) as a peer of `muc`, and moved `9344` under it.
- Updated `9344` coordinates from `48.344112, 11.746225` to `48.0843, 11.2970` — the latter is approximately the location of the neighbouring `Geb. 345` on the DLR Oberpfaffenhofen apron (closest known reference point from OSM). The exact within-site position may want a follow-up refinement via the usual coordinate-edit PR pattern.

Closes #2985

## Test plan

- [x] `pytest data/processors/areatree` passes (22/22)
- [x] `python data/compile.py` succeeds
- [x] Verified in `data/output/api_data.json`:
  - `9344` → parents `['root', 'oberpfaffenhofen']`, coords at Oberpfaffenhofen
  - new `oberpfaffenhofen` site appears with inferred coords
  - `muc` coords now correctly average the two LabCampus buildings (48.354, 11.754) — no longer pulled south by the misplaced 9344