### PR TITLE
ci(autofix): add pinact job to keep action references SHA-pinned

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
     paths:
       - 'server/src/**'
+      - '.github/workflows/**'
+      - '.github/actions/**'
   pull_request_target:
     types: [ labeled ]
     branches: [ main ]
@@ -220,13 +222,29 @@ jobs:
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
         with:
           commit-message: "chore: Update OpenAPI spec and types"
+  pin-actions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with: {persist-credentials: false}
+      - name: Pin GitHub Actions to SHAs
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          skip_push: "true"
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4
+        with:
+          commit-message: "chore: pin GitHub Actions to SHAs"
 
   # This final step is needed to mark the whole workflow as successful
   # Don't change its name - it is used by the merge protection rules
   done:
     name: Finished autofix
     runs-on: ubuntu-latest
-    needs: [ update-server-snapshots, sort-cargo-toml, update-openapi, update-screenshots ]
+    needs: [ update-server-snapshots, sort-cargo-toml, update-openapi, update-screenshots, pin-actions ]
     if: always()
     permissions: {}
     steps:


### PR DESCRIPTION
## Summary

- Add a `pin-actions` job to `autofix.yml` that runs [`suzuki-shunsuke/pinact-action`](https://github.com/suzuki-shunsuke/pinact-action) in fix mode, then hands the diff to `autofix-ci/action` to commit — same pattern as the other jobs here.
- Expand the workflow's `paths:` filter so changes under `.github/workflows/**` and `.github/actions/**` trigger the run.
- Wire `pin-actions` into the `done` job's `needs:` so it gates merges the same way the other autofix jobs do.

## Why

Every action in this repo is already SHA-pinned with a `# vX.Y.Z` comment, and [`zizmor`](https://github.com/zizmorcore/zizmor) (in `security.yaml`) already flags unpinned `uses:`. The two things pinact adds on top:

1. **SHA ↔ comment drift detection.** If a future PR ends up with `actions/checkout@<old-sha> # v6.0.2` where the SHA actually points to v6.0.1 (moved tag, manual edit mistake), zizmor passes; pinact catches the mismatch.
2. **Autofix.** `pinact run --fix` rewrites tags → SHAs and refreshes the version comment, so any accidental `@v4` or stale comment is fixed in-place by the bot rather than bouncing back with a review nit.

Trade-off worth flagging: expanding `paths:` means the existing heavy autofix jobs (`update-openapi`, `update-server-snapshots`) will also run on workflow-only PRs. They'll produce no diff and autofix-ci will no-op, but the cargo build cost is real. If that becomes noisy we can add per-job change-detection later (e.g. `dorny/paths-filter`).

## Test plan

- [ ] CI runs green on this PR (workflow-file change → `pin-actions` triggers; no diff expected since the repo is already pinned).
- [ ] Open a follow-up PR that introduces a deliberately unpinned `uses: actions/checkout@v6` to confirm pinact rewrites it and autofix-ci posts the commit back.
- [ ] Confirm the autofix.ci GitHub App has `workflows: write` on this repo. If not, the commit-back will fail on workflow-file changes and we'll need to either grant it or drop to validate-only (`fix: "false"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)