### PR TITLE
refactor(webclient): replace manual addEventListener / ResizeObserver with VueUse

### DIFF
--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -44,11 +44,9 @@ const marker = ref<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
 const runtimeConfig = useRuntimeConfig();
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
-// Tracks the fullscreen control's DOM container so we can observe its size
-// from the setup scope (the actual element is assigned inside map.on("load")).
 const fullscreenContainerEl = ref<HTMLElement | null>(null);
-// Mobile-only workaround for a maplibre bug where the canvas does not resize
-// when the fullscreen container's dimensions change during animation.
+// Maplibre bug: the map doesn't update to the new size when changing between
+// fullscreen in the mobile version.
 useResizeObserver(fullscreenContainerEl, () => {
   map.value?.resize();
 });
@@ -176,9 +174,6 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
       }
     };
     map.addControl(fullscreenCtl);
-    // The mobile workaround for the fullscreen resize bug is wired up via the
-    // setup-scope `useResizeObserver` above; assigning the element here is
-    // what activates it.
     if (isMobile) {
       fullscreenContainerEl.value = fullscreenCtl._container;
     }

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useResizeObserver } from "@vueuse/core";
 import type { GeoJSONSource } from "maplibre-gl";
 import {
   FullscreenControl,
@@ -43,6 +44,14 @@ const marker = ref<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
 const runtimeConfig = useRuntimeConfig();
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
+// Tracks the fullscreen control's DOM container so we can observe its size
+// from the setup scope (the actual element is assigned inside map.on("load")).
+const fullscreenContainerEl = ref<HTMLElement | null>(null);
+// Mobile-only workaround for a maplibre bug where the canvas does not resize
+// when the fullscreen container's dimensions change during animation.
+useResizeObserver(fullscreenContainerEl, () => {
+  map.value?.resize();
+});
 
 // Geolocation state
 const geolocationState = useSharedGeolocation();
@@ -166,15 +175,13 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
         fullscreenCtl._map.resize();
       }
     };
-    // There is a bug that the map doesn't update to the new size
-    // when changing between fullscreen in the mobile version.
-    if (isMobile) {
-      const fullscreenObserver = new ResizeObserver(() => {
-        fullscreenCtl._map.resize();
-      });
-      fullscreenObserver.observe(fullscreenCtl._container);
-    }
     map.addControl(fullscreenCtl);
