### PR TITLE
refactor(webclient): consolidate map mobile-query and drop hand-rolled map-ready polling

### DIFF
--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { until } from "@vueuse/core";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -8,6 +9,7 @@ import {
 } from "maplibre-gl";
 import type { components } from "~/api_types";
 import { FloorControl } from "~/composables/FloorControl";
+import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
 
 const props = defineProps<{
@@ -20,6 +22,8 @@ const props = defineProps<{
 const map = ref<MapLibreMap | undefined>(undefined);
 const marker = ref<Marker | undefined>(undefined);
 const floorControl = ref<FloorControl>(new FloorControl());
+const mapContainer = ref<HTMLElement>();
+const isMobile = useIsMobile();
 const zoom = computed<number>(() => {
   if (props.type === "building") return 17;
   if (props.type === "room") return 18;
@@ -112,13 +116,12 @@ function initMap(containerId: string): MapLibreMap {
   map.on("load", () => {
     initialLoaded.value = true;
 
-    const isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
     const fullscreenCtl = new FullscreenControl();
     map.addControl(fullscreenCtl, "top-right");
 
     // controls
     const controls = [];
-    if (!isMobile) {
+    if (!isMobile.value) {
       controls.push(
         new NavigationControl({
           showCompass: false,
@@ -166,29 +169,10 @@ function initMap(containerId: string): MapLibreMap {
 }
 
 // --- Loading components ---
-onMounted(() => {
-  nextTick(() => {
-    // Even though 'mounted' is called there is no guarantee apparently,
-    // that we can reference the map by ID in the DOM yet. For this reason we
-    // try to poll now (Not the best solution probably)
-    let timeoutInMs = 25;
-
-    function pollMap() {
-      const canLoadMap = document.getElementById("interactive-legacy-map") !== null;
-      if (canLoadMap) {
-        loadInteractiveMap();
-        window.scrollTo({ top: 0, behavior: "auto" });
-      } else {
-        console.info(
-          `'mounted' called, but page is not mounted yet. Retrying map-load in ${timeoutInMs}ms`
-        );
-        setTimeout(pollMap, timeoutInMs);
-        timeoutInMs *= 1.5;
-      }
-    }
-
-    pollMap();
-  });
+onMounted(async () => {
+  await until(mapContainer).toBeTruthy();
+  loadInteractiveMap();
+  window.scrollTo({ top: 0, behavior: "auto" });
 });
 </script>
 
@@ -206,6 +190,7 @@ onMounted(() => {
     <div
       v-if="webglSupport"
       id="interactive-legacy-map"
+      ref="mapContainer"
       class="absolute !h-full !w-full transition-opacity duration-300"
       :class="{ 'opacity-0': !initialLoaded }"
     />

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -11,6 +11,7 @@ import type { IndoorMapOptions } from "maplibre-gl-indoor";
 import { IndoorControl, MapServerHandler } from "maplibre-gl-indoor";
 import type { components } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
+import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
 import {
   calculateItineraryBounds,
@@ -46,6 +47,7 @@ const geolocateControl = ref<GeolocateControl | undefined>(undefined);
 
 // Geolocation state
 const geolocationState = useSharedGeolocation();
+const isMobileQuery = useIsMobile();
 
 // Motis routing state
 const highlightedLegIndex = ref<number | null>(null);
@@ -133,7 +135,7 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
     // is maximized instead. This is determined once to select the correct
     // container to maximize, and then remains unchanged even if the browser
     // is resized (not relevant for users but for developers).
-    const isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
+    const isMobile = isMobileQuery.value;
     const fullscreenContainer = isMobile
       ? document.getElementById("interactive-indoor-map")
       : document.getElementById("interactive-indoor-map-container");

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { until } from "@vueuse/core";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -6,6 +7,7 @@ import {
   Marker,
   NavigationControl,
 } from "maplibre-gl";
+import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
 
 interface Props {
@@ -22,6 +24,7 @@ const { t } = useI18n({ useScope: "local" });
 const map = ref<MapLibreMap | undefined>(undefined);
 const marker = ref<Marker | undefined>(undefined);
 const mapContainer = ref<HTMLElement>();
+const isMobile = useIsMobile();
 
 function createMarker(hueRotation = 120) {
   const markerDiv = document.createElement("div");
@@ -50,8 +53,7 @@ function initMap() {
 
   mapInstance.on("load", () => {
     mapInstance.addControl(new NavigationControl({}), "top-left");
-    const isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
-    if (isMobile) {
+    if (isMobile.value) {
       const fullscreenCtl = new FullscreenControl({ container: mapContainer.value as HTMLElement });
       mapInstance.addControl(fullscreenCtl);
     }
@@ -96,18 +98,9 @@ watch(
   { immediate: false }
 );
 
-onMounted(() => {
-  nextTick(() => {
-    let timeoutInMs = 25;
-    function pollMap() {
-      if (mapContainer.value) initMap();
-      else {
-        setTimeout(pollMap, timeoutInMs);
-        timeoutInMs *= 1.5;
-      }
-    }
-    pollMap();
-  });
+onMounted(async () => {
+  await until(mapContainer).toBeTruthy();
+  initMap();
 });
 
 onUnmounted(() => {

--- a/webclient/app/components/LocationPickerModal.vue
+++ b/webclient/app/components/LocationPickerModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { until } from "@vueuse/core";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -7,6 +8,7 @@ import {
   NavigationControl,
 } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
+import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
 
 interface LocationPickerProps {
@@ -33,6 +35,7 @@ const marker = ref<Marker | undefined>(undefined);
 const floorControl = ref<FloorControl>(new FloorControl());
 const mapContainer = ref<HTMLElement>();
 const isMapLoaded = ref(false);
+const isMobile = useIsMobile();
 
 const coordinates = ref({
   lat: props.initialLat,
@@ -75,8 +78,7 @@ function initMap() {
     mapInstance.addControl(new NavigationControl({}), "top-left");
 
     // Add fullscreen control for mobile
-    const isMobile = window.matchMedia("only screen and (max-width: 480px)").matches;
-    if (isMobile) {
+    if (isMobile.value) {
       const fullscreenCtl = new FullscreenControl({
         container: mapContainer.value as HTMLElement,
       });
@@ -158,22 +160,9 @@ watch(
   { immediate: false }
 );
 
-onMounted(() => {
-  nextTick(() => {
-    // Poll for map container availability
-    let timeoutInMs = 25;
-
-    function pollMap() {
-      if (mapContainer.value) {
-        initMap();
-      } else {
-        setTimeout(pollMap, timeoutInMs);
-        timeoutInMs *= 1.5;
-      }
-    }
-
-    pollMap();
-  });
+onMounted(async () => {
+  await until(mapContainer).toBeTruthy();
+  initMap();
 });
 
 onUnmounted(() => {

--- a/webclient/app/composables/useIsMobile.ts
+++ b/webclient/app/composables/useIsMobile.ts
@@ -1,0 +1,8 @@
+import { useMediaQuery } from "@vueuse/core";
+
+// Matches the breakpoint at which our MapLibre map controls switch to a
+// compact / fullscreen layout. Kept as a single source of truth so the
+// magic string isn't duplicated across map components.
+export function useIsMobile() {
+  return useMediaQuery("only screen and (max-width: 480px)");
+}


### PR DESCRIPTION
## Summary

Two small VueUse-driven cleanups in the map components:

- **One source of truth for the mobile breakpoint.** Four map components each carried their own copy of `window.matchMedia("only screen and (max-width: 480px)").matches`. Moved into `useIsMobile()` (a thin wrapper around `@vueuse/core`'s `useMediaQuery`), used by `IndoorMap.vue`, `DetailsInteractiveMap.vue`, `LocationPickerInline.vue`, and `LocationPickerModal.vue`.
- **Drop the recursive-`setTimeout` map-ready polling.** Three components polled for the map container element with exponential-ish backoff (`timeoutInMs *= 1.5`). Replaced with `await until(mapContainer).toBeTruthy()` on the existing template refs. For `DetailsInteractiveMap.vue` the template ref was missing — added it (the `id="interactive-legacy-map"` is preserved so the rest of `loadInteractiveMap()`'s `getElementById` calls keep working).

No user-visible behavior change is intended; the polling backoff and the synchronous `.matches` read are functionally equivalent to the VueUse primitives that replace them, with the small benefits of SSR-safety and auto-cleanup.

## Test plan

- [ ] `pnpm lint` clean
- [ ] `pnpm type-check` clean
- [ ] Mobile (≤480px) viewport: map fullscreen control still appears on `LocationPickerInline`, `LocationPickerModal`, `IndoorMap`; `DetailsInteractiveMap` still hides `NavigationControl` on mobile
- [ ] Desktop viewport: no fullscreen control on the location pickers; `DetailsInteractiveMap` still shows `NavigationControl`
- [ ] Navigating into a location details page still loads the map after the v-if'd container mounts (no race where `loadInteractiveMap` runs against a non-existent element)

🤖 Generated with [Claude Code](https://claude.com/claude-code)