### PR TITLE
fix(server): preserve full CSV schema when applying property edits

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -41,20 +41,9 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2026-0045,RUSTSEC-2026-0046,RUSTSEC-2026-0047,RUSTSEC-2026-0044,RUSTSEC-2026-0048,RUSTSEC-2026-0049,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2024-0436,RUSTSEC-2025-0141,RUSTSEC-2026-0097
-          # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing sidechannels => not used explicitly
-          # RUSTSEC-2026-0045 = Timing side-channel in AES-CCM tag verification in AWS-LC => transitive through aws-lc-sys and awaiting upstream dependency updates
-          # RUSTSEC-2026-0046 = PKCS7_verify certificate chain validation bypass in AWS-LC => transitive through aws-lc-sys and awaiting upstream dependency updates
-          # RUSTSEC-2026-0047 = PKCS7_verify signature validation bypass in AWS-LC => transitive through aws-lc-sys and awaiting upstream dependency updates
-          # RUSTSEC-2026-0044 = AWS-LC X.509 name constraints bypass via wildcard/Unicode CN => transitive through aws-lc-sys and awaiting upstream dependency updates
-          # RUSTSEC-2026-0048 = CRL distribution point scope check logic error in AWS-LC => transitive through aws-lc-sys and awaiting upstream dependency updates
-          # RUSTSEC-2026-0049 = rustls-webpki CRL distribution point matching bug => transitive through rustls-webpki and awaiting upstream dependency updates
-          # RUSTSEC-2026-0098 = rustls-webpki URI name constraints were incorrectly accepted => transitive through rustls-webpki and awaiting upstream dependency updates
-          # RUSTSEC-2026-0099 = rustls-webpki wildcard DNS name constraints were incorrectly accepted => transitive through rustls-webpki and awaiting upstream dependency updates
-          # RUSTSEC-2026-0104 = Reachable panic in certificate revocation list parsing in rand => transitive through testcontainers/bollard and awaiting upstream dependency updates
-          # RUSTSEC-2026-0097 = Rand is unsound with a custom logger using rand::rng() => transitive through testcontainers/bollard and awaiting upstream dependency updates
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2024-0436
+          # RUSTSEC-2023-0071 = Marvin Attack: potential key recovery through timing sidechannels => rsa is only pulled by sqlx-mysql, which is an optional sqlx-macros-core dep that is not actually compiled (we only enable the `postgres` feature on sqlx)
           # RUSTSEC-2024-0436 = paste is unmaintained => transitive through imageproc/nalgebra/simba and rav1e, awaiting upstream updates
