### PR TITLE
fix(data): propagate floors and room-precise coords to POIs

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -233,6 +233,7 @@ def _run_pipeline(
     lf = sections.extract_tumonline_props(lf)
     df = lf.collect()
     df = sections.compute_floor_prop(df)
+    df = poi.propagate_poi_floors(df)
     df = sections.compute_props(df)
     df = sections.localize_links(df)
 

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2628,6 +2628,8 @@ components:
             A sorted (lowest floor first) list of floors
 
             For buildings, this may contain multiple floors while rooms usually only have one floor.
+            POIs inherit floors from their immediate parent: a single floor when parented to a room,
+            or the full building list when parented to a building.
         links:
           type: array
           items:

--- a/data/processors/coords.py
+++ b/data/processors/coords.py
@@ -89,7 +89,39 @@ def assign_coordinates(df: pl.DataFrame) -> pl.DataFrame:
         .alias("coords_source")
     )
 
-    # 3. For rooms/virtual_rooms/poi without coords: copy from parent building
+    # 3a. POIs whose direct parent is a room: inherit the room's coords first,
+    # so the marker lands at the room centroid instead of the building centroid.
+    # accuracy stays "building" — the existing "inaccurate position" toast
+    # (DetailsContentSidebar.vue) keeps encouraging the user to refine the coord.
+    room_coords = df.filter((pl.col("type") == "room") & pl.col("coords_lat").is_not_null()).select(
+        pl.col("id").alias("room_id"),
+        pl.col("coords_lat").alias("room_lat"),
+        pl.col("coords_lon").alias("room_lon"),
+    )
+    poi_needs_coords = df.filter((pl.col("type") == "poi") & pl.col("coords_lat").is_null()).select(
+        "id",
+        pl.col("parents").list.last().alias("direct_parent"),
+    )
+    if poi_needs_coords.height > 0:
+        poi_room_match = poi_needs_coords.join(
+            room_coords, left_on="direct_parent", right_on="room_id", how="inner"
+        ).select("id", "room_lat", "room_lon")
+        if poi_room_match.height > 0:
+            df = df.join(poi_room_match, on="id", how="left")
+            df = df.with_columns(
+                pl.coalesce(pl.col("coords_lat"), pl.col("room_lat")).alias("coords_lat"),
+                pl.coalesce(pl.col("coords_lon"), pl.col("room_lon")).alias("coords_lon"),
+                pl.when(pl.col("coords_lat").is_null() & pl.col("room_lat").is_not_null())
+                .then(pl.lit("inferred"))
+                .otherwise(pl.col("coords_source"))
+                .alias("coords_source"),
+                pl.when(pl.col("coords_lat").is_null() & pl.col("room_lat").is_not_null())
+                .then(pl.lit("building"))
+                .otherwise(pl.col("coords_accuracy"))
+                .alias("coords_accuracy"),
+            ).drop("room_lat", "room_lon")
+
+    # 3b. For rooms/virtual_rooms/poi still without coords: copy from parent building
     building_coords = df.filter(pl.col("type") == "building").select(
         pl.col("id").alias("bldg_id"),
         pl.col("coords_lat").alias("bldg_lat"),

--- a/data/processors/poi.py
+++ b/data/processors/poi.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -7,6 +8,8 @@ from utils import TranslatableStr as _
 
 from processors import merge
 from processors.df_utils import translatable_to_columns
+
+_logger = logging.getLogger(__name__)
 
 BASE_PATH = Path(__file__).parent.parent
 SOURCES_PATH = BASE_PATH / "sources"
@@ -93,3 +96,48 @@ def merge_poi(df: pl.DataFrame) -> pl.DataFrame:
         df = pl.concat([df, new_df], how="diagonal_relaxed")
 
     return df
+
+
+def propagate_poi_floors(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Copy the immediate parent's `props_floors_json` onto each POI row.
+
+    POIs don't get floors assigned by `sections.compute_floor_prop` (which only
+    targets `[building, joined_building, site, campus]` and their room children
+    with a roomcode). Without floors, `FloorControl.setAvailableFloors([])`
+    dims every button and the indoor overlay never displays.
+
+    For a room-parented POI this yields a single-floor list (auto-selected by
+    `DetailsInteractiveMap.vue`). For a building-parented POI it yields the
+    full building floor list (user picks).
+    """
+    pois = df.filter(pl.col("type") == "poi").select(
+        "id",
+        pl.col("parents").list.last().alias("parent_id"),
+    )
+    if pois.height == 0:
+        return df
+
+    parent_floors = df.select(
+        pl.col("id").alias("parent_id"),
+        pl.col("props_floors_json").alias("parent_floors_json"),
+    )
+    pois_with_parent = pois.join(parent_floors, on="parent_id", how="left")
+
+    for row in pois_with_parent.filter(pl.col("parent_floors_json").is_null()).iter_rows(named=True):
+        _logger.warning(f"POI {row['id']}: parent {row['parent_id']} has no floors")
+
+    updates = pois_with_parent.filter(pl.col("parent_floors_json").is_not_null()).select(
+        "id",
+        pl.col("parent_floors_json").alias("props_floors_json_new"),
+    )
+    if updates.height == 0:
+        return df
+
+    return (
+        df.join(updates, on="id", how="left")
+        .with_columns(
+            pl.coalesce(pl.col("props_floors_json_new"), pl.col("props_floors_json")).alias("props_floors_json"),
+        )
+        .drop("props_floors_json_new")
+    )

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -384,6 +384,8 @@ struct PropsResponse {
     /// A sorted (lowest floor first) list of floors
     ///
     /// For buildings, this may contain multiple floors while rooms usually only have one floor.
+    /// POIs inherit floors from their immediate parent: a single floor when parented to a room,
+    /// or the full building list when parented to a building.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     floors: Vec<FloorResponse>,
 }

--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -64,6 +64,51 @@ test.describe("Details Page - Interactive Map", () => {
   });
 });
 
+test.describe("Details Page - POI Floor Inheritance", () => {
+  // Regression for TUM-Dev/NavigaTUM#1696: POIs used to leave FloorControl empty
+  // (every button dimmed), so the indoor overlay never showed. POIs now inherit
+  // floors from their immediate parent in the data pipeline.
+  const stubBasemap = async (page: import("@playwright/test").Page) => {
+    await page.route(
+      "https://nav.tum.de/martin/style/navigatum-basemap.json",
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ version: 8, sources: {}, layers: [] }),
+        });
+      },
+    );
+  };
+
+  test("room-parented POI auto-selects the room's floor", async ({ page }) => {
+    await stubBasemap(page);
+    await page.goto("/view/validierungsautomat-5", { waitUntil: "networkidle" });
+    await expect(page).toHaveURL("poi/validierungsautomat-5");
+
+    const floorCtrl = page.locator(".floor-ctrl");
+    await expect(floorCtrl).toBeVisible();
+
+    // Single inherited floor → DetailsInteractiveMap auto-calls setLevel(EG.id)
+    const egButton = floorCtrl.locator("button", { hasText: /^EG$/ });
+    await expect(egButton).toHaveClass(/active/);
+  });
+
+  test("building-parented POI exposes building floors as clickable", async ({ page }) => {
+    await stubBasemap(page);
+    await page.goto("/view/validierungsautomat-9", { waitUntil: "networkidle" });
+    await expect(page).toHaveURL("poi/validierungsautomat-9");
+
+    const floorCtrl = page.locator(".floor-ctrl");
+    await expect(floorCtrl).toBeVisible();
+
+    // Multiple inherited floors → no auto-select, EG button is enabled.
+    const egButton = floorCtrl.locator("button", { hasText: /^EG$/ });
+    await expect(egButton).toBeEnabled();
+    await expect(egButton).not.toHaveCSS("cursor", "not-allowed");
+  });
+});
+
 test.describe("Details Page - Images", () => {
   test("should display and interact with location images", async ({ page }) => {
     await page.goto("/view/chemie", { waitUntil: "networkidle" });

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1252,6 +1252,8 @@ export type components = {
        * @description A sorted (lowest floor first) list of floors
        *
        * For buildings, this may contain multiple floors while rooms usually only have one floor.
+       * POIs inherit floors from their immediate parent: a single floor when parented to a room,
+       * or the full building list when parented to a building.
        */
       readonly floors?: readonly components["schemas"]["FloorResponse"][];
       readonly links?: readonly components["schemas"]["PossibleURLRefResponse"][];

--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -141,7 +141,7 @@ function initMap(containerId: string): MapLibreMap {
       const availableFloorIds = props.floors.map((floor) => floor.id);
       floorControl.value.setAvailableFloors(availableFloorIds);
       if (props.floors.length === 1) {
-        floorControl.value.setLevel(availableFloorIds[0] || null);
+        floorControl.value.setLevel(availableFloorIds[0] ?? null);
       }
     }
   });


### PR DESCRIPTION
## Summary

- POIs now inherit `props_floors_json` from their immediate parent via a new `propagate_poi_floors` step that runs right after `compute_floor_prop`. Room-parented POIs get a single-floor list (auto-selected by `DetailsInteractiveMap.vue`); building-parented POIs get the full clickable list.
- POIs with a room parent inherit the room's coordinates instead of the parent building's, so the marker lands at the room centroid. `accuracy` stays `"building"` so the existing inaccurate-position toast keeps prompting for refinement.
- Server docstring on `LocationDetailsResponse.floors` mentions the new POI inheritance behavior.

Closes #1696

## Why the previous attempt didn't help

#1697 retargeted POI parents from buildings to specific rooms, expecting the floor pipeline to follow. It never did — `compute_floor_prop` only writes floors for `[building, joined_building, site, campus]` and their room children with a `props_ids_roomcode`. POI rows were always skipped, so `FloorControl.setAvailableFloors([])` dimmed every button.

## Test plan

- [ ] CI green (data pipeline build + ruff + cargo + Playwright)
- [ ] `/poi/validierungsautomat-8` (parent `5501.EG.199A`): marker on room centroid, FloorControl preselects `EG`, indoor overlay renders, inaccurate-position toast still shown
- [ ] `/poi/validierungsautomat-5` and `validierungsautomat-7` (parent `5601.EG.001`): picker active with `EG` selected, indoor overlay visible
- [ ] `/poi/validierungsautomat-9` (parent `0501`, a building): picker unlocked with all building floors clickable; no preselect
- [ ] New Playwright tests in `tests/specs/details.ui.spec.ts` (`Details Page - POI Floor Inheritance`) pass against a freshly built dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)