### PR TITLE
chore(compose): bump meilisearch v1.43.0 → v1.45.2

### DIFF
--- a/compose.local.yml
+++ b/compose.local.yml
@@ -43,7 +43,7 @@ services:
       db:
         condition: service_healthy
   meilisearch:
-    image: getmeili/meilisearch:v1.43.0
+    image: getmeili/meilisearch:v1.45.2
     restart: unless-stopped
     ports:
       - "7700:7700"

--- a/compose.yml
+++ b/compose.yml
@@ -55,7 +55,7 @@ services:
       db:
         condition: service_healthy
   meilisearch:
-    image: getmeili/meilisearch:v1.43.0
+    image: getmeili/meilisearch:v1.45.2
     restart: unless-stopped
     networks:
       - traefik_traefik


### PR DESCRIPTION
## Summary
- Splits the docker-compose meilisearch bump out of #2994.
- `getmeili/meilisearch` v1.43.0 → v1.45.2 in `compose.yml` and `compose.local.yml`.

## Test plan
- [ ] CI green on this branch
- [ ] `docker compose up` still healthy locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)