-          # RUSTSEC-2025-0141 = bincode is unmaintained => transitive through polars, awaiting upstream updates
   codeql:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3211,7 @@ dependencies = [
  "bytes",
  "chroma-forge",
  "chrono",
+ "csv",
  "fast_qr",
  "futures",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -60,7 +60,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "derive_more",
  "futures-core",
@@ -97,7 +97,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -248,7 +248,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "time",
  "tracing",
  "url",
@@ -599,7 +599,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "itoa",
@@ -623,7 +623,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "mime",
@@ -659,9 +659,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -701,7 +701,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -709,7 +709,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1354,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1414,18 +1414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2024,7 +2012,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2120,36 +2108,11 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -2179,27 +2142,6 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.25.2",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.4",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hickory-resolver"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
@@ -2207,7 +2149,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni",
@@ -2264,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2279,7 +2221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -2290,7 +2232,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -2324,16 +2266,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -2365,7 +2307,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "log",
@@ -2400,14 +2342,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2701,7 +2643,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2892,14 +2834,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2952,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"
@@ -3102,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -3143,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -3178,24 +3120,9 @@ name = "motis-openapi-progenitor"
 version = "0.4.0"
 dependencies = [
  "chrono",
- "progenitor-client 0.14.0",
+ "progenitor-client",
  "reqwest 0.13.4",
  "serde",
-]
-
-[[package]]
-name = "motis-openapi-progenitor"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbabd8afe8f7407f4cccd5c6e6a7894579f90b3a95db125ec9c98eb1dced256"
-dependencies = [
- "bytes",
- "chrono",
- "futures-core",
- "progenitor-client 0.11.2",
- "reqwest 0.12.28",
- "serde",
- "serde_urlencoded",
 ]
 
 [[package]]
@@ -3273,7 +3200,7 @@ dependencies = [
  "logos",
  "meilisearch-sdk",
  "moka",
- "motis-openapi-progenitor 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "motis-openapi-progenitor",
  "oauth2",
  "oauth2-reqwest",
  "octocrab",
@@ -3476,7 +3403,7 @@ dependencies = [
  "base64",
  "chrono",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -3512,7 +3439,7 @@ dependencies = [
  "futures",
  "futures-util",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3831,7 +3758,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3947,21 +3874,6 @@ dependencies = [
 
 [[package]]
 name = "progenitor-client"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a0beb939758f229cbae70a4889c7c76a4ac0e90f0b1e7ae9b4636a927d1018"
-dependencies = [
- "bytes",
- "futures-core",
- "percent-encoding",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "serde_urlencoded",
-]
-
-[[package]]
-name = "progenitor-client"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e8a874cf25a33cac7a01b9c1de87bcfbc8aea93f3156d09dcc3bee516a78926"
@@ -4070,7 +3982,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4108,7 +4020,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4276,7 +4188,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4311,16 +4223,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4395,8 +4307,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "hickory-resolver 0.25.2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4404,18 +4315,13 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4425,7 +4331,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4441,8 +4346,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "hickory-resolver 0.26.1",
- "http 1.4.0",
+ "hickory-resolver",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4620,7 +4525,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4645,9 +4550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4716,7 +4621,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytemuck",
  "core_maths",
  "log",
@@ -4806,7 +4711,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5031,9 +4936,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -5199,9 +5104,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5331,7 +5236,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -5374,7 +5279,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "chrono",
  "crc",
@@ -5576,7 +5481,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5626,7 +5531,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "itertools",
  "log",
  "memchr",
@@ -5831,7 +5736,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5892,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -5922,7 +5827,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5930,7 +5835,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -5977,11 +5882,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -6150,9 +6055,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -6213,9 +6118,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -6292,7 +6197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -6400,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6621,7 +6526,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6729,7 +6634,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7103,7 +7008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -7186,9 +7091,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7209,18 +7114,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ base64 = "0.22.1"
 bytes = "1"
 chroma-forge = "1.0.0"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
+csv = "1.3"
 fast_qr = { version = "0.13.1", features = ["image"] }
 futures = "0.3.32"
 image = { version = "0.25.9", default-features = false, features = ["jpeg", "png", "webp"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -75,6 +75,7 @@ actix-governor = { workspace=true, features = ["logger"] }
 tempfile.workspace=true
 base64.workspace=true
 bytes.workspace=true
+csv.workspace=true
 parquet = { workspace=true, default-features = false, features = ["zstd"] }
 
 # geodata

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,7 +49,7 @@ sqlx = { workspace=true, features = ['chrono', 'json', 'macros', 'migrate', 'pos
 chrono = { workspace=true, default-features = false, features = ["serde"] }
 
 # search
-meilisearch-sdk = {version="0.33.0", default-features = false, features = ["reqwest", "jwt_aws_lc_rs"]}
+meilisearch-sdk.workspace = true
 logos.workspace=true
 regex.workspace=true
 
@@ -80,7 +80,7 @@ parquet = { workspace=true, default-features = false, features = ["zstd"] }
 # geodata
 actix-middleware-etag.workspace=true
 valhalla-client = { workspace=true, default-features = false }
-motis-openapi-progenitor = "0.4.0"
+motis-openapi-progenitor.workspace = true
 chroma-forge.workspace=true
 
 # docs

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -67,13 +67,14 @@ COPY    motis-openapi-progenitor/Cargo.* ./motis-openapi-progenitor/
 RUN     mkdir -p ./server/src/ \
         && echo "fn main() { println!(\"Hello, world!\");}" > server/src/main.rs \
         && mkdir -p ./motis-openapi-progenitor/src/ \
-        && echo "fn main() { println!(\"Hello, world!\");}" > motis-openapi-progenitor/src/main.rs \
+        && : > motis-openapi-progenitor/src/lib.rs \
         && if [ $PROFILE == "release" ]; then cargo build --release; else cargo build; fi \
-        && rm -fr target/${PROFILE}/deps/navigatum*
+        && rm -fr target/${PROFILE}/deps/navigatum* target/${PROFILE}/deps/*motis_openapi_progenitor*
 
 # second run of the image build (including our code)
 COPY    server/.sqlx server/.sqlx
 
+COPY    motis-openapi-progenitor/src motis-openapi-progenitor/src
 COPY    server/src server/src
 COPY    server/migrations server/migrations
 RUN     if [ $PROFILE == "release" ]; then \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -75,6 +75,7 @@ RUN     mkdir -p ./server/src/ \
 COPY    server/.sqlx server/.sqlx
 
 COPY    motis-openapi-progenitor/src motis-openapi-progenitor/src
+COPY    motis-openapi-progenitor/README.md motis-openapi-progenitor/README.md
 COPY    server/src server/src
 COPY    server/migrations server/migrations
 RUN     if [ $PROFILE == "release" ]; then \

--- a/server/src/routes/feedback/proposed_edits/property.rs
+++ b/server/src/routes/feedback/proposed_edits/property.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -44,10 +45,8 @@ impl PropertyEdit {
         key: &str,
         base_dir: &Path,
         csv_path_fn: fn(&Path) -> PathBuf,
-        new_fields: Vec<String>,
+        new_fields: &[String],
     ) -> anyhow::Result<()> {
-        use std::io::{BufWriter, Write as _};
-
         let csv_file = csv_path_fn(base_dir);
         let temp_file = csv_file.with_extension("tmp");
 
@@ -85,7 +84,7 @@ impl PropertyEdit {
                             .map(ToString::to_string)
                             .collect()
                     });
-                    write_padded_row(&mut writer, &new_fields, col_count, extras.as_deref())?;
+                    write_padded_row(&mut writer, new_fields, col_count, extras.as_deref())?;
                     wrote_edit = true;
                     if existing_key == key {
                         continue;
@@ -101,7 +100,7 @@ impl PropertyEdit {
             }
 
             if !wrote_edit {
-                write_padded_row(&mut writer, &new_fields, col_count, None)?;
+                write_padded_row(&mut writer, new_fields, col_count, None)?;
             }
         }
 
@@ -110,12 +109,12 @@ impl PropertyEdit {
     }
 }
 
-fn write_padded_row<W: std::io::Write>(
+fn write_padded_row<W: Write>(
     writer: &mut W,
     new_fields: &[String],
     col_count: usize,
     extras: Option<&[String]>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let mut fields: Vec<String> = new_fields.iter().map(|f| csv_escape(f)).collect();
     let known = new_fields.len();
     if col_count > known {
@@ -151,7 +150,7 @@ impl AppliableEdit for PropertyEdit {
                     key,
                     base_dir,
                     Self::names_csv_path,
-                    vec![key.to_string(), name_val.to_string(), short_val.to_string()],
+                    &[key.to_string(), name_val.to_string(), short_val.to_string()],
                 )?;
                 Ok(format!("name: `{name_val}`, short_name: `{short_val}`"))
             }
@@ -167,7 +166,7 @@ impl AppliableEdit for PropertyEdit {
                     key,
                     base_dir,
                     Self::usages_csv_path,
-                    vec![
+                    &[
                         key.to_string(),
                         name_de.clone(),
                         name_en.clone(),

--- a/server/src/routes/feedback/proposed_edits/property.rs
+++ b/server/src/routes/feedback/proposed_edits/property.rs
@@ -61,7 +61,15 @@ impl PropertyEdit {
         {
             let output = File::create(&temp_file)?;
             let mut writer = BufWriter::new(output);
-            writeln!(writer, "{}", header.iter().map(|h| csv_escape(h)).collect::<Vec<_>>().join(","))?;
+            writeln!(
+                writer,
+                "{}",
+                header
+                    .iter()
+                    .map(|h| csv_escape(h))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            )?;
 
             let mut wrote_edit = false;
 

--- a/server/src/routes/feedback/proposed_edits/property.rs
+++ b/server/src/routes/feedback/proposed_edits/property.rs
@@ -44,50 +44,85 @@ impl PropertyEdit {
         key: &str,
         base_dir: &Path,
         csv_path_fn: fn(&Path) -> PathBuf,
-        header: &str,
-        make_line: impl FnOnce() -> String,
+        new_fields: Vec<String>,
     ) -> anyhow::Result<()> {
-        use std::io::{BufRead as _, BufReader, BufWriter, Write as _};
+        use std::io::{BufWriter, Write as _};
 
         let csv_file = csv_path_fn(base_dir);
         let temp_file = csv_file.with_extension("tmp");
 
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .flexible(true)
+            .from_path(&csv_file)?;
+        let header: Vec<String> = reader.headers()?.iter().map(ToString::to_string).collect();
+        let col_count = header.len();
+
         {
             let output = File::create(&temp_file)?;
             let mut writer = BufWriter::new(output);
-            writeln!(writer, "{header}")?;
+            writeln!(writer, "{}", header.iter().map(|h| csv_escape(h)).collect::<Vec<_>>().join(","))?;
 
             let mut wrote_edit = false;
-            let new_line = make_line();
 
-            {
-                let input = File::open(&csv_file)?;
-                for line in BufReader::new(input)
-                    .lines()
-                    .skip(1)
-                    .map_while(Result::ok)
-                    .filter(|l| !l.trim().is_empty())
-                {
-                    if let Some(existing_key) = line.split(',').next() {
-                        if !wrote_edit && existing_key >= key {
-                            wrote_edit = true;
-                            writeln!(writer, "{new_line}")?;
-                        }
-                        if existing_key != key {
-                            writeln!(writer, "{line}")?;
-                        }
+            for record in reader.records() {
+                let record = record?;
+                let existing_key = record.get(0).unwrap_or("");
+
+                if !wrote_edit && existing_key >= key {
+                    let extras: Option<Vec<String>> = (existing_key == key).then(|| {
+                        record
+                            .iter()
+                            .skip(new_fields.len())
+                            .map(ToString::to_string)
+                            .collect()
+                    });
+                    write_padded_row(&mut writer, &new_fields, col_count, extras.as_deref())?;
+                    wrote_edit = true;
+                    if existing_key == key {
+                        continue;
                     }
+                }
+                if existing_key != key {
+                    writeln!(
+                        writer,
+                        "{}",
+                        record.iter().map(csv_escape).collect::<Vec<_>>().join(",")
+                    )?;
                 }
             }
 
             if !wrote_edit {
-                writeln!(writer, "{new_line}")?;
+                write_padded_row(&mut writer, &new_fields, col_count, None)?;
             }
         }
 
         fs::rename(&temp_file, &csv_file)?;
         Ok(())
     }
+}
+
+fn write_padded_row<W: std::io::Write>(
+    writer: &mut W,
+    new_fields: &[String],
+    col_count: usize,
+    extras: Option<&[String]>,
+) -> std::io::Result<()> {
+    let mut fields: Vec<String> = new_fields.iter().map(|f| csv_escape(f)).collect();
+    let known = new_fields.len();
+    if col_count > known {
+        let trailing = col_count - known;
+        if let Some(ex) = extras {
+            for i in 0..trailing {
+                fields.push(ex.get(i).map(|s| csv_escape(s)).unwrap_or_default());
+            }
+        } else {
+            for _ in 0..trailing {
+                fields.push(String::new());
+            }
+        }
+    }
+    writeln!(writer, "{}", fields.join(","))
 }
 
 fn csv_escape(s: &str) -> String {
@@ -108,15 +143,7 @@ impl AppliableEdit for PropertyEdit {
                     key,
                     base_dir,
                     Self::names_csv_path,
-                    "id,name,short_name,arch_name",
-                    || {
-                        format!(
-                            "{},{},{},",
-                            csv_escape(key),
-                            csv_escape(name_val),
-                            csv_escape(short_val)
-                        )
-                    },
+                    vec![key.to_string(), name_val.to_string(), short_val.to_string()],
                 )?;
                 Ok(format!("name: `{name_val}`, short_name: `{short_val}`"))
             }
@@ -132,17 +159,13 @@ impl AppliableEdit for PropertyEdit {
                     key,
                     base_dir,
                     Self::usages_csv_path,
-                    "id,name_de,name_en,din_277,din_277_desc",
-                    || {
-                        format!(
-                            "{},{},{},{},{}",
-                            csv_escape(key),
-                            csv_escape(name_de),
-                            csv_escape(name_en),
-                            csv_escape(din),
-                            csv_escape(din_desc),
-                        )
-                    },
+                    vec![
+                        key.to_string(),
+                        name_de.clone(),
+                        name_en.clone(),
+                        din.to_string(),
+                        din_desc.to_string(),
+                    ],
                 )?;
                 Ok(format!(
                     "usage: `{name_de}` / `{name_en}` (DIN 277: `{din}`)"
@@ -190,21 +213,16 @@ mod tests {
 
     use super::*;
 
+    const NAMES_HEADER: &str = "id,name,short_name,arch_name";
+    const USAGES_HEADER: &str = "id,name_de,name_en,din_277,din_277_desc,din277_name";
+
     fn setup() -> (tempfile::TempDir, PathBuf) {
         let dir = tempfile::TempDir::new().unwrap();
         let sources_dir = dir.path().join("data").join("sources");
         fs::create_dir_all(&sources_dir).unwrap();
 
-        fs::write(
-            sources_dir.join("names.csv"),
-            "id,name,short_name,arch_name\n",
-        )
-        .unwrap();
-        fs::write(
-            sources_dir.join("usages.csv"),
-            "id,name_de,name_en,din_277,din_277_desc\n",
-        )
-        .unwrap();
+        fs::write(sources_dir.join("names.csv"), format!("{NAMES_HEADER}\n")).unwrap();
+        fs::write(sources_dir.join("usages.csv"), format!("{USAGES_HEADER}\n")).unwrap();
 
         (dir, sources_dir)
     }
@@ -229,7 +247,7 @@ mod tests {
         let (dir, sources_dir) = setup();
         fs::write(
             sources_dir.join("names.csv"),
-            "id,name,short_name,arch_name\nalpha,A,,\nzulu,Z,,\n",
+            format!("{NAMES_HEADER}\nalpha,A,,\nzulu,Z,,\n"),
         )
         .unwrap();
 
@@ -247,11 +265,11 @@ mod tests {
     }
 
     #[test]
-    fn test_name_edit_update() {
+    fn test_name_edit_preserves_arch_name() {
         let (dir, sources_dir) = setup();
         fs::write(
             sources_dir.join("names.csv"),
-            "id,name,short_name,arch_name\nalpha,Old,,\n",
+            format!("{NAMES_HEADER}\nalpha,Old,SN,1951\n"),
         )
         .unwrap();
 
@@ -262,12 +280,12 @@ mod tests {
         edit.apply("alpha", dir.path(), "branch").unwrap();
         assert_snapshot!(fs::read_to_string(sources_dir.join("names.csv")).unwrap(), @r"
         id,name,short_name,arch_name
-        alpha,New,N,
+        alpha,New,N,1951
         ");
     }
 
     #[test]
-    fn test_usage_edit() {
+    fn test_usage_edit_insert_pads_to_full_width() {
         let (dir, sources_dir) = setup();
         let edit = PropertyEdit::Usage {
             name_de: "Büro".to_string(),
@@ -278,8 +296,29 @@ mod tests {
         let desc = edit.apply("room1", dir.path(), "branch").unwrap();
         assert_snapshot!(desc, @"usage: `Büro` / `Office` (DIN 277: `NF2.1`)");
         assert_snapshot!(fs::read_to_string(sources_dir.join("usages.csv")).unwrap(), @r"
-        id,name_de,name_en,din_277,din_277_desc
-        room1,Büro,Office,NF2.1,Büroräume
+        id,name_de,name_en,din_277,din_277_desc,din277_name
+        room1,Büro,Office,NF2.1,Büroräume,
+        ");
+    }
+
+    #[test]
+    fn test_usage_edit_preserves_din277_name() {
+        let (dir, sources_dir) = setup();
+        fs::write(
+            sources_dir.join("usages.csv"),
+            format!("{USAGES_HEADER}\nroom1,Werkstatt,Workshop,NF3.2,,Werkstätten\n"),
+        )
+        .unwrap();
+        let edit = PropertyEdit::Usage {
+            name_de: "Labor".to_string(),
+            name_en: "Lab".to_string(),
+            din_277: Some("NF3.3".to_string()),
+            din_277_desc: Some("Labor".to_string()),
+        };
+        edit.apply("room1", dir.path(), "branch").unwrap();
+        assert_snapshot!(fs::read_to_string(sources_dir.join("usages.csv")).unwrap(), @r"
+        id,name_de,name_en,din_277,din_277_desc,din277_name
+        room1,Labor,Lab,NF3.3,Labor,Werkstätten
         ");
     }
 


### PR DESCRIPTION
## Summary

- `apply_csv_edit` hardcoded the CSV header and column count, which drifted out of sync with `data/sources/usages.csv` after `din277_name` was added. Result: property edits dropped that column from the header and emitted narrower rows, producing structurally broken PRs (#3044, #3045, #3046).
- Now the header is read from the existing file and preserved verbatim. New rows are padded to the file's column count, and trailing columns on an updated row are carried over from the existing row — so a name edit can no longer silently wipe `arch_name` either.
- Tests use the real CSV headers as constants so future column additions force a tests-side update; regressions for both `din277_name` and `arch_name` preservation are added.

## Test plan

- [x] `cargo test -p navigatum-server proposed_edits::property` — 8 tests pass
- [x] `cargo clippy -p navigatum-server --tests` clean for `property.rs`
- [ ] Re-submit one of the broken edits through the API after deploy and confirm the resulting PR has a clean diff