### PR TITLE
fix(server): expand library search to English and sub-library variants

### DIFF
--- a/server/src/setup/search_synonyms.yaml
+++ b/server/src/setup/search_synonyms.yaml
@@ -6,8 +6,16 @@ ch: [ Chemie ]
 Maschinenwesen: [ mw ]
 
 Immathalle: [ Immatrikulationshalle ]
-Bib: [ Bibliothek, Teilbibliothek ]
-TB: [ Teilbibliothek ]
+
+# English ↔ German for "library" (issue #960). First English↔German pair —
+# extend this pattern when adding others (mensa↔cafeteria, hörsaal↔lecture hall, …).
+library: [ Bibliothek, Teilbibliothek, Universitätsbibliothek, Bib, TB ]
+libraries: [ Bibliothek, Teilbibliothek, Universitätsbibliothek, Bib, TB ]
+Bibliothek: [ Teilbibliothek, Universitätsbibliothek, library, libraries, Bib ]
+Teilbibliothek: [ Bibliothek, Universitätsbibliothek, library, libraries, Bib, TB ]
+Universitätsbibliothek: [ Bibliothek, Teilbibliothek, library, libraries ]
+Bib: [ Bibliothek, Teilbibliothek, Universitätsbibliothek, library, libraries ]
+TB: [ Teilbibliothek, Bibliothek, library, libraries ]
 
 HS: [ Hörsaal, Vorlesungssaal ]
 Hörsaal: [ HS, Vorlesungssaal ]

--- a/tests/specs/search.ui.spec.ts
+++ b/tests/specs/search.ui.spec.ts
@@ -45,6 +45,18 @@ test.describe("Search Page - Results Display", () => {
   });
 });
 
+test.describe("Search Page - English ↔ German synonyms (#960)", () => {
+  for (const query of ["library", "libraries", "bibliothek", "Teilbibliothek"]) {
+    test(`q=${query} returns at least one building result`, async ({ page }) => {
+      await page.goto(`/search?q=${query}`, { waitUntil: "networkidle" });
+      await page.waitForLoadState("networkidle");
+
+      const resultLinks = page.locator('a[href*="/view/"]');
+      expect(await resultLinks.count()).toBeGreaterThan(0);
+    });
+  }
+});
+
 test.describe("Search Page - Empty and Error States", () => {
   test("should handle empty search query", async ({ page }) => {
     await page.goto("/search?q=", { waitUntil: "networkidle" });


### PR DESCRIPTION
## Summary

Closes #960.

- Adds `library` / `libraries` as Meilisearch synonyms expanding to all German library variants (`Bibliothek`, `Teilbibliothek`, `Universitätsbibliothek`, `Bib`, `TB`).
- Adds the missing forward expansion from `Bibliothek` → `Teilbibliothek` / `Universitätsbibliothek` so that `?q=bibliothek` also surfaces sub-library buildings (e.g. `5401` "Bibliothek, Hörsaal CH 1", a.k.a. Teilbibliothek Chemie).
- Adds a small Playwright regression spec covering `library` / `libraries` / `bibliothek` / `Teilbibliothek`.

Synonyms live in [`server/src/setup/search_synonyms.yaml`](https://github.com/TUM-Dev/NavigaTUM/blob/main/server/src/setup/search_synonyms.yaml) and are loaded via `include_str!` + `Settings::with_synonyms()` in `meilisearch.rs`, so the change is picked up on the next Meilisearch reindex.

This is intentionally scoped to "library" only — other German↔English misses (Mensa↔cafeteria, Hörsaal↔lecture hall, …) can follow the same pattern in separate PRs. A comment in the YAML flags it as the first English↔German pair.

## Test plan

- [ ] `/search?q=library` returns ≥1 building result (including `5401`)
- [ ] `/search?q=libraries` returns ≥1 building result
- [ ] `/search?q=bibliothek` now also includes `Teilbibliothek` buildings (`5401`, `5510`, `5603`, …)
- [ ] `/search?q=Bib` still returns its existing hits (regression)
- [ ] New Playwright cases in `tests/specs/search.ui.spec.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)