### PR TITLE
fix(webclient): polish the navigation search-route button

### DIFF
--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -149,6 +149,24 @@ test.describe("Navigation Page - Search route button", () => {
       .toBe(true);
     await expect(page).toHaveURL((url) => url.searchParams.get("from") === "mi");
   });
+
+  test("autohides once the field loses focus", async ({ page }) => {
+    await page.goto("/navigate", { waitUntil: "networkidle" });
+
+    const fromInput = page.getByPlaceholder("Von").first();
+    await fromInput.fill("Mathematik Informatik");
+    await page.getByText("Fakultät Mathematik").click();
+    await expect(page).toHaveURL((url) => url.searchParams.get("from") === "mi");
+
+    // While the field stays focused, the button remains available...
+    await expect(page.getByRole("button", { name: "Route suchen" }).first()).toBeVisible();
+
+    // ...but it must not linger as dead chrome once focus moves away, even though the endpoint
+    // selection (and thus the route) is still set.
+    await fromInput.blur();
+    await expect(page.getByRole("button", { name: "Route suchen" })).toHaveCount(0);
+    await expect(page).toHaveURL((url) => url.searchParams.get("from") === "mi");
+  });
 });
 
 test.describe("Navigation Page - Back Navigation", () => {

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -13,6 +13,10 @@ const { t, locale } = useI18n({ useScope: "local" });
 const route = useRoute();
 const router = useRouter();
 const currently_actively_picking = ref(false);
+// Tracks real input focus (distinct from `currently_actively_picking`, which only governs the
+// autocomplete dropdown and is cleared as soon as an entry is picked). The search button keys off
+// this so it stays visible while the field is being edited and autohides once focus leaves.
+const isFocused = ref(false);
 
 // Use shared geolocation state
 const geolocationState = useSharedGeolocation();
@@ -197,12 +201,30 @@ const { data, error } = await useFetch<SearchResponse>(url, {
       :placeholder="t('input.placeholder-' + queryId)"
       :aria-label="t('input.aria-searchlabel')"
       @focus="
-        console.log('focuseed', queryId);
+        isFocused = true;
         currently_actively_picking = true;
         highlighted = 0;
       "
+      @blur="isFocused = false"
       @keydown="onKeyDown"
     />
+    <!--
+      Offer to search only while the field is focused and already holds a selected endpoint: without
+      an id there is nothing to route, and a button lingering after blur is just noise. `mousedown`
+      is prevented so the click does not blur the textarea first, which would hide this very button
+      before the click lands.
+    -->
+    <button
+      v-if="selected && isFocused"
+      type="submit"
+      class="focusable text-zinc-600 dark:text-zinc-300 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900 flex items-center justify-center px-3 py-2.5 transition-all duration-200 rounded-sm"
+      :title="t('search_route')"
+      :aria-label="t('search_route')"
+      @mousedown.prevent
+      @click="currently_actively_picking = false"
+    >
+      <MdiIcon :path="mdiMagnify" :size="16" />
+    </button>
     <ClientOnly>
       <button
         v-if="isGeolocationSupported && !geolocationState.mapGeolocationActive"
@@ -225,17 +247,6 @@ const { data, error } = await useFetch<SearchResponse>(url, {
         />
       </button>
     </ClientOnly>
-    <!-- Only offer to search once an endpoint is picked: without an id there is nothing to route. -->
-    <button
-      v-if="selected"
-      type="submit"
-      class="focusable text-blue-600 hover:text-blue-800 hover:bg-blue-50 flex items-center justify-center px-3 py-2.5 transition-all duration-200 rounded-sm"
-      :title="t('search_route')"
-      :aria-label="t('search_route')"
-      @click="currently_actively_picking = false"
-    >
-      <MdiIcon :path="mdiMagnify" :size="18" />
-    </button>
   </div>
   <!-- Autocomplete -->
   <ClientOnly>

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -277,6 +277,7 @@ const { data, error } = await useFetch<SearchResponse>(url, {
             v-if="expandedFacets.has(s.facet) || i < s.n_visible"
             :highlighted="e.id === visibleElements[highlighted ?? -1]"
             :item="e"
+            @mousedown.prevent
             @click="select(e.id)"
             @mouseover="highlighted = i"
           />


### PR DESCRIPTION
Follow-up to #3090, which added the in-field "search route" button on `/navigate`. The button had a few rough edges:

1. **Dark mode / light mode styling.** It used `text-blue-600` with no dark-mode variant, so it rendered blue on the dark `zinc-700` field background and looked faint on light. It now matches the adjacent GPS button — zinc text, blue on hover, in both themes — and uses the same 16px icon size.
2. **Position.** It sat to the *right* of the GPS icon; it now sits to its *left* in both fields.
3. **Visibility.** It keyed off the committed endpoint alone, so it never appeared while a field was being edited and lingered as dead chrome after focus moved away. It is now tied to actual input focus (a new `isFocused` ref, kept distinct from the autocomplete's `currently_actively_picking`, which is cleared the moment an entry is picked): it shows while editing a field that has a selected endpoint and autohides on blur. `mousedown` is prevented on the button so the click doesn't blur the textarea and remove the button before the click lands.