### PR TITLE
chore(renovate): split non-major updates by ecosystem and automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "group:recommended",
-    "group:allNonMajor",
     "customManagers:biomeVersions"
   ],
   "timezone": "Europe/Berlin",
@@ -23,11 +22,40 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major-release",
-      "automerge": false
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "github-actions",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "docker",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["pep621", "pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "groupName": "python",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "groupName": "node",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "groupName": "rust",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "groupName": "pre-commit",
+      "automerge": true
     },
     {
       "groupName": "testing",
@@ -86,14 +114,6 @@
       ]
     },
     {
-      "groupName": "maplibre",
-      "automerge": false,
-      "matchPackageNames": [
-        "/maplibre-gl/",
-        "/maplibre-gl-indoor/"
-      ]
-    },
-    {
       "matchUpdateTypes": [
         "minor",
         "patch"
@@ -105,10 +125,17 @@
       ]
     },
     {
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "groupName": "devDependencies"
+      "groupName": "maplibre",
+      "automerge": false,
+      "matchPackageNames": [
+        "/maplibre-gl/",
+        "/maplibre-gl-indoor/"
+      ]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": "major-release",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Splits the single `group:allNonMajor` bundle into per-manager groups so each ecosystem (github-actions, docker, python, node, rust, pre-commit) lands its own focused PR instead of one cross-stack bundle (motivated by #2994, which we had to manually fan out into #3070/#3071/#3072).
- Enables `automerge: true` on every non-major ecosystem group. Test suite is the gate; if a specific package needs hand-review it can opt out via a named group (the existing `maplibre` rule is kept for exactly that).
- Moves the `major-release` rule to the end of `packageRules` so it correctly overrides per-ecosystem and named groups for majors. Previously a major pytest/serde/biome would inherit `automerge: true` from its specific group because that rule was evaluated last.
- Drops the `devDependencies` catch-all — now covered by the `npm` ecosystem rule.

## Test plan
- [ ] Renovate config validates (`renovate-config-validator` ran clean locally)
- [ ] Next Renovate run produces split-by-ecosystem PRs instead of one bundle
- [ ] A major bump still opens a non-automerge PR in the `major-release` group

🤖 Generated with [Claude Code](https://claude.com/claude-code)