### PR TITLE
feat(webclient): add "search route" button inside navigation search fields

### DIFF
--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -101,6 +101,39 @@ test.describe("Navigation Page - Location Search", () => {
   });
 });
 
+test.describe("Navigation Page - Search route button", () => {
+  test("appears only once an endpoint is selected and submits without reloading", async ({
+    page,
+  }) => {
+    await page.goto("/navigate", { waitUntil: "networkidle" });
+
+    // No endpoint picked yet -> no route to search for, so no button.
+    await expect(page.getByRole("button", { name: "Route suchen" })).toHaveCount(0);
+
+    const fromInput = page.getByPlaceholder("Von").first();
+    await fromInput.fill("Mathematik Informatik");
+    await page.getByText("Fakultät Mathematik").click();
+    await expect(page).toHaveURL((url) => url.searchParams.get("from") === "mi");
+
+    // Selecting an endpoint reveals the search button inside that field.
+    const searchButton = page.getByRole("button", { name: "Route suchen" }).first();
+    await expect(searchButton).toBeVisible();
+
+    // Submitting must stay client-side: a full reload would discard in-memory state (e.g. the
+    // public-transit time selection). Tag the window and assert the tag survives the click.
+    await page.evaluate(() => {
+      (window as unknown as { __noReload: boolean }).__noReload = true;
+    });
+    await searchButton.click();
+    await expect
+      .poll(() =>
+        page.evaluate(() => (window as unknown as { __noReload?: boolean }).__noReload === true)
+      )
+      .toBe(true);
+    await expect(page).toHaveURL((url) => url.searchParams.get("from") === "mi");
+  });
+});
+
 test.describe("Navigation Page - Back Navigation", () => {
   test("should show and use back button when coming from details page", async ({ page }) => {
     await page.goto("/navigate?from=mi&to=mw&coming_from=mi", { waitUntil: "networkidle" });

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { mdiCrosshairsGps } from "@mdi/js";
+import { mdiCrosshairsGps, mdiMagnify } from "@mdi/js";
 import { useRouteQuery } from "@vueuse/router";
 import type { operations } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
@@ -225,6 +225,17 @@ const { data, error } = await useFetch<SearchResponse>(url, {
         />
       </button>
     </ClientOnly>
+    <!-- Only offer to search once an endpoint is picked: without an id there is nothing to route. -->
+    <button
+      v-if="selected"
+      type="submit"
+      class="focusable text-blue-600 hover:text-blue-800 hover:bg-blue-50 flex items-center justify-center px-3 py-2.5 transition-all duration-200 rounded-sm"
+      :title="t('search_route')"
+      :aria-label="t('search_route')"
+      @click="currently_actively_picking = false"
+    >
+      <MdiIcon :path="mdiMagnify" :size="18" />
+    </button>
   </div>
   <!-- Autocomplete -->
   <ClientOnly>
@@ -287,6 +298,7 @@ de:
     aria-actionlabel: Suche nach dem im Suchfeld eingetragenen Raum
     aria-searchlabel: Suchfeld
     action: Go
+  search_route: Route suchen
   show_hidden: +{count} ausgeblendet
   sections:
     sites_buildings: Gebäude / Standorte
@@ -312,6 +324,7 @@ en:
     aria-actionlabel: Search for the room-query entered in the search field
     aria-searchlabel: Search-field
     action: Go
+  search_route: Search route
   show_hidden: +{count} hidden
   sections:
     sites_buildings: Buildings / Sites

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -135,6 +135,13 @@ useSeoMeta({
   twitterCard: "summary",
 });
 
+// The endpoints already live in the URL query, so the route below recomputes reactively as
+// they change. A native GET submit would full-reload the page and discard the in-memory time
+// selection, so we only dismiss the keyboard / autocomplete instead.
+function onSearchSubmit() {
+  if (typeof document !== "undefined") (document.activeElement as HTMLElement | null)?.blur();
+}
+
 function setBoundingBoxFromIndex(from_shape_index: number, to_shape_index: number) {
   if (data.value?.router !== "valhalla") return;
 
@@ -206,7 +213,14 @@ function handleSelectItinerary(itineraryIndex: number) {
         </div>
       </NuxtLinkLocale>
       <NavigationModeSelector v-model:mode="mode" />
-      <form action="/navigate" autocomplete="off" method="GET" role="search" class="flex flex-col gap-2">
+      <form
+        action="/navigate"
+        autocomplete="off"
+        method="GET"
+        role="search"
+        class="flex flex-col gap-2"
+        @submit.prevent="onSearchSubmit"
+      >
         <NavigationSearchBar query-id="from" />
         <NavigationSearchBar query-id="to" />
         <div v-if="mode === 'public_transit'" class="mb-4">


### PR DESCRIPTION
Adds a Google-Maps-style **search button inside each `/navigate` search field**, shown only once that field has a selected endpoint.

Closes #2411