+    // The mobile workaround for the fullscreen resize bug is wired up via the
+    // setup-scope `useResizeObserver` above; assigning the element here is
+    // what activates it.
+    if (isMobile) {
+      fullscreenContainerEl.value = fullscreenCtl._container;
+    }
 
     const location = new GeolocateControl({
       positionOptions: {

--- a/webclient/app/components/Modal.vue
+++ b/webclient/app/components/Modal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { mdiClose } from "@mdi/js";
+import { onKeyStroke } from "@vueuse/core";
 
 export interface Props {
   title: string;
@@ -26,20 +27,10 @@ watchEffect(() => {
   }
 });
 
-onMounted(() => {
-  const handleEscape = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      close();
-    }
-  };
+onKeyStroke("Escape", () => close());
 
-  document.addEventListener("keydown", handleEscape);
-
-  // Cleanup function
-  onBeforeUnmount(() => {
-    document.removeEventListener("keydown", handleEscape);
-    document.body?.classList.remove("overflow-y-hidden");
-  });
+onBeforeUnmount(() => {
+  document.body?.classList.remove("overflow-y-hidden");
 });
 
 function close() {

--- a/webclient/app/components/MotisNavigationRoutingResults.vue
+++ b/webclient/app/components/MotisNavigationRoutingResults.vue
@@ -30,9 +30,6 @@ const transitContainer2 = ref<HTMLElement | null>(null);
 const showDirectOverflow = ref(false);
 const showTransitOverflow = ref(false);
 
-// scrollWidth (content) can grow without the element's box (clientWidth)
-// changing when `props.data` updates, so a watch on data is still needed in
-// addition to the resize observers that catch box-size changes.
 const checkOverflow = () => {
   if (transitContainer.value) {
     showDirectOverflow.value =
@@ -44,6 +41,7 @@ const checkOverflow = () => {
   }
 };
 
+// Both needed: data changes can grow scrollWidth without the box (clientWidth) changing.
 watch(
   () => props.data,
   () => nextTick(checkOverflow),

--- a/webclient/app/components/MotisNavigationRoutingResults.vue
+++ b/webclient/app/components/MotisNavigationRoutingResults.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, watch } from "vue";
+import { useResizeObserver } from "@vueuse/core";
 import type { components } from "~/api_types";
 
 type MotisRoutingResponse = components["schemas"]["MotisRoutingResponse"];
@@ -30,35 +30,31 @@ const transitContainer2 = ref<HTMLElement | null>(null);
 const showDirectOverflow = ref(false);
 const showTransitOverflow = ref(false);
 
-// Check for overflow after content updates
+// scrollWidth (content) can grow without the element's box (clientWidth)
+// changing when `props.data` updates, so a watch on data is still needed in
+// addition to the resize observers that catch box-size changes.
 const checkOverflow = () => {
-  nextTick(() => {
-    if (transitContainer.value) {
-      showDirectOverflow.value =
-        transitContainer.value.scrollWidth > transitContainer.value.clientWidth;
-    }
-    if (transitContainer2.value) {
-      showTransitOverflow.value =
-        transitContainer2.value.scrollWidth > transitContainer2.value.clientWidth;
-    }
-  });
+  if (transitContainer.value) {
+    showDirectOverflow.value =
+      transitContainer.value.scrollWidth > transitContainer.value.clientWidth;
+  }
+  if (transitContainer2.value) {
+    showTransitOverflow.value =
+      transitContainer2.value.scrollWidth > transitContainer2.value.clientWidth;
+  }
 };
 
-// Watch for data changes to recheck overflow
-watch(() => props.data, checkOverflow, { deep: true, flush: "post" });
-
-// Setup overflow detection
-onMounted(() => {
-  checkOverflow();
-
-  // Recheck on window resize
-  window.addEventListener("resize", checkOverflow);
-
-  // Cleanup on unmount
-  onUnmounted(() => {
-    window.removeEventListener("resize", checkOverflow);
-  });
-});
+watch(
+  () => props.data,
+  () => nextTick(checkOverflow),
+  {
+    deep: true,
+    flush: "post",
+    immediate: true,
+  }
+);
+useResizeObserver(transitContainer, checkOverflow);
+useResizeObserver(transitContainer2, checkOverflow);
 
 const hasResults = computed(() => {
   return (props.data?.direct?.length || 0) > 0 || (props.data?.itineraries?.length || 0) > 0;

--- a/webclient/app/layouts/default.vue
+++ b/webclient/app/layouts/default.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from "@vueuse/core";
 import { useEditProposal } from "~/composables/editProposal";
 import { useFeedback } from "~/composables/feedback";
 
@@ -50,12 +51,9 @@ function handleKeyDown(event: KeyboardEvent) {
 
 onMounted(() => {
   searchElement.value = document.getElementById("search");
-  document.addEventListener("keydown", handleKeyDown);
 });
 
-onUnmounted(() => {
-  document.removeEventListener("keydown", handleKeyDown);
-});
+useEventListener(document, "keydown", handleKeyDown);
 
 const i18nHead = useLocaleHead({ dir: true, seo: true });
 useHead({


### PR DESCRIPTION
## Summary

Four call sites were hand-rolling `addEventListener` / `ResizeObserver` plus matching `onUnmounted` / `onBeforeUnmount` cleanup. Switch them to VueUse so the cleanup is implicit and the intent is clearer:

- \`layouts/default.vue\` — global \`keydown\` handler → \`useEventListener\`
- \`components/Modal.vue\` — Escape-to-close → \`onKeyStroke\`
- \`components/MotisNavigationRoutingResults.vue\` — window \`resize\` overflow recheck → \`useResizeObserver\` on the actual containers (kept the \`watch(() => props.data)\` because \`scrollWidth\` can change without the box-size changing, which \`ResizeObserver\` alone wouldn't catch)
- \`components/IndoorMap.vue\` — mobile fullscreen resize-bug workaround → \`useResizeObserver\` driven from a setup-scope ref that gets assigned inside \`map.on(\"load\")\`. The previous \`new ResizeObserver(...)\` had no cleanup path, so this also closes a small leak when the indoor map is unmounted while in fullscreen.

\`composables/FloorControl.ts\` has the same shape but it's a maplibre \`IControl\` class outside of any Vue setup scope — VueUse composables don't apply there, so it's left alone.

## Test plan

- [ ] \`pnpm lint\` clean
- [ ] \`pnpm type-check\` clean
- [ ] On the index page, typing a letter still focuses the search bar (default layout keydown handler)
- [ ] Pressing Escape closes a modal (Modal.vue)
- [ ] Resize the routing results pane until a transit-row overflows: the right-edge fade-out appears; shrink again and it disappears
- [ ] Indoor map on mobile: enter fullscreen, rotate / animate, map canvas resizes to fit (no blank strip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)