### PR TITLE
fix(webclient): hide empty subtext line in search results

### DIFF
--- a/webclient/app/components/SearchResultItem.vue
+++ b/webclient/app/components/SearchResultItem.vue
@@ -26,10 +26,16 @@ defineProps<{
         </div>
         <span v-else class="line-clamp-1" v-html="item.name" />
       </div>
-      <small>
+      <small
+        v-if="
+          item.subtext ||
+          ((item.type === 'room' || item.type === 'virtual_room' || item.type === 'poi') && item.subtext_bold)
+        "
+      >
         {{ item.subtext }}
-        <template v-if="item.type === 'room' || item.type === 'virtual_room' || item.type === 'poi'"
-          >, <b v-html="item.subtext_bold"
+        <template
+          v-if="(item.type === 'room' || item.type === 'virtual_room' || item.type === 'poi') && item.subtext_bold"
+          ><template v-if="item.subtext">, </template><b v-html="item.subtext_bold"
         /></template>
       </small>
     </div>


### PR DESCRIPTION
## Summary
- POI search rows (e.g. `/search?q=validierungsaut`) showed a stray `,` below the name because `SearchResultItem.vue` rendered the `, <b/>` separator unconditionally for room/virtual_room/poi results — even when both `subtext` and `subtext_bold` were empty.
- Only emit the separator when `subtext_bold` actually has content, and skip the whole `<small>` line when neither field is populated.
- Rooms with both fields populated (`Building, arch_id`) render unchanged.

## Test plan
- [ ] `/search?q=validierungsaut` — POI rows show just the name, no dangling comma.
- [ ] `/search?q=mi+hs1` (or any room search) — room rows still show `Building, arch_id` on the second line.
- [ ] Mixed query (e.g. `/search?q=hs`) — buildings, rooms, and POIs all render cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)