### PR TITLE
fix(server): authenticate batch-PR lookup

### DIFF
--- a/server/src/external/github.rs
+++ b/server/src/external/github.rs
@@ -154,8 +154,9 @@ impl GitHub {
     /// Find an open PR with a specific label
     #[tracing::instrument]
     pub async fn find_pr_with_label(self, label: &str) -> anyhow::Result<Option<(u64, String)>> {
-        // Listing PRs on a public repo does not require auth
-        let octocrab = Octocrab::default();
+        let Some(octocrab) = self.octocrab else {
+            anyhow::bail!("GitHub client not initialized");
+        };
 
         // Search through all pages of open PRs to find one with the label
         let mut page = octocrab


### PR DESCRIPTION
## Summary

- `find_pr_with_label` explicitly used `Octocrab::default()` (unauthenticated). Anonymous GitHub API is rate-limited to 60 req/h per IP. Once that bucket is exhausted, every batch lookup returns an error — the caller (`find_open_batch_pr`) swallows it as "no open batch PR" and opens a fresh PR.
- That's why #3044 / #3045 / #3046 / #3047 all carry the \`batch-in-progress\` label but never reused each other: none of them ever *saw* an existing batch.
- Switch to the authenticated client the rest of \`GitHub\` already uses (5000 req/h). Error swallowing in the caller stays as-is per request.

## Test plan

- [x] \`cargo check -p navigatum-server\` clean
- [ ] After deploy, submit two webform edits back-to-back and confirm the second lands on the same PR as the first