### PR TITLE
fix: navigate has single endpoint fit

### DIFF
--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -72,6 +72,74 @@ test.describe("Navigation Page - Map Display", () => {
 
     // await expect(page).toHaveScreenshot();
   });
+
+  // Regression test for TUM-Dev/NavigaTUM#1960: with only one endpoint defined
+  // the map used to stay on the campus-overview default (the Studitum) instead
+  // of framing the endpoint. There is no route to fit to, so the page resolves
+  // the single endpoint's coordinates via /api/locations/<id> and centres on
+  // them. Map rendering is flaky to screenshot in CI, so we assert that the
+  // resolution request fires (proving the focus path ran) rather than on pixels.
+  test("resolves the single endpoint when only `from` is defined", async ({ page }) => {
+    const detailsRequest = page.waitForRequest((req) => req.url().includes("/api/locations/mi"), {
+      timeout: 15_000,
+    });
+    await page.goto("/navigate?from=mi", { waitUntil: "domcontentloaded" });
+    await detailsRequest;
+    await expect(page).toHaveURL(/from=mi/);
+  });
+
+  test("resolves the single endpoint when only `to` is defined", async ({ page }) => {
+    const detailsRequest = page.waitForRequest((req) => req.url().includes("/api/locations/mi"), {
+      timeout: 15_000,
+    });
+    await page.goto("/navigate?to=mi", { waitUntil: "domcontentloaded" });
+    await detailsRequest;
+    await expect(page).toHaveURL(/to=mi/);
+  });
+
+  test("with both endpoints, fits the route and does not resolve a single endpoint", async ({
+    page,
+  }) => {
+    const locationsRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/locations/")) locationsRequests.push(req.url());
+    });
+    const routeRequest = page.waitForRequest((req) => req.url().includes("/api/maps/route"), {
+      timeout: 15_000,
+    });
+    await page.goto("/navigate?from=mi&to=mw&mode=pedestrian", { waitUntil: "domcontentloaded" });
+    await routeRequest;
+    // The single-endpoint resolver would only fire client-side once the map has
+    // mounted, so wait for the canvas before asserting it stayed silent.
+    await expect(page.locator("canvas").first()).toBeVisible();
+    expect(locationsRequests).toEqual([]);
+  });
+
+  test("with neither endpoint, keeps the campus-overview default", async ({ page }) => {
+    const locationsRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/locations/")) locationsRequests.push(req.url());
+    });
+    await page.goto("/navigate", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("canvas").first()).toBeVisible();
+    expect(locationsRequests).toEqual([]);
+  });
+
+  test("falls back gracefully when the single endpoint id is unresolvable", async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+    const detailsResponse = page.waitForResponse(
+      (resp) => resp.url().includes("/api/locations/invalid_location_123"),
+      { timeout: 15_000 }
+    );
+    await page.goto("/navigate?from=invalid_location_123", { waitUntil: "domcontentloaded" });
+
+    // The id does not resolve, so the resolver must swallow the 404 rather than
+    // throw, and the map must still render (on its campus-overview default).
+    expect((await detailsResponse).status()).toBe(404);
+    await expect(page.locator("canvas").first()).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  });
 });
 
 test.describe("Navigation Page - Turn-by-Turn Directions", () => {

--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -1,4 +1,14 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+// Collects every /api/locations/* request a page fires, so a test can assert
+// whether the single-endpoint resolver ran (issue #1960).
+function trackLocationRequests(page: Page): string[] {
+  const requests: string[] = [];
+  page.on("request", (req) => {
+    if (req.url().includes("/api/locations/")) requests.push(req.url());
+  });
+  return requests;
+}
 
 test.describe("Navigation Page - Basic Functionality", () => {
   test("should load navigation page with inputs", async ({ page }) => {
@@ -100,10 +110,7 @@ test.describe("Navigation Page - Map Display", () => {
   test("with both endpoints, fits the route and does not resolve a single endpoint", async ({
     page,
   }) => {
-    const locationsRequests: string[] = [];
-    page.on("request", (req) => {
-      if (req.url().includes("/api/locations/")) locationsRequests.push(req.url());
-    });
+    const locationsRequests = trackLocationRequests(page);
     const routeRequest = page.waitForRequest((req) => req.url().includes("/api/maps/route"), {
       timeout: 15_000,
     });
@@ -116,10 +123,7 @@ test.describe("Navigation Page - Map Display", () => {
   });
 
   test("with neither endpoint, keeps the campus-overview default", async ({ page }) => {
-    const locationsRequests: string[] = [];
-    page.on("request", (req) => {
-      if (req.url().includes("/api/locations/")) locationsRequests.push(req.url());
-    });
+    const locationsRequests = trackLocationRequests(page);
     await page.goto("/navigate", { waitUntil: "domcontentloaded" });
     await expect(page.locator("canvas").first()).toBeVisible();
     expect(locationsRequests).toEqual([]);

--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -1,7 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 
-// Collects every /api/locations/* request a page fires, so a test can assert
-// whether the single-endpoint resolver ran (issue #1960).
+// Collects /api/locations/* requests, to check whether the resolver ran.
 function trackLocationRequests(page: Page): string[] {
   const requests: string[] = [];
   page.on("request", (req) => {
@@ -10,10 +9,7 @@ function trackLocationRequests(page: Page): string[] {
   return requests;
 }
 
-// The map serialises its viewport into the URL hash as `#zoom/lat/lng`, which
-// lets us assert what the camera is actually framing. The MI building complex
-// (a joined_building) sits at ~48.26252/11.66808 and frames at zoom 16; the
-// campus-overview default is zoom 18 centred on the Studitum (~48.2669/11.6701).
+// Viewport hashes (`#zoom/lat/lng`): MI frames at zoom 16, campus default at zoom 18.
 const MI_VIEWPORT = /#16\/48\.262\d*\/11\.668\d*/;
 const CAMPUS_DEFAULT_VIEWPORT = /#18\/48\.266\d*\/11\.670\d*/;
 
@@ -21,7 +17,7 @@ test.describe("Navigation Page - Basic Functionality", () => {
   test("should load navigation page with inputs", async ({ page }) => {
     await page.goto("/navigate", { waitUntil: "networkidle" });
 
-    // The map serialises its viewport into the URL hash, so allow it after the path.
+    // Allow the map's viewport hash after the path.
     await expect(page).toHaveURL(/\/navigate(#|$)/);
     // Wait for page to fully load
     await page.waitForLoadState("networkidle");
@@ -91,12 +87,9 @@ test.describe("Navigation Page - Map Display", () => {
     // await expect(page).toHaveScreenshot();
   });
 
-  // Regression test for TUM-Dev/NavigaTUM#1960: with only one endpoint defined
-  // the map used to stay on the campus-overview default (the Studitum) instead
-  // of framing the endpoint. There is no route to fit to, so the page resolves
-  // the single endpoint's coordinates via /api/locations/<id> and centres on
-  // them. We assert both that the resolution request fires (the mechanism) and
-  // that the viewport hash ends up framing the endpoint (the actual outcome).
+  // Regression test for #1960: with one endpoint, the map must centre on it
+  // rather than the campus default. Checks the resolve request fires and the
+  // viewport hash frames the endpoint.
   test("resolves the single endpoint when only `from` is defined", async ({ page }) => {
     const detailsRequest = page.waitForRequest((req) => req.url().includes("/api/locations/mi"), {
       timeout: 15_000,
@@ -126,8 +119,7 @@ test.describe("Navigation Page - Map Display", () => {
     });
     await page.goto("/navigate?from=mi&to=mw&mode=pedestrian", { waitUntil: "domcontentloaded" });
     await routeRequest;
-    // The single-endpoint resolver would only fire client-side once the map has
-    // mounted, so wait for the canvas before asserting it stayed silent.
+    // Wait for the map to mount before asserting the resolver stayed silent.
     await expect(page.locator("canvas").first()).toBeVisible();
     expect(locationsRequests).toEqual([]);
   });
@@ -149,9 +141,7 @@ test.describe("Navigation Page - Map Display", () => {
     );
     await page.goto("/navigate?from=invalid_location_123", { waitUntil: "domcontentloaded" });
 
-    // The id does not resolve, so the resolver must swallow the 404 rather than
-    // throw, and the map must stay on its campus-overview default instead of
-    // jumping to an unrelated building.
+    // The 404 must be swallowed (no throw) and the map left at the default view.
     expect((await detailsResponse).status()).toBe(404);
     await expect(page.locator("canvas").first()).toBeVisible();
     await expect(page).toHaveURL(CAMPUS_DEFAULT_VIEWPORT);

--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -10,11 +10,19 @@ function trackLocationRequests(page: Page): string[] {
   return requests;
 }
 
+// The map serialises its viewport into the URL hash as `#zoom/lat/lng`, which
+// lets us assert what the camera is actually framing. The MI building complex
+// (a joined_building) sits at ~48.26252/11.66808 and frames at zoom 16; the
+// campus-overview default is zoom 18 centred on the Studitum (~48.2669/11.6701).
+const MI_VIEWPORT = /#16\/48\.262\d*\/11\.668\d*/;
+const CAMPUS_DEFAULT_VIEWPORT = /#18\/48\.266\d*\/11\.670\d*/;
+
 test.describe("Navigation Page - Basic Functionality", () => {
   test("should load navigation page with inputs", async ({ page }) => {
     await page.goto("/navigate", { waitUntil: "networkidle" });
 
-    await expect(page).toHaveURL("/navigate");
+    // The map serialises its viewport into the URL hash, so allow it after the path.
+    await expect(page).toHaveURL(/\/navigate(#|$)/);
     // Wait for page to fully load
     await page.waitForLoadState("networkidle");
     const fromInput = page.getByPlaceholder("Von").first();
@@ -87,8 +95,8 @@ test.describe("Navigation Page - Map Display", () => {
   // the map used to stay on the campus-overview default (the Studitum) instead
   // of framing the endpoint. There is no route to fit to, so the page resolves
   // the single endpoint's coordinates via /api/locations/<id> and centres on
-  // them. Map rendering is flaky to screenshot in CI, so we assert that the
-  // resolution request fires (proving the focus path ran) rather than on pixels.
+  // them. We assert both that the resolution request fires (the mechanism) and
+  // that the viewport hash ends up framing the endpoint (the actual outcome).
   test("resolves the single endpoint when only `from` is defined", async ({ page }) => {
     const detailsRequest = page.waitForRequest((req) => req.url().includes("/api/locations/mi"), {
       timeout: 15_000,
@@ -96,6 +104,7 @@ test.describe("Navigation Page - Map Display", () => {
     await page.goto("/navigate?from=mi", { waitUntil: "domcontentloaded" });
     await detailsRequest;
     await expect(page).toHaveURL(/from=mi/);
+    await expect(page).toHaveURL(MI_VIEWPORT);
   });
 
   test("resolves the single endpoint when only `to` is defined", async ({ page }) => {
@@ -105,6 +114,7 @@ test.describe("Navigation Page - Map Display", () => {
     await page.goto("/navigate?to=mi", { waitUntil: "domcontentloaded" });
     await detailsRequest;
     await expect(page).toHaveURL(/to=mi/);
+    await expect(page).toHaveURL(MI_VIEWPORT);
   });
 
   test("with both endpoints, fits the route and does not resolve a single endpoint", async ({
@@ -126,6 +136,7 @@ test.describe("Navigation Page - Map Display", () => {
     const locationsRequests = trackLocationRequests(page);
     await page.goto("/navigate", { waitUntil: "domcontentloaded" });
     await expect(page.locator("canvas").first()).toBeVisible();
+    await expect(page).toHaveURL(CAMPUS_DEFAULT_VIEWPORT);
     expect(locationsRequests).toEqual([]);
   });
 
@@ -139,9 +150,11 @@ test.describe("Navigation Page - Map Display", () => {
     await page.goto("/navigate?from=invalid_location_123", { waitUntil: "domcontentloaded" });
 
     // The id does not resolve, so the resolver must swallow the 404 rather than
-    // throw, and the map must still render (on its campus-overview default).
+    // throw, and the map must stay on its campus-overview default instead of
+    // jumping to an unrelated building.
     expect((await detailsResponse).status()).toBe(404);
     await expect(page.locator("canvas").first()).toBeVisible();
+    await expect(page).toHaveURL(CAMPUS_DEFAULT_VIEWPORT);
     expect(pageErrors).toEqual([]);
   });
 });

--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -11,6 +11,7 @@ import type { components } from "~/api_types";
 import { FloorControl } from "~/composables/FloorControl";
 import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
+import { zoomForLocationType } from "~/utils/map";
 
 const props = defineProps<{
   coords: LocationDetailsResponse["coords"];
@@ -24,11 +25,7 @@ const marker = ref<Marker | undefined>(undefined);
 const floorControl = ref<FloorControl>(new FloorControl());
 const mapContainer = ref<HTMLElement>();
 const isMobile = useIsMobile();
-const zoom = computed<number>(() => {
-  if (props.type === "building") return 17;
-  if (props.type === "room") return 18;
-  return 16;
-});
+const zoom = computed<number>(() => zoomForLocationType(props.type));
 
 const initialLoaded = ref(false);
 

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -108,8 +108,10 @@ function createMarker(hueRotation = 0): HTMLDivElement {
 async function initMap(containerId: string): Promise<MapLibreMap> {
   const map = new MapLibreMap({
     container: containerId,
-    // while having the hash in the url is nice, it is overridden on map load anyway => not much use
-    hash: false,
+    // Serialise the viewport (zoom and centre) into the URL hash. An incoming
+    // hash is overridden once we frame the route or endpoint, but the written
+    // hash keeps the map state deep-linkable and reflects what is on screen.
+    hash: true,
 
     canvasContextAttributes: {
       // create the gl context with MSAA antialiasing, so custom layers are antialiasing.

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -108,9 +108,7 @@ function createMarker(hueRotation = 0): HTMLDivElement {
 async function initMap(containerId: string): Promise<MapLibreMap> {
   const map = new MapLibreMap({
     container: containerId,
-    // Serialise the viewport (zoom and centre) into the URL hash. An incoming
-    // hash is overridden once we frame the route or endpoint, but the written
-    // hash keeps the map state deep-linkable and reflects what is on screen.
+    // Reflect the viewport in the URL hash so the map state is deep-linkable.
     hash: true,
 
     canvasContextAttributes: {
@@ -392,14 +390,7 @@ function drawRoute(shapes: readonly Coordinate[], isAfterLoaded = false) {
   );
 }
 
-/**
- * Centre the map on a single location.
- *
- * Used by the navigation view when only one endpoint is defined and there is
- * no route to fit to: the map should frame that endpoint rather than fall back
- * to the campus-overview default. The zoom is chosen by entry type so a room is
- * shown closer than a whole site.
- */
+/** Centre the map on a single location, used when there is no route to fit. */
 function flyToCoords(
   coords: { lat: number; lon: number },
   type?: LocationDetailsResponse["type"],

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -14,6 +14,7 @@ import type { components } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
 import { useIsMobile } from "~/composables/useIsMobile";
 import { webglSupport } from "~/composables/webglSupport";
+import { zoomForLocationType } from "~/utils/map";
 import {
   calculateItineraryBounds,
   calculateLegBounds,
@@ -58,12 +59,7 @@ const isMobileQuery = useIsMobile();
 
 // Motis routing state
 const highlightedLegIndex = ref<number | null>(null);
-function zoomForType(type: LocationDetailsResponse["type"] | undefined): number {
-  if (type === "building") return 17;
-  if (type === "room") return 18;
-  return 16;
-}
-const zoom = computed<number>(() => zoomForType(props.type));
+const zoom = computed<number>(() => zoomForLocationType(props.type));
 
 onMounted(async () => {
   if (!webglSupport) return;
@@ -412,7 +408,7 @@ function flyToCoords(
     return;
   }
   marker.value?.setLngLat([coords.lon, coords.lat]);
-  map.value.flyTo({ center: [coords.lon, coords.lat], zoom: zoomForType(type) });
+  map.value.flyTo({ center: [coords.lon, coords.lat], zoom: zoomForLocationType(type) });
 }
 
 function fitBounds(lon: [number, number], lat: [number, number]) {

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -58,11 +58,12 @@ const isMobileQuery = useIsMobile();
 
 // Motis routing state
 const highlightedLegIndex = ref<number | null>(null);
-const zoom = computed<number>(() => {
-  if (props.type === "building") return 17;
-  if (props.type === "room") return 18;
+function zoomForType(type: LocationDetailsResponse["type"] | undefined): number {
+  if (type === "building") return 17;
+  if (type === "room") return 18;
   return 16;
-});
+}
+const zoom = computed<number>(() => zoomForType(props.type));
 
 onMounted(async () => {
   if (!webglSupport) return;
@@ -393,6 +394,27 @@ function drawRoute(shapes: readonly Coordinate[], isAfterLoaded = false) {
   );
 }
 
+/**
+ * Centre the map on a single location.
+ *
+ * Used by the navigation view when only one endpoint is defined and there is
+ * no route to fit to: the map should frame that endpoint rather than fall back
+ * to the campus-overview default. The zoom is chosen by entry type so a room is
+ * shown closer than a whole site.
+ */
+function flyToCoords(
+  coords: { lat: number; lon: number },
+  type?: LocationDetailsResponse["type"],
+  isAfterLoaded = false
+) {
+  if (!map.value || (!isAfterLoaded && !map.value.loaded())) {
+    afterLoaded.value = () => flyToCoords(coords, type, true);
+    return;
+  }
+  marker.value?.setLngLat([coords.lon, coords.lat]);
+  map.value.flyTo({ center: [coords.lon, coords.lat], zoom: zoomForType(type) });
+}
+
 function fitBounds(lon: [number, number], lat: [number, number]) {
   if (!map.value) {
     console.error("tried to fly to point but map has not loaded yet.. wtf??");
@@ -550,6 +572,7 @@ function triggerGeolocation() {
 defineExpose({
   drawRoute,
   fitBounds,
+  flyToCoords,
   drawMotisItinerary,
   highlightMotisLeg,
   focusOnMotisLeg,

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -98,9 +98,7 @@ watch(
 
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 
-// When exactly one endpoint is defined there is no route to fit the map to, so
-// it would otherwise stay on its campus-overview default (the Studitum). Centre
-// it on whichever endpoint the user did specify instead.
+// The endpoint to centre on when only `from` or `to` is set (no route to fit).
 const single_endpoint = computed<string | undefined>(() => {
   if (selected_from.value && !selected_to.value) return selected_from.value;
   if (selected_to.value && !selected_from.value) return selected_to.value;
@@ -123,8 +121,7 @@ async function focusSingleEndpoint(value: string) {
     );
     map.flyToCoords(details.coords, details.type);
   } catch {
-    // Unresolvable id (e.g. a typo, or an entry without coordinates): keep the
-    // campus-overview default rather than jumping to an unrelated building.
+    // Unresolvable id: keep the default view.
   }
 }
 

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -3,7 +3,7 @@ import { mdiChevronLeft } from "@mdi/js";
 import { refDebounced } from "@vueuse/core";
 import { useRouteQuery } from "@vueuse/router";
 import { useTemplateRef } from "vue";
-import type { operations } from "~/api_types";
+import type { components, operations } from "~/api_types";
 import IndoorMap from "~/components/IndoorMap.vue";
 import Toast from "~/components/Toast.vue";
 import { firstOrDefault } from "~/composables/common";
@@ -92,6 +92,46 @@ watch(
         newMap.drawMotisItinerary(newData.itineraries[0]);
       }
     }
+  },
+  { immediate: true }
+);
+
+type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
+
+// When exactly one endpoint is defined there is no route to fit the map to, so
+// it would otherwise stay on its campus-overview default (the Studitum). Centre
+// it on whichever endpoint the user did specify instead.
+const single_endpoint = computed<string | undefined>(() => {
+  if (selected_from.value && !selected_to.value) return selected_from.value;
+  if (selected_to.value && !selected_from.value) return selected_to.value;
+  return undefined;
+});
+
+async function focusSingleEndpoint(value: string) {
+  const map = indoorMap.value;
+  if (!map) return;
+
+  const parsed = parseCoordinateId(value);
+  if (typeof parsed !== "string") {
+    map.flyToCoords(parsed);
+    return;
+  }
+  try {
+    const details = await $fetch<LocationDetailsResponse>(
+      `${runtimeConfig.public.apiURL}/api/locations/${encodeURIComponent(parsed)}`,
+      { query: { lang: locale.value }, credentials: "omit" }
+    );
+    map.flyToCoords(details.coords, details.type);
+  } catch {
+    // Unresolvable id (e.g. a typo, or an entry without coordinates): keep the
+    // campus-overview default rather than jumping to an unrelated building.
+  }
+}
+
+watch(
+  [single_endpoint, indoorMap],
+  ([value]) => {
+    if (value) focusSingleEndpoint(value);
   },
   { immediate: true }
 );

--- a/webclient/app/utils/map.ts
+++ b/webclient/app/utils/map.ts
@@ -1,0 +1,10 @@
+import type { components } from "~/api_types";
+
+type LocationType = components["schemas"]["LocationTypeResponse"];
+
+/** Zoom level for framing a single location of the given type. */
+export function zoomForLocationType(type: LocationType | undefined): number {
+  if (type === "building") return 17;
+  if (type === "room") return 18;
+  return 16;
+}


### PR DESCRIPTION
Fixes #1960.

## Problem

Opening `/navigate` with only one endpoint set (`?from=mi` or `?to=mi`) returns a 404 from the route API — it requires both endpoints to resolve. With no route to fit, the map never moved and stayed on its hardcoded campus-overview default (the Studitum), so users had to pan/zoom to find the place they'd just identified.

## Fix

- When exactly one endpoint is set, resolve its coordinates (`coord:` value parsed directly, otherwise via `/api/locations/<id>`) and centre the map on it, with a zoom chosen by entry type.
- Unresolvable ids are swallowed gracefully — the map stays on the default rather than jumping to an unrelated building.
- Both-endpoints and neither-endpoint behaviour are unchanged.

## Notable changes

- **`utils/map.ts`** — extracted the duplicated zoom-by-type logic (it existed identically in `IndoorMap` and `DetailsInteractiveMap`) into a shared `zoomForLocationType` helper.
- **MapLibre hash routing** enabled on the navigate map (`#zoom/lat/lng`), making the viewport deep-linkable — and lets the tests assert what the camera is actually framing.

## Testing

Playwright regression tests in `navigation.ui.spec.ts` cover `from`-only, `to`-only, both, neither, and an invalid id. The single-endpoint and fallback cases assert the **viewport via the URL hash** (zoom 16 on MI vs. the zoom-18 campus default), not just that the resolve request fired.

Verified locally by running the suite against a local webclient build pointed at the production API. Acceptance criteria from the issue all covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)