### PR TITLE
feat(webclient): live SV Iris learning-room availability card

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -42,7 +42,7 @@ jobs:
           CONNECTUM_OAUTH_CLIENT_ID: "${{ secrets.CONECTUM_OAUTH_CLIENT_ID }}"
           CONNECTUM_OAUTH_CLIENT_SECRET: "${{ secrets.CONECTUM_OAUTH_CLIENT_SECRET }}"
         working-directory: data/external
-      - name: Download AStA Iris learning-room roster
+      - name: Download Studentische Vertretung IRIS learning-room roster
         continue-on-error: true # an outage leaves the previous roster in place => coverage degrades, build still works
         run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/iris.py
         working-directory: data/external

--- a/data/README.md
+++ b/data/README.md
@@ -154,7 +154,7 @@ Some work is underway to ensure that this format is actually being followed via 
     - **Steps 7x**: -
     - **Steps 8x**: Generate properties and sections (such as overview sections)
 - **Steps 90-99**: Process and export for search, and derive external coverage signals (such as
-  AStA Iris learning-room coverage, which needs the `arch_name` aliases built at step 98).
+  Studentische Vertretung IRIS learning-room coverage, which needs the `arch_name` aliases built at step 98).
 - **Step 100**: Export final data (for use in the API). Some temporary data fields might be removed at this point.
 
 ### Details

--- a/data/compile.py
+++ b/data/compile.py
@@ -265,7 +265,7 @@ def _run_pipeline(
     df = lf.collect()
 
     # Needs arch_name (added at step 98) to join the Iris roster against NavigaTUM aliases.
-    _logger.info("-- 99 AStA Iris learning-room coverage")
+    _logger.info("-- 99 Studentische Vertretung IRIS learning-room coverage")
     df = iris.add_iris_coverage(df)
 
     _logger.info("-- 100 Export and generate Sitemap")

--- a/data/external/loaders/iris.py
+++ b/data/external/loaders/iris.py
@@ -6,7 +6,7 @@ from external.schemas.iris import IrisRoomsSchema
 
 def load_iris_rooms() -> pl.DataFrame:
     """
-    Load the AStA Iris learning-room roster. Dtypes enforced by `IrisRoomsSchema`.
+    Load the Studentische Vertretung IRIS learning-room roster. Dtypes enforced by `IrisRoomsSchema`.
 
     Both columns stay `String` so building ids like "0201" keep their leading zeros.
     """

--- a/data/external/schemas/iris.py
+++ b/data/external/schemas/iris.py
@@ -2,7 +2,7 @@ import dataframely as dy
 
 
 class IrisRoomsSchema(dy.Schema):
-    """AStA Iris learning-room roster (`iris.csv`)."""
+    """Studentische Vertretung IRIS learning-room roster (`iris.csv`)."""
 
     # The `<arch_name>@<building_id>` form, joined against NavigaTUM aliases. Globally unique.
     raum_nr_architekt = dy.String(nullable=False, primary_key=True)

--- a/data/external/scrapers/iris.py
+++ b/data/external/scrapers/iris.py
@@ -14,9 +14,9 @@ _logger = logging.getLogger(__name__)
 
 def scrape_iris() -> None:
     """
-    Write `iris.csv` from the live AStA Iris endpoint.
+    Write `iris.csv` from the live Studentische Vertretung IRIS endpoint.
 
-    Refuses to overwrite with an empty roster, so a transient AStA outage leaves the previously
+    Refuses to overwrite with an empty roster, so a transient outage leaves the previously
     scraped data in place rather than wiping coverage.
     """
     response = requests.get(IRIS_API_URL, timeout=30)

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2635,9 +2635,9 @@ components:
         has_iris_coverage:
           type: boolean
           description: |-
-            Whether this building/area has `AStA` Iris learning-room coverage.
+            Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
 
-            Derived at data-build time by matching the `AStA` Iris room roster against our aliases.
+            Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
             When `true`, the page can offer a learning-room availability view without a second request.
             Absent (rather than `false`) for entries without coverage.
         links:

--- a/data/processors/schema.py
+++ b/data/processors/schema.py
@@ -114,7 +114,7 @@ class LocationSchema(dy.Schema):
     description_json = dy.String()
     external_data_json = dy.String()
 
-    # --- AStA Iris learning-room coverage ---
+    # --- Studentische Vertretung IRIS learning-room coverage ---
     has_iris_coverage = dy.Bool(nullable=False)
 
     @dy.rule()

--- a/data/sources/links.yaml
+++ b/data/sources/links.yaml
@@ -10,10 +10,6 @@
   url: https://www.fs.ei.tum.de/
 '0201':
 - text:
-    de: Lernraumbelegung
-    en: Learning rooms usage
-  url: https://www.devapp.it.tum.de/iris/app/
-- text:
     de: Über das StudiTUM
     en: About the StudiTUM
   url:
@@ -78,10 +74,6 @@
   url: https://tum-som.com/events/
 '4113':
 - text:
-    de: Lernraumbelegung
-    en: Learning rooms usage
-  url: https://www.devapp.it.tum.de/iris/app/
-- text:
     de: Über das StudiTUM
     en: About the StudiTUM
   url:
@@ -131,10 +123,6 @@
     en: Opening hours & articles
   url: https://fsmb.de/studierende/skriptenverkauf/
 '5532':
-- text:
-    de: Lernraumbelegung
-    en: Learning rooms usage
-  url: https://www.devapp.it.tum.de/iris/app/
 - text:
     de: Über das StudiTUM
     en: About the StudiTUM

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -388,9 +388,9 @@ struct PropsResponse {
     /// or the full building list when parented to a building.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     floors: Vec<FloorResponse>,
-    /// Whether this building/area has `AStA` Iris learning-room coverage.
+    /// Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
     ///
-    /// Derived at data-build time by matching the `AStA` Iris room roster against our aliases.
+    /// Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
     /// When `true`, the page can offer a learning-room availability view without a second request.
     /// Absent (rather than `false`) for entries without coverage.
     #[serde(default, skip_serializing_if = "core::ops::Not::not")]

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1259,9 +1259,9 @@ export type components = {
        */
       readonly floors?: readonly components["schemas"]["FloorResponse"][];
       /**
-       * @description Whether this building/area has AStA Iris learning-room coverage.
+       * @description Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
        *
-       * Derived at data-build time by matching the AStA Iris room roster against our aliases.
+       * Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
        * When `true`, the page can offer a learning-room availability view without a second request.
        * Absent (rather than `false`) for entries without coverage.
        */

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -200,7 +200,6 @@ const suggestLocationFix = () => {
         id="details-no_floor_overlay"
       />
       <Toast v-if="data.props.comment" :msg="data.props.comment" id="details-comment"/>
-      <DetailsIrisCoverageCard :has-coverage="data.props.has_iris_coverage"/>
     </div>
 
     <!-- Property Table -->
@@ -213,6 +212,8 @@ const suggestLocationFix = () => {
     <div class="flex flex-col gap-6">
       <DetailsBuildingOverviewSection :buildings="data.sections?.buildings_overview"/>
       <ClientOnly>
+        <!-- Browser-side live status; gated on the build-time signal so uncovered pages issue no Iris request. -->
+        <LazyDetailsIrisCoverageCard v-if="data.props.has_iris_coverage" :building-id="data.id"/>
         <LazyDetailsRoomOverviewSection :rooms="data.sections?.rooms_overview"/>
         <LazyDetailsNearbyTransportSection :id="data.id"/>
       </ClientOnly>

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -1,47 +1,138 @@
 <script setup lang="ts">
 import { mdiBookOpenPageVariantOutline, mdiOpenInNew } from "@mdi/js";
+import { useIrisAvailability } from "~/composables/irisAvailability";
+import {
+  bookedUntilTime,
+  IRIS_SITE_URL,
+  type IrisRoomRow,
+  isKnownStatus,
+  occupancyPercent,
+} from "~/utils/iris";
 
 const props = defineProps<{
-  // Absent (rather than `false`) for entries without coverage, so an undefined value
-  // must render nothing rather than an empty state.
-  readonly hasCoverage?: boolean;
+  // The NavigaTUM building id whose Iris learning rooms to show. Only passed for entries whose
+  // build-time `has_iris_coverage` signal is true, so the parent gates the browser-side fetch.
+  readonly buildingId: string;
 }>();
 
 const { t } = useI18n({ useScope: "local" });
 
-const IRIS_URL = "https://iris.asta.tum.de/";
+const cardEl = ref<HTMLElement | null>(null);
+const { rooms, loading } = useIrisAvailability(() => props.buildingId, cardEl);
+
+// Hide once the first snapshot settled with nothing to show (a failed first load, or no room that
+// resolved to a NavigaTUM page) - that is the silent-degradation path. The card stays mounted while
+// loading so its element can be observed and the fetch can start when it scrolls into view.
+const visible = computed(() => loading.value || rooms.value.length > 0);
+
+function statusLabel(status: string): string {
+  // German status words are passed through; the four known statuses are localized.
+  return isKnownStatus(status) ? t(`status.${status}`) : status;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  frei: "text-green-900 dark:text-green-50 bg-green-100 dark:bg-green-800",
+  belegt: "text-red-900 dark:text-red-50 bg-red-100 dark:bg-red-800",
+  WAAS: "text-sky-900 dark:text-sky-50 bg-sky-100 dark:bg-sky-800",
+};
+const STATUS_BADGE_FALLBACK = "text-zinc-700 dark:text-zinc-200 bg-zinc-200 dark:bg-zinc-600";
+
+function badgeClass(status: string): string {
+  return STATUS_BADGE[status] ?? STATUS_BADGE_FALLBACK;
+}
+
+// The secondary line under a room: booker/until for booked rooms, occupancy for sensor rooms.
+function detailLine(room: IrisRoomRow): string {
+  if (room.status === "belegt") {
+    const until = room.bookedUntil ? bookedUntilTime(room.bookedUntil) : null;
+    if (room.bookedBy && until) return t("booked_by_until", { by: room.bookedBy, time: until });
+    if (until) return t("until", { time: until });
+    if (room.bookedBy) return t("booked_by", { by: room.bookedBy });
+  }
+  if (room.occupancy) return t("occupancy", { percent: occupancyPercent(room.occupancy) });
+  return "";
+}
 </script>
 
 <template>
-  <div
-    v-if="props.hasCoverage"
-    class="text-blue-900 dark:text-blue-50 bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded p-3 text-sm flex flex-row gap-3 print:!hidden"
-  >
-    <MdiIcon :path="mdiBookOpenPageVariantOutline" :size="20" class="mt-0.5 shrink-0" aria-hidden="true" />
-    <div class="flex flex-col items-start gap-2">
-      <div class="flex flex-col gap-0.5">
-        <span class="font-semibold">{{ t("title") }}</span>
-        <span>{{ t("description") }}</span>
-      </div>
-      <Btn
-        :to="IRIS_URL"
-        variant="link"
-        size="text-sm gap-1.5 rounded font-semibold"
-      >
-        {{ t("cta") }}
-        <MdiIcon :path="mdiOpenInNew" :size="16" class="my-auto" aria-hidden="true" />
+  <section v-if="visible" ref="cardEl" class="flex flex-col gap-3 print:!hidden">
+    <div class="flex flex-row items-baseline justify-between gap-2">
+      <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold flex flex-row items-center gap-2">
+        <MdiIcon :path="mdiBookOpenPageVariantOutline" :size="20" class="text-blue-600 dark:text-blue-300" aria-hidden="true" />
+        {{ t("title") }}
+      </p>
+      <Btn :to="IRIS_SITE_URL" variant="link" size="text-xs gap-1 rounded font-semibold">
+        {{ t("source") }}
+        <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
       </Btn>
     </div>
-  </div>
+
+    <div
+      v-if="loading && !rooms.length"
+      class="text-zinc-500 dark:text-zinc-400 text-sm"
+    >
+      {{ t("loading") }}
+    </div>
+    <ul
+      v-else
+      class="bg-zinc-100 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 flex flex-col gap-1 rounded-sm border p-2"
+    >
+      <li v-for="room in rooms" :key="room.archName">
+        <NuxtLinkLocale
+          :to="room.path"
+          class="group text-zinc-700 dark:text-zinc-200 hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-white dark:hover:text-black flex flex-col gap-0.5 rounded-sm px-2 py-1.5"
+        >
+          <span class="flex flex-row items-center justify-between gap-2">
+            <span class="truncate font-medium">{{ room.name }}</span>
+            <span class="flex shrink-0 flex-row items-center gap-1.5">
+              <span
+                v-if="room.occupancy"
+                class="inline-block h-2.5 w-2.5 rounded-full ring-1 ring-black/10 dark:ring-white/20"
+                :style="{ backgroundColor: room.occupancy.color }"
+                aria-hidden="true"
+              />
+              <span class="rounded-sm px-1.5 py-0.5 text-xs font-semibold" :class="badgeClass(room.status)">
+                {{ statusLabel(room.status) }}
+              </span>
+            </span>
+          </span>
+          <span
+            v-if="detailLine(room)"
+            class="text-zinc-500 dark:text-zinc-300 group-hover:text-white dark:group-hover:text-black truncate text-xs"
+          >
+            {{ detailLine(room) }}
+          </span>
+        </NuxtLinkLocale>
+      </li>
+    </ul>
+  </section>
 </template>
 
 <i18n lang="yaml">
 de:
-  title: Auf der Suche nach einem Lernplatz?
-  description: AStA Iris zeigt, welche Lernräume in diesem Gebäude gerade frei sind.
-  cta: Freien Lernraum finden
+  title: Lernräume
+  source: via AStA Iris
+  loading: Live-Verfügbarkeit wird geladen…
+  occupancy: "{percent}% belegt"
+  until: bis {time}
+  booked_by: "{by}"
+  booked_by_until: "{by} · bis {time}"
+  status:
+    frei: frei
+    belegt: belegt
+    unbekannt: unbekannt
+    WAAS: sensorbasiert
 en:
-  title: Looking for a place to study?
-  description: AStA Iris shows which learning rooms in this building are currently free.
-  cta: Find a free learning room
+  title: Learning rooms
+  source: via AStA Iris
+  loading: Loading live availability…
+  occupancy: "{percent}% full"
+  until: until {time}
+  booked_by: "{by}"
+  booked_by_until: "{by} · until {time}"
+  status:
+    frei: free
+    belegt: booked
+    unbekannt: unknown
+    WAAS: sensor-based
 </i18n>

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
-import { mdiBookOpenPageVariantOutline, mdiOpenInNew } from "@mdi/js";
+import {
+  mdiAccountGroup,
+  mdiCheck,
+  mdiChevronDown,
+  mdiChevronRight,
+  mdiChevronUp,
+  mdiHelpCircle,
+  mdiLock,
+  mdiOpenInNew,
+} from "@mdi/js";
+import { useToggle } from "@vueuse/core";
 import { useIrisAvailability } from "~/composables/irisAvailability";
 import {
   bookedUntilTime,
   IRIS_SITE_URL,
   type IrisRoomRow,
-  isKnownStatus,
   occupancyPercent,
 } from "~/utils/iris";
 
@@ -25,43 +34,105 @@ const { rooms, loading } = useIrisAvailability(() => props.buildingId, cardEl);
 // loading so its element can be observed and the fetch can start when it scrolls into view.
 const visible = computed(() => loading.value || rooms.value.length > 0);
 
-function statusLabel(status: string): string {
-  // German status words are passed through; the four known statuses are localized.
-  return isKnownStatus(status) ? t(`status.${status}`) : status;
+// The default view shows rooms a student could plausibly grab now: fully free (`frei`) and
+// sensor-based (`WAAS`) rooms whose avatar colour already encodes how full they are. Booked
+// (`belegt`) and unknown-status rooms hide behind the expand toggle so the sidebar stays scannable.
+function isPartiallyFree(room: IrisRoomRow): boolean {
+  return room.status === "frei" || room.status === "WAAS";
 }
 
-const STATUS_BADGE: Record<string, string> = {
-  frei: "text-green-900 dark:text-green-50 bg-green-100 dark:bg-green-800",
-  belegt: "text-red-900 dark:text-red-50 bg-red-100 dark:bg-red-800",
-  WAAS: "text-sky-900 dark:text-sky-50 bg-sky-100 dark:bg-sky-800",
-};
-const STATUS_BADGE_FALLBACK = "text-zinc-700 dark:text-zinc-200 bg-zinc-200 dark:bg-zinc-600";
+const partiallyFreeRooms = computed(() => rooms.value.filter(isPartiallyFree));
+const otherRooms = computed(() => rooms.value.filter((room) => !isPartiallyFree(room)));
+const [expanded, toggleExpanded] = useToggle(false);
+// If every room is booked/unknown, defaulting to the partial-free filter would render an empty
+// list. In that case there is no useful "show all" to expand to, so just show every room.
+const canCollapse = computed(
+  () => partiallyFreeRooms.value.length > 0 && otherRooms.value.length > 0
+);
+const visibleRooms = computed<readonly IrisRoomRow[]>(() => {
+  if (!canCollapse.value) return rooms.value;
+  // Keep the partially-free rooms on top once expanded so the useful ones stay above the fold.
+  return expanded.value ? [...partiallyFreeRooms.value, ...otherRooms.value] : partiallyFreeRooms.value;
+});
 
-function badgeClass(status: string): string {
-  return STATUS_BADGE[status] ?? STATUS_BADGE_FALLBACK;
-}
-
-// The secondary line under a room: booker/until for booked rooms, occupancy for sensor rooms.
-function detailLine(room: IrisRoomRow): string {
-  if (room.status === "belegt") {
-    const until = room.bookedUntil ? bookedUntilTime(room.bookedUntil) : null;
-    if (room.bookedBy && until) return t("booked_by_until", { by: room.bookedBy, time: until });
-    if (until) return t("until", { time: until });
-    if (room.bookedBy) return t("booked_by", { by: room.bookedBy });
+function avatarIcon(status: string): string {
+  switch (status) {
+    case "frei":
+      return mdiCheck;
+    case "belegt":
+      return mdiLock;
+    case "WAAS":
+      return mdiAccountGroup;
+    default:
+      return mdiHelpCircle;
   }
-  if (room.occupancy) return t("occupancy", { percent: occupancyPercent(room.occupancy) });
-  return "";
+}
+
+// Fixed semantic colours per status. WAAS rooms override this from the Iris-computed occupancy band
+// via `avatarStyle`, so the colour itself reads as how full the room is.
+function avatarClass(status: string): string {
+  switch (status) {
+    case "frei":
+      return "bg-green-500 dark:bg-green-400";
+    case "belegt":
+      return "bg-red-500 dark:bg-red-400";
+    case "WAAS":
+      return "bg-sky-500 dark:bg-sky-400";
+    default:
+      return "bg-zinc-400 dark:bg-zinc-500";
+  }
+}
+
+function avatarStyle(room: IrisRoomRow): Record<string, string> | undefined {
+  if (room.status === "WAAS" && room.occupancy) {
+    return { backgroundColor: room.occupancy.color };
+  }
+  return undefined;
+}
+
+// One short context line under the room name. The avatar colour carries the headline, so this
+// only needs to add the detail (a time, a percentage, or - for unknown values - the raw status).
+function detailLine(room: IrisRoomRow): string {
+  switch (room.status) {
+    case "frei":
+      return t("status.frei");
+    case "belegt": {
+      const until = room.bookedUntil ? bookedUntilTime(room.bookedUntil) : null;
+      if (until && room.bookedBy) return t("until_by", { time: until, by: room.bookedBy });
+      if (until) return t("until", { time: until });
+      if (room.bookedBy) return room.bookedBy;
+      return t("status.belegt");
+    }
+    case "WAAS":
+      return room.occupancy
+        ? t("occupancy", { percent: occupancyPercent(room.occupancy) })
+        : t("status.WAAS");
+    case "unbekannt":
+      return t("status.unbekannt");
+    default:
+      // Iris may add new status codes; pass through verbatim rather than mislabel them.
+      return room.status;
+  }
+}
+
+function statusAriaLabel(status: string): string {
+  switch (status) {
+    case "frei":
+    case "belegt":
+    case "WAAS":
+    case "unbekannt":
+      return t(`status.${status}`);
+    default:
+      return status;
+  }
 }
 </script>
 
 <template>
   <section v-if="visible" ref="cardEl" class="flex flex-col gap-3 print:!hidden">
     <div class="flex flex-row items-baseline justify-between gap-2">
-      <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold flex flex-row items-center gap-2">
-        <MdiIcon :path="mdiBookOpenPageVariantOutline" :size="20" class="text-blue-600 dark:text-blue-300" aria-hidden="true" />
-        {{ t("title") }}
-      </p>
-      <Btn :to="IRIS_SITE_URL" variant="link" size="text-xs gap-1 rounded font-semibold">
+      <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold">{{ t("title") }}</p>
+      <Btn :to="IRIS_SITE_URL" variant="link" size="text-xs gap-1 rounded">
         {{ t("source") }}
         <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
       </Btn>
@@ -73,66 +144,79 @@ function detailLine(room: IrisRoomRow): string {
     >
       {{ t("loading") }}
     </div>
-    <ul
-      v-else
-      class="bg-zinc-100 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 flex flex-col gap-1 rounded-sm border p-2"
-    >
-      <li v-for="room in rooms" :key="room.archName">
-        <NuxtLinkLocale
-          :to="room.path"
-          class="group text-zinc-700 dark:text-zinc-200 hover:bg-blue-500 dark:hover:bg-blue-400 hover:text-white dark:hover:text-black flex flex-col gap-0.5 rounded-sm px-2 py-1.5"
-        >
-          <span class="flex flex-row items-center justify-between gap-2">
-            <span class="truncate font-medium">{{ room.name }}</span>
-            <span class="flex shrink-0 flex-row items-center gap-1.5">
-              <span
-                v-if="room.occupancy"
-                class="inline-block h-2.5 w-2.5 rounded-full ring-1 ring-black/10 dark:ring-white/20"
-                :style="{ backgroundColor: room.occupancy.color }"
-                aria-hidden="true"
-              />
-              <span class="rounded-sm px-1.5 py-0.5 text-xs font-semibold" :class="badgeClass(room.status)">
-                {{ statusLabel(room.status) }}
-              </span>
-            </span>
-          </span>
-          <span
-            v-if="detailLine(room)"
-            class="text-zinc-500 dark:text-zinc-300 group-hover:text-white dark:group-hover:text-black truncate text-xs"
+    <div v-else class="text-zinc-600 dark:text-zinc-300 grid grid-cols-1 gap-3">
+      <NuxtLinkLocale
+        v-for="room in visibleRooms"
+        :key="room.archName"
+        :to="room.path"
+        class="focusable border-zinc-200 dark:border-zinc-700 flex flex-row items-center justify-between gap-3 rounded-sm border border-solid p-3.5 !no-underline hover:bg-zinc-100 dark:hover:bg-zinc-800"
+      >
+        <div class="flex flex-row items-center gap-3 min-w-0">
+          <div
+            class="text-white dark:text-black min-w-11 h-11 w-11 rounded-full p-2 flex items-center justify-center shrink-0"
+            :class="avatarClass(room.status)"
+            :style="avatarStyle(room)"
+            :aria-label="statusAriaLabel(room.status)"
           >
-            {{ detailLine(room) }}
-          </span>
-        </NuxtLinkLocale>
-      </li>
-    </ul>
+            <MdiIcon :path="avatarIcon(room.status)" :size="24" aria-hidden="true" />
+          </div>
+          <div class="flex flex-col justify-evenly min-w-0">
+            <div class="line-clamp-2 text-balance text-zinc-800 dark:text-zinc-100">{{ room.name }}</div>
+            <small class="text-zinc-600 dark:text-zinc-300 truncate">{{ detailLine(room) }}</small>
+          </div>
+        </div>
+        <MdiIcon :path="mdiChevronRight" :size="16" class="shrink-0" aria-hidden="true" />
+      </NuxtLinkLocale>
+    </div>
+    <Btn
+      v-if="canCollapse"
+      variant="linkButton"
+      :aria-label="expanded ? t('show_less_aria') : t('show_more_aria', { count: otherRooms.length })"
+      @click="toggleExpanded()"
+    >
+      <template v-if="expanded">
+        <MdiIcon :path="mdiChevronUp" :size="16" class="mt-0.5" />
+        {{ t("show_less") }}
+      </template>
+      <template v-else>
+        <MdiIcon :path="mdiChevronDown" :size="16" class="mt-0.5" />
+        {{ t("show_more", { count: otherRooms.length }) }}
+      </template>
+    </Btn>
   </section>
 </template>
 
 <i18n lang="yaml">
 de:
   title: Lernräume
-  source: via AStA Iris
+  source: via Studentische Vertretung IRIS
   loading: Live-Verfügbarkeit wird geladen…
   occupancy: "{percent}% belegt"
   until: bis {time}
-  booked_by: "{by}"
-  booked_by_until: "{by} · bis {time}"
+  until_by: "bis {time} · {by}"
+  show_more: "alle anzeigen ({count} weitere)"
+  show_less: weniger anzeigen
+  show_more_aria: "alle Räume anzeigen, einschließlich {count} weiterer belegter oder unbekannter Räume"
+  show_less_aria: nur (teilweise) freie Räume anzeigen
   status:
     frei: frei
     belegt: belegt
-    unbekannt: unbekannt
+    unbekannt: Status unbekannt
     WAAS: sensorbasiert
 en:
   title: Learning rooms
-  source: via AStA Iris
+  source: via Studentische Vertretung IRIS
   loading: Loading live availability…
-  occupancy: "{percent}% full"
+  occupancy: "{percent}% in use"
   until: until {time}
-  booked_by: "{by}"
-  booked_by_until: "{by} · until {time}"
+  until_by: "until {time} · {by}"
+  show_more: "show all ({count} more)"
+  show_less: show less
+  show_more_aria: "show all rooms, including {count} more booked or unknown rooms"
+  show_less_aria: show only (partially) free rooms
   status:
     frei: free
     belegt: booked
-    unbekannt: unknown
+    unbekannt: status unknown
     WAAS: sensor-based
 </i18n>

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -133,7 +133,8 @@ function statusAriaLabel(status: string): string {
     <div class="flex flex-row items-baseline justify-between gap-2">
       <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold">{{ t("title") }}</p>
       <Btn :to="IRIS_SITE_URL" variant="link" size="text-xs gap-1 rounded">
-        {{ t("source") }}
+        <span class="sm:hidden">{{ t("source_short") }}</span>
+        <span class="hidden sm:inline">{{ t("source") }}</span>
         <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
       </Btn>
     </div>
@@ -144,7 +145,7 @@ function statusAriaLabel(status: string): string {
     >
       {{ t("loading") }}
     </div>
-    <div v-else class="text-zinc-600 dark:text-zinc-300 grid grid-cols-1 gap-3">
+    <div v-else class="text-zinc-600 dark:text-zinc-300 grid grid-cols-1 sm:grid-cols-2 gap-3">
       <NuxtLinkLocale
         v-for="room in visibleRooms"
         :key="room.archName"
@@ -190,6 +191,7 @@ function statusAriaLabel(status: string): string {
 de:
   title: Lernräume
   source: via Studentische Vertretung IRIS
+  source_short: via SV IRIS
   loading: Live-Verfügbarkeit wird geladen…
   occupancy: "{percent}% belegt"
   until: bis {time}
@@ -206,6 +208,7 @@ de:
 en:
   title: Learning rooms
   source: via Studentische Vertretung IRIS
+  source_short: via SV IRIS
   loading: Loading live availability…
   occupancy: "{percent}% in use"
   until: until {time}

--- a/webclient/app/composables/irisAvailability.ts
+++ b/webclient/app/composables/irisAvailability.ts
@@ -1,0 +1,101 @@
+import {
+  tryOnScopeDispose,
+  useDocumentVisibility,
+  useElementVisibility,
+  useTimeoutPoll,
+} from "@vueuse/core";
+import { useIrisSnapshot } from "~/composables/irisSnapshot";
+import { buildRoomRows, type IrisRoomRow, roomsForBuilding } from "~/utils/iris";
+
+// Iris recomputes room status roughly once a minute, so polling faster would only repeat work.
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Drive the live Iris learning-room availability for one building.
+ *
+ * Builds on {@link useIrisSnapshot} for the browser-side roster fetch, filters it to the building,
+ * resolves each room's `raum_nr_architekt` to a NavigaTUM room via the alias lookup (caching results,
+ * omitting misses), and refreshes every {@link POLL_INTERVAL_MS} while the card is both on-screen and
+ * in a foreground tab. Every fetch degrades silently: a failed poll keeps the last good snapshot.
+ */
+export function useIrisAvailability(
+  buildingId: MaybeRefOrGetter<string>,
+  target: MaybeRefOrGetter<HTMLElement | null | undefined>
+) {
+  const { locale } = useI18n();
+  const runtimeConfig = useRuntimeConfig();
+  const snapshot = useIrisSnapshot();
+
+  const rooms = shallowRef<readonly IrisRoomRow[]>([]);
+  // `loading` stays true only until the first snapshot settles, so the card can show a placeholder
+  // until then and hide afterwards if nothing resolved (the silent-degradation path).
+  const loading = ref(true);
+
+  // archName → resolved NavigaTUM path, or `null` once looked up but unmatched. Aliases are stable
+  // across polls, so each is resolved at most once; `redirect_url` is locale-independent.
+  const resolved = new Map<string, string | null>();
+
+  let resolveBatch: AbortController | null = null;
+  tryOnScopeDispose(() => resolveBatch?.abort());
+
+  async function resolveAlias(archName: string, signal: AbortSignal): Promise<void> {
+    if (resolved.has(archName)) return;
+    try {
+      const res = await fetch(
+        `${runtimeConfig.public.apiURL}/api/locations/${encodeURIComponent(archName)}?lang=${locale.value}`,
+        { credentials: "omit", signal }
+      );
+      if (!res.ok) {
+        // A 404 means the room has no NavigaTUM alias; record the miss so it is never retried.
+        // Other errors (5xx, network) are left unresolved so a later poll can try again.
+        if (res.status === 404) resolved.set(archName, null);
+        return;
+      }
+      const body = (await res.json()) as { redirect_url?: string | null };
+      resolved.set(archName, body.redirect_url ?? null);
+    } catch {
+      // Transient failure - leave the alias unresolved and retry on the next poll.
+    }
+  }
+
+  async function refresh(): Promise<void> {
+    const all = await snapshot.refresh();
+    // On failure or abort keep the last good rows; only the loading placeholder needs clearing.
+    if (all === null) {
+      loading.value = false;
+      return;
+    }
+
+    resolveBatch?.abort();
+    const controller = new AbortController();
+    resolveBatch = controller;
+    const buildingRooms = roomsForBuilding(all, toValue(buildingId));
+    await Promise.all(buildingRooms.map((room) => resolveAlias(room.archName, controller.signal)));
+    if (controller.signal.aborted) return;
+
+    rooms.value = buildRoomRows(buildingRooms, resolved);
+    loading.value = false;
+  }
+
+  // `useTimeoutPoll` awaits each async refresh before scheduling the next, so a slow resolve cannot
+  // pile up overlapping polls; `immediateCallback` refreshes the moment polling resumes.
+  const poll = useTimeoutPoll(refresh, POLL_INTERVAL_MS, {
+    immediate: false,
+    immediateCallback: true,
+  });
+
+  // Poll only while the card is both on-screen and in a foreground tab; pause otherwise.
+  const documentVisible = useDocumentVisibility();
+  const onScreen = useElementVisibility(target);
+  const active = computed(() => documentVisible.value === "visible" && onScreen.value);
+  watch(
+    active,
+    (isActive) => {
+      if (isActive) poll.resume();
+      else poll.pause();
+    },
+    { immediate: true }
+  );
+
+  return { rooms, loading };
+}

--- a/webclient/app/composables/irisSnapshot.ts
+++ b/webclient/app/composables/irisSnapshot.ts
@@ -1,0 +1,41 @@
+import { tryOnScopeDispose } from "@vueuse/core";
+import { IRIS_API_URL, type IrisRoom, parseIrisRooms } from "~/utils/iris";
+
+/**
+ * Own the browser-side fetch of the full AStA Iris room roster.
+ *
+ * The roster is fetched directly from `iris.asta.tum.de` (public, CORS-`*`) and never proxied
+ * through the NavigaTUM server. Each {@link refresh} aborts a still-pending one so a slow earlier
+ * response cannot overwrite a faster later one, and any failure degrades silently: `refresh` resolves
+ * to `null` and sets {@link failed} instead of throwing, leaving the last good {@link rooms} in place.
+ */
+export function useIrisSnapshot() {
+  const rooms = shallowRef<readonly IrisRoom[]>([]);
+  const failed = ref(false);
+
+  let inFlight: AbortController | null = null;
+  tryOnScopeDispose(() => inFlight?.abort());
+
+  async function refresh(): Promise<readonly IrisRoom[] | null> {
+    inFlight?.abort();
+    const controller = new AbortController();
+    inFlight = controller;
+    try {
+      const res = await fetch(IRIS_API_URL, { credentials: "omit", signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      if (controller.signal.aborted) return null;
+      rooms.value = parseIrisRooms(body);
+      failed.value = false;
+      return rooms.value;
+    } catch {
+      if (controller.signal.aborted) return null;
+      failed.value = true;
+      return null;
+    } finally {
+      if (inFlight === controller) inFlight = null;
+    }
+  }
+
+  return { rooms, failed, refresh };
+}

--- a/webclient/app/composables/irisSnapshot.ts
+++ b/webclient/app/composables/irisSnapshot.ts
@@ -2,7 +2,7 @@ import { tryOnScopeDispose } from "@vueuse/core";
 import { IRIS_API_URL, type IrisRoom, parseIrisRooms } from "~/utils/iris";
 
 /**
- * Own the browser-side fetch of the full AStA Iris room roster.
+ * Own the browser-side fetch of the full Studentische Vertretung IRIS room roster.
  *
  * The roster is fetched directly from `iris.asta.tum.de` (public, CORS-`*`) and never proxied
  * through the NavigaTUM server. Each {@link refresh} aborts a still-pending one so a slow earlier

--- a/webclient/app/utils/iris.ts
+++ b/webclient/app/utils/iris.ts
@@ -1,10 +1,10 @@
-// Types and pure derivation for the AStA Iris learning-room availability card.
+// Types and pure derivation for the Studentische Vertretung IRIS learning-room availability card.
 //
 // The browser-side fetch, per-room alias resolution, and polling live in the
 // `useIrisAvailability` composable. Everything here is pure (no Nuxt auto-imports,
 // no network) so the parsing and alias-join logic stays unit-testable.
 
-// Public, unauthenticated AStA Iris endpoints. The API sends `Access-Control-Allow-Origin: *`,
+// Public, unauthenticated Studentische Vertretung IRIS endpoints. The API sends `Access-Control-Allow-Origin: *`,
 // so the browser may fetch it directly - NavigaTUM never proxies live status.
 export const IRIS_API_URL = "https://iris.asta.tum.de/api/";
 export const IRIS_SITE_URL = "https://iris.asta.tum.de/";
@@ -71,7 +71,7 @@ function parseOccupancy(raw: Record<string, unknown>): IrisOccupancy | null {
 }
 
 /**
- * Parse the AStA Iris `GET /api/` body into the rooms we render.
+ * Parse the Studentische Vertretung IRIS `GET /api/` body into the rooms we render.
  *
  * Tolerant by design: a malformed body yields an empty list and individual rooms missing the
  * fields we depend on are skipped, so a partial response degrades gracefully instead of throwing.

--- a/webclient/app/utils/iris.ts
+++ b/webclient/app/utils/iris.ts
@@ -1,0 +1,148 @@
+// Types and pure derivation for the AStA Iris learning-room availability card.
+//
+// The browser-side fetch, per-room alias resolution, and polling live in the
+// `useIrisAvailability` composable. Everything here is pure (no Nuxt auto-imports,
+// no network) so the parsing and alias-join logic stays unit-testable.
+
+// Public, unauthenticated AStA Iris endpoints. The API sends `Access-Control-Allow-Origin: *`,
+// so the browser may fetch it directly - NavigaTUM never proxies live status.
+export const IRIS_API_URL = "https://iris.asta.tum.de/api/";
+export const IRIS_SITE_URL = "https://iris.asta.tum.de/";
+
+// The four statuses Iris documents. Any other value is passed through verbatim.
+export const IRIS_STATUSES = ["frei", "belegt", "WAAS", "unbekannt"] as const;
+export type IrisStatus = (typeof IRIS_STATUSES)[number];
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set(IRIS_STATUSES);
+
+/** Whether `status` is one of the statuses we localize (vs. an unknown value to pass through). */
+export function isKnownStatus(status: string): status is IrisStatus {
+  return KNOWN_STATUSES.has(status);
+}
+
+export interface IrisOccupancy {
+  // Occupancy as a fraction in `[0, 1]`. The raw Wi-Fi-counter value can dip slightly
+  // negative around an empty room, so it is clamped on parse.
+  readonly percent: number;
+  // The colour band Iris computed for this occupancy, a hex string like `#5cb85c`. Rendered as-is.
+  readonly color: string;
+}
+
+export interface IrisRoom {
+  // `<arch_name>@<building_id>` (e.g. `1450@5504`). Globally unique and, when present,
+  // a NavigaTUM room alias - this is the key the alias lookup resolves.
+  readonly archName: string;
+  readonly name: string;
+  readonly code: string;
+  // The NavigaTUM building id this room belongs to (Iris `gebaeude_code`, 1:1 with our ids).
+  readonly buildingId: string;
+  readonly status: string;
+  // `belegt` rooms only: who booked the room and until when, as raw Iris strings. Null when absent.
+  readonly bookedBy: string | null;
+  readonly bookedUntil: string | null;
+  // `WAAS` (Wi-Fi-counter) rooms only; null otherwise.
+  readonly occupancy: IrisOccupancy | null;
+}
+
+// An Iris room whose alias resolved to a NavigaTUM entity, ready to render as a linked row.
+export interface IrisRoomRow extends IrisRoom {
+  // Canonical in-app path of the matched NavigaTUM room, e.g. `/room/5504.01.450`.
+  readonly path: string;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+// Iris encodes "no value" as the empty string rather than omitting the key.
+function nonEmpty(value: unknown): string | null {
+  const str = asString(value);
+  return str !== null && str.trim() !== "" ? str : null;
+}
+
+function parseOccupancy(raw: Record<string, unknown>): IrisOccupancy | null {
+  if (raw.status !== "WAAS") return null;
+  const color = nonEmpty(raw.color);
+  const percent = raw.percent;
+  if (color === null || typeof percent !== "number" || Number.isNaN(percent)) return null;
+  return { percent: Math.min(1, Math.max(0, percent)), color };
+}
+
+/**
+ * Parse the AStA Iris `GET /api/` body into the rooms we render.
+ *
+ * Tolerant by design: a malformed body yields an empty list and individual rooms missing the
+ * fields we depend on are skipped, so a partial response degrades gracefully instead of throwing.
+ */
+export function parseIrisRooms(json: unknown): IrisRoom[] {
+  if (typeof json !== "object" || json === null) return [];
+  const raeume = (json as { raeume?: unknown }).raeume;
+  if (!Array.isArray(raeume)) return [];
+
+  const rooms: IrisRoom[] = [];
+  for (const entry of raeume) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const raw = entry as Record<string, unknown>;
+    const archName = nonEmpty(raw.raum_nr_architekt);
+    const buildingId = nonEmpty(raw.gebaeude_code);
+    const status = nonEmpty(raw.status);
+    if (archName === null || buildingId === null || status === null) continue;
+
+    rooms.push({
+      archName,
+      name: nonEmpty(raw.raum_name) ?? nonEmpty(raw.raum_code) ?? archName,
+      code: nonEmpty(raw.raum_code) ?? archName,
+      buildingId,
+      status,
+      bookedBy: nonEmpty(raw.belegung_durch),
+      bookedUntil: nonEmpty(raw.belegung_bis),
+      occupancy: parseOccupancy(raw),
+    });
+  }
+  return rooms;
+}
+
+/** Keep only the rooms Iris attributes to `buildingId`. */
+export function roomsForBuilding(rooms: readonly IrisRoom[], buildingId: string): IrisRoom[] {
+  return rooms.filter((room) => room.buildingId === buildingId);
+}
+
+/** The integer occupancy percentage (`0`..`100`) to display for a WAAS room. */
+export function occupancyPercent(occupancy: IrisOccupancy): number {
+  return Math.round(occupancy.percent * 100);
+}
+
+/**
+ * Best-effort `HH:MM` from an Iris booked-until timestamp like `2026-06-06 19:28:40`.
+ *
+ * Iris returns a timezone-less local-time string; a regex extraction avoids the engine-dependent
+ * parsing of `new Date(...)` for that format. The raw value is returned when no time is found.
+ */
+export function bookedUntilTime(raw: string): string {
+  const match = raw.match(/(\d{1,2}):(\d{2})/);
+  if (!match) return raw;
+  const [, hours = "", minutes = ""] = match;
+  return `${hours.padStart(2, "0")}:${minutes}`;
+}
+
+/**
+ * Join parsed rooms with the resolved alias→path map, preserving Iris order.
+ *
+ * `resolved` maps an `archName` to the matched NavigaTUM path, or to `null` when the alias was
+ * looked up but no entity matched. Rooms that are unresolved (`undefined`) or unmatched (`null`)
+ * are silently omitted, mirroring the build-time coverage join.
+ */
+export function buildRoomRows(
+  rooms: readonly IrisRoom[],
+  resolved: ReadonlyMap<string, string | null>
+): IrisRoomRow[] {
+  const rows: IrisRoomRow[] = [];
+  for (const room of rooms) {
+    const path = resolved.get(room.archName);
+    if (!path) continue;
+    rows.push({ ...room, path });
+  }
+  return rows;
+}

--- a/webclient/content/about/datenschutz.md
+++ b/webclient/content/about/datenschutz.md
@@ -59,6 +59,14 @@ Die Verarbeitung basiert auf Grundlage des Art. 6 Abs. 1 lit. f DSGVO (berechtig
 Der Browser der Nutzer:in kontaktiert die [Transitous-API für den öffentlichen Verkehr](https://transitous.org) (`https://api.transitous.org`) **direkt** für die Echtzeit-Abfahrten.
 NavigaTUM proxyt diese Anfragen nicht und sieht die Antwort nicht.
 
+#### Lernraum-Verfügbarkeit
+
+Detailseiten von Gebäuden bzw. Bereichen, für die eine Lernraum-Abdeckung vorliegt, enthalten den Abschnitt "Lernräume", der den aktuellen Belegungsstatus von Lernräumen des Gebäudes anzeigt.
+Die Verarbeitung basiert auf Grundlage des Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der Anzeige der aktuellen Lernraum-Verfügbarkeit für das angezeigte Gebäude).
+Der Browser der Nutzer:in kontaktiert hierfür die [AStA-Iris-Lernraum-Anzeige](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **direkt**.
+Anders als beim öffentlichen Verkehr wird diese Anfrage nicht erst durch eine ausdrückliche Aktion ausgelöst, sondern automatisch, sobald der Abschnitt sichtbar ist, und danach etwa alle 60 Sekunden wiederholt (Details siehe Abschnitt "Empfänger").
+NavigaTUM proxyt diese Anfragen nicht und sieht die Antwort nicht.
+
 ### Empfänger von personenbezogenen Daten
 
 Der technische Betrieb unserer Datenverarbeitungssysteme erfolgt durch:
@@ -73,7 +81,18 @@ E-Mail: lrzpost(at)lrz.de
 www.lrz.de
 ```
 
-Für die Funktion "Naheliegender öffentlicher Verkehr" kontaktiert der Browser der Nutzer:in zusätzlich einen Drittanbieter:
+#### Browser-seitig kontaktierte Drittanbieter-Dienste
+
+Einige Funktionen zeigen Live-Daten an, indem der Browser der Nutzer:in einen Drittanbieter **direkt** kontaktiert.
+Für alle diese Dienste gilt gleichermaßen: NavigaTUM proxyt diese Anfragen nicht, sieht die Antworten nicht und speichert daraus keine Daten.
+Bei jeder Anfrage erreichen den jeweiligen Drittanbieter die technisch notwendigen Angaben - insbesondere die IP-Adresse der Nutzer:in sowie die vom Browser standardmäßig gesendeten HTTP-Header (`User-Agent`, `Referer`).
+Der `Referer` ist durch die Referrer-Policy von NavigaTUM auf den Origin `https://nav.tum.de/` beschränkt.
+Es werden **keine** NavigaTUM-Kennungen der Nutzer:in und **keine** an anderer Stelle eingegebene Suchanfrage mitgesendet.
+NavigaTUM hat mit keinem dieser Anbieter einen Vertrag.
+
+Derzeit betrifft das folgende Dienste:
+
+**Naheliegender öffentlicher Verkehr - Transitous**
 
 ```plain
 Transitous - Community-betriebenes freies und offenes ÖPNV-Routing
@@ -81,13 +100,27 @@ https://transitous.org
 Quelle / Kontakt: https://github.com/public-transport/transitous
 ```
 
-Folgende Daten werden vom Browser der Nutzer:in an `api.transitous.org` übermittelt, sobald eine Haltestelle aufgeklappt wird:
+Der Browser kontaktiert `https://api.transitous.org` erst, sobald die Nutzer:in eine konkrete Haltestelle aufklappt.
+Zusätzlich zu den oben genannten Angaben werden dabei übermittelt:
 
-- die Haltestellen-ID (z.B. eine DELFI-/GTFS-Stop-ID) der Haltestelle, die geöffnet wurde
+- die Haltestellen-ID (z.B. eine DELFI-/GTFS-Stop-ID) der aufgeklappten Haltestelle
 - das angefragte Sprach-Tag (`de` oder `en`)
-- die vom Browser standardmäßig gesendeten HTTP-Header, insbesondere die IP-Adresse, der `User-Agent` und der `Referer` - Letzterer ist durch die Referrer-Policy von NavigaTUM auf den Origin `https://nav.tum.de/` beschränkt.
 
-NavigaTUM hat keinen Vertrag mit Transitous und sieht die Antwort nicht. Wie Transitous die Anfragen verarbeitet, ist in deren [Datenschutzerklärung](https://transitous.org/privacy/) beschrieben (Kurzfassung: IP, Zeitpunkt, angefragte URL und `User-Agent` werden bis zu 2 Tage protokolliert).
+Wie Transitous die Anfragen verarbeitet, ist in deren [Datenschutzerklärung](https://transitous.org/privacy/) beschrieben (Kurzfassung: IP, Zeitpunkt, angefragte URL und `User-Agent` werden bis zu 2 Tage protokolliert).
+
+**Lernraum-Verfügbarkeit - AStA Iris**
+
+```plain
+AStA Iris - Lernraum-Anzeige der Studentischen Vertretung der TU München
+Verantwortliche Stelle: Technische Universität München, Arcisstraße 21, 80333 München
+https://iris.asta.tum.de
+```
+
+Auf Gebäude-/Bereichsseiten mit Lernraum-Abdeckung kontaktiert der Browser `https://iris.asta.tum.de/api/` automatisch, sobald der Abschnitt "Lernräume" sichtbar ist, und danach etwa alle 60 Sekunden erneut.
+Sobald der Abschnitt aus dem Sichtfeld scrollt oder der Browser-Tab in den Hintergrund wechselt, pausiert die Aktualisierung.
+Über die oben genannten Angaben hinaus werden **keine** weiteren Parameter übermittelt: Die Anfrage ruft stets die vollständige, für alle Nutzer:innen identische Iris-Raumliste ab und enthält insbesondere **keine** Angabe dazu, welches Gebäude die Nutzer:in gerade betrachtet.
+
+Wie die Anfragen verarbeitet werden, ist in der [Datenschutzerklärung von AStA Iris](https://www.devapp.it.tum.de/iris/app/about) beschrieben (Kurzfassung: Der Webserver protokolliert u.a. IP-Adresse, Zeitpunkt und angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert; der Betrieb erfolgt durch das LRZ).
 
 Gegebenenfalls werden Ihre Daten an die zuständigen Aufsichts- und Rechnungsprüfungsbehörden zur Wahrnehmung der jeweiligen Kontrollrechte übermittelt.
 
@@ -124,6 +157,12 @@ Laut der [Datenschutzerklärung von Transitous](https://transitous.org/privacy/)
 - den `User-Agent`-Header
 
 Nach 2 Tagen werden die Logeinträge gelöscht. Eine frühere Löschung von Einträgen, die einer Person zugeordnet werden können (z.B. über IP-Adresse und Zeitfenster), kann per E-Mail direkt bei der Transitous-Serverbetreibung angefragt werden; die entsprechende Adresse ist auf <https://transitous.org/privacy/> veröffentlicht.
+
+#### Lernraum-Verfügbarkeit
+
+NavigaTUM speichert keine Daten aus der Funktion "Lernräume".
+Die Anfrage verlässt den Browser der Nutzer:in direkt in Richtung der AStA-Iris-Anzeige und die Antwort wird ausschließlich clientseitig dargestellt.
+Eine etwaige Protokollierung erfolgt allein auf Seiten von AStA Iris als Betreiber: Laut dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) protokolliert der Webserver u.a. die IP-Adresse, den Zeitpunkt und die angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert (Betrieb durch das LRZ).
 
 ## Ihre Rechte
 
@@ -321,3 +360,13 @@ Die Anfrage geht direkt vom Browser der Nutzer:in an die Transitous-API für den
 
 **Bereitstellung vorgeschrieben oder erforderlich:**
 Die Bereitstellung der Haltestellen-ID und der Anfrage erfolgt freiwillig; klappt die Nutzer:in den Abschnitt nicht auf, werden keine Daten an Transitous übermittelt.
+
+#### Lernraum-Verfügbarkeit
+
+Auf Gebäude-/Bereichsseiten mit Lernraum-Abdeckung zeigt der Abschnitt "Lernräume" den aktuellen Belegungsstatus der Lernräume. Sobald dieser Abschnitt sichtbar ist, lädt der Browser den Status automatisch und aktualisiert ihn etwa alle 60 Sekunden; bei nicht sichtbarem Abschnitt oder im Hintergrund liegendem Tab pausiert die Aktualisierung.
+
+**Empfänger:**
+Die Anfrage geht direkt vom Browser der Nutzer:in an die AStA-Iris-Anzeige (`https://iris.asta.tum.de/api/`). NavigaTUM proxyt diese Anfragen nicht, sieht die Antwort nicht und speichert keine Daten aus dieser Funktion. Die Anfrage enthält keine NavigaTUM-Kennung und keine Angabe zum betrachteten Gebäude. Wie AStA Iris als Betreiber die Anfragen verarbeitet, ist in dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) beschrieben.
+
+**Bereitstellung vorgeschrieben oder erforderlich:**
+Die Bereitstellung erfolgt freiwillig; ruft die Nutzer:in keine Gebäude-/Bereichsseite mit Lernraum-Abdeckung auf bzw. ist der Abschnitt nicht sichtbar, werden keine Daten an die AStA-Iris-Anzeige übermittelt.

--- a/webclient/content/about/datenschutz.md
+++ b/webclient/content/about/datenschutz.md
@@ -63,7 +63,7 @@ NavigaTUM proxyt diese Anfragen nicht und sieht die Antwort nicht.
 
 Detailseiten von Gebäuden bzw. Bereichen, für die eine Lernraum-Abdeckung vorliegt, enthalten den Abschnitt "Lernräume", der den aktuellen Belegungsstatus von Lernräumen des Gebäudes anzeigt.
 Die Verarbeitung basiert auf Grundlage des Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der Anzeige der aktuellen Lernraum-Verfügbarkeit für das angezeigte Gebäude).
-Der Browser der Nutzer:in kontaktiert hierfür die [AStA-Iris-Lernraum-Anzeige](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **direkt**.
+Der Browser der Nutzer:in kontaktiert hierfür die [IRIS-Lernraum-Anzeige der Studentischen Vertretung](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **direkt**.
 Anders als beim öffentlichen Verkehr wird diese Anfrage nicht erst durch eine ausdrückliche Aktion ausgelöst, sondern automatisch, sobald der Abschnitt sichtbar ist, und danach etwa alle 60 Sekunden wiederholt (Details siehe Abschnitt "Empfänger").
 NavigaTUM proxyt diese Anfragen nicht und sieht die Antwort nicht.
 
@@ -108,10 +108,10 @@ Zusätzlich zu den oben genannten Angaben werden dabei übermittelt:
 
 Wie Transitous die Anfragen verarbeitet, ist in deren [Datenschutzerklärung](https://transitous.org/privacy/) beschrieben (Kurzfassung: IP, Zeitpunkt, angefragte URL und `User-Agent` werden bis zu 2 Tage protokolliert).
 
-**Lernraum-Verfügbarkeit - AStA Iris**
+**Lernraum-Verfügbarkeit - Studentische Vertretung IRIS**
 
 ```plain
-AStA Iris - Lernraum-Anzeige der Studentischen Vertretung der TU München
+IRIS - Lernraum-Anzeige der Studentischen Vertretung der TU München
 Verantwortliche Stelle: Technische Universität München, Arcisstraße 21, 80333 München
 https://iris.asta.tum.de
 ```
@@ -120,7 +120,7 @@ Auf Gebäude-/Bereichsseiten mit Lernraum-Abdeckung kontaktiert der Browser `htt
 Sobald der Abschnitt aus dem Sichtfeld scrollt oder der Browser-Tab in den Hintergrund wechselt, pausiert die Aktualisierung.
 Über die oben genannten Angaben hinaus werden **keine** weiteren Parameter übermittelt: Die Anfrage ruft stets die vollständige, für alle Nutzer:innen identische Iris-Raumliste ab und enthält insbesondere **keine** Angabe dazu, welches Gebäude die Nutzer:in gerade betrachtet.
 
-Wie die Anfragen verarbeitet werden, ist in der [Datenschutzerklärung von AStA Iris](https://www.devapp.it.tum.de/iris/app/about) beschrieben (Kurzfassung: Der Webserver protokolliert u.a. IP-Adresse, Zeitpunkt und angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert; der Betrieb erfolgt durch das LRZ).
+Wie die Anfragen verarbeitet werden, ist in der [Datenschutzerklärung von IRIS der Studentischen Vertretung](https://www.devapp.it.tum.de/iris/app/about) beschrieben (Kurzfassung: Der Webserver protokolliert u.a. IP-Adresse, Zeitpunkt und angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert; der Betrieb erfolgt durch das LRZ).
 
 Gegebenenfalls werden Ihre Daten an die zuständigen Aufsichts- und Rechnungsprüfungsbehörden zur Wahrnehmung der jeweiligen Kontrollrechte übermittelt.
 
@@ -161,8 +161,8 @@ Nach 2 Tagen werden die Logeinträge gelöscht. Eine frühere Löschung von Eint
 #### Lernraum-Verfügbarkeit
 
 NavigaTUM speichert keine Daten aus der Funktion "Lernräume".
-Die Anfrage verlässt den Browser der Nutzer:in direkt in Richtung der AStA-Iris-Anzeige und die Antwort wird ausschließlich clientseitig dargestellt.
-Eine etwaige Protokollierung erfolgt allein auf Seiten von AStA Iris als Betreiber: Laut dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) protokolliert der Webserver u.a. die IP-Adresse, den Zeitpunkt und die angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert (Betrieb durch das LRZ).
+Die Anfrage verlässt den Browser der Nutzer:in direkt in Richtung der IRIS-Anzeige der Studentischen Vertretung und die Antwort wird ausschließlich clientseitig dargestellt.
+Eine etwaige Protokollierung erfolgt allein auf Seiten der Studentischen Vertretung IRIS als Betreiber: Laut dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) protokolliert der Webserver u.a. die IP-Adresse, den Zeitpunkt und die angefragte URL; Logeinträge, die älter als sieben Tage sind, werden durch Kürzung der IP-Adresse anonymisiert (Betrieb durch das LRZ).
 
 ## Ihre Rechte
 
@@ -366,7 +366,7 @@ Die Bereitstellung der Haltestellen-ID und der Anfrage erfolgt freiwillig; klapp
 Auf Gebäude-/Bereichsseiten mit Lernraum-Abdeckung zeigt der Abschnitt "Lernräume" den aktuellen Belegungsstatus der Lernräume. Sobald dieser Abschnitt sichtbar ist, lädt der Browser den Status automatisch und aktualisiert ihn etwa alle 60 Sekunden; bei nicht sichtbarem Abschnitt oder im Hintergrund liegendem Tab pausiert die Aktualisierung.
 
 **Empfänger:**
-Die Anfrage geht direkt vom Browser der Nutzer:in an die AStA-Iris-Anzeige (`https://iris.asta.tum.de/api/`). NavigaTUM proxyt diese Anfragen nicht, sieht die Antwort nicht und speichert keine Daten aus dieser Funktion. Die Anfrage enthält keine NavigaTUM-Kennung und keine Angabe zum betrachteten Gebäude. Wie AStA Iris als Betreiber die Anfragen verarbeitet, ist in dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) beschrieben.
+Die Anfrage geht direkt vom Browser der Nutzer:in an die IRIS-Anzeige der Studentischen Vertretung (`https://iris.asta.tum.de/api/`). NavigaTUM proxyt diese Anfragen nicht, sieht die Antwort nicht und speichert keine Daten aus dieser Funktion. Die Anfrage enthält keine NavigaTUM-Kennung und keine Angabe zum betrachteten Gebäude. Wie die Studentische Vertretung IRIS als Betreiber die Anfragen verarbeitet, ist in dessen [Datenschutzerklärung](https://www.devapp.it.tum.de/iris/app/about) beschrieben.
 
 **Bereitstellung vorgeschrieben oder erforderlich:**
-Die Bereitstellung erfolgt freiwillig; ruft die Nutzer:in keine Gebäude-/Bereichsseite mit Lernraum-Abdeckung auf bzw. ist der Abschnitt nicht sichtbar, werden keine Daten an die AStA-Iris-Anzeige übermittelt.
+Die Bereitstellung erfolgt freiwillig; ruft die Nutzer:in keine Gebäude-/Bereichsseite mit Lernraum-Abdeckung auf bzw. ist der Abschnitt nicht sichtbar, werden keine Daten an die IRIS-Anzeige der Studentischen Vertretung übermittelt.

--- a/webclient/content/en/about/privacy.md
+++ b/webclient/content/en/about/privacy.md
@@ -67,7 +67,7 @@ NavigaTUM does not proxy these requests and does not see the response.
 
 Detail pages of buildings or areas that have learning-room coverage include a "Learning rooms" section showing the current occupancy status of the building's learning rooms.
 The processing is based on Art. 6 para. 1 lit. f GDPR (legitimate interest in showing the current learning-room availability for the displayed building).
-For this, the user's browser contacts the [AStA Iris learning-room display](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **directly**.
+For this, the user's browser contacts the [Studentische Vertretung IRIS learning-room display](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **directly**.
 Unlike the public-transport feature, this request is not triggered by an explicit action: it is sent automatically once the section becomes visible and then repeated roughly every 60 seconds (see the "Recipients" section for details).
 NavigaTUM does not proxy these requests and does not see the response.
 
@@ -112,10 +112,10 @@ In addition to the information listed above, the following is transmitted:
 
 Transitous's own handling of these requests is described in their [privacy policy](https://transitous.org/privacy/) (summary: IP, time, requested URL and `User-Agent` are logged for up to 2 days).
 
-**Learning-room availability - AStA Iris**
+**Learning-room availability - Studentische Vertretung IRIS**
 
 ```plain
-AStA Iris - learning-room display of the student representation of TU Munich
+IRIS - learning-room display of the Studentische Vertretung (student representation) of TU Munich
 Responsible body: Technical University of Munich, Arcisstraße 21, 80333 Munich
 https://iris.asta.tum.de
 ```
@@ -124,7 +124,7 @@ On building/area pages that have learning-room coverage, the browser contacts `h
 As soon as the section scrolls out of view or the browser tab moves to the background, the refresh pauses.
 Beyond the information listed above, **no** further parameters are transmitted: the request always fetches the full Iris room list, which is identical for every user, and in particular contains **no** indication of which building the user is currently viewing.
 
-How these requests are processed is described in the [AStA Iris privacy policy](https://www.devapp.it.tum.de/iris/app/about) (summary: the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address; operated by the LRZ).
+How these requests are processed is described in the [Studentische Vertretung IRIS privacy policy](https://www.devapp.it.tum.de/iris/app/about) (summary: the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address; operated by the LRZ).
 
 If necessary, your data will be transmitted to the competent supervisory and auditing authorities for the exercise of
 the respective control rights.
@@ -169,8 +169,8 @@ After 2 days the log entries are deleted. Earlier deletion of entries that can b
 #### Learning-room availability
 
 NavigaTUM does not store any data from the "Learning rooms" feature.
-The request leaves the user's browser directly for the AStA Iris display and the response is rendered client-side only.
-Any logging takes place solely at AStA Iris as the operator: per its [privacy policy](https://www.devapp.it.tum.de/iris/app/about), the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address (operated by the LRZ).
+The request leaves the user's browser directly for the Studentische Vertretung IRIS display and the response is rendered client-side only.
+Any logging takes place solely at Studentische Vertretung IRIS as the operator: per its [privacy policy](https://www.devapp.it.tum.de/iris/app/about), the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address (operated by the LRZ).
 
 ## Your rights
 
@@ -396,7 +396,7 @@ The provision of the stop identifier and the request itself is voluntary; if the
 On building/area pages that have learning-room coverage, the "Learning rooms" section shows the current occupancy status of the learning rooms. Once this section is visible, the browser loads the status automatically and refreshes it roughly every 60 seconds; while the section is off-screen or the tab is in the background, the refresh pauses.
 
 **Recipient:**
-The request goes directly from the user's browser to the AStA Iris display (`https://iris.asta.tum.de/api/`). NavigaTUM does not proxy these requests, does not see the response and does not store any data from this feature. The request contains no NavigaTUM identifier and no indication of the building being viewed. How AStA Iris, as the operator, processes these requests is described in its [privacy policy](https://www.devapp.it.tum.de/iris/app/about).
+The request goes directly from the user's browser to the Studentische Vertretung IRIS display (`https://iris.asta.tum.de/api/`). NavigaTUM does not proxy these requests, does not see the response and does not store any data from this feature. The request contains no NavigaTUM identifier and no indication of the building being viewed. How Studentische Vertretung IRIS, as the operator, processes these requests is described in its [privacy policy](https://www.devapp.it.tum.de/iris/app/about).
 
 **Provision prescribed or required:**
-The provision is voluntary; if the user does not open a building/area page that has learning-room coverage, or the section is not visible, no data is sent to the AStA Iris display.
+The provision is voluntary; if the user does not open a building/area page that has learning-room coverage, or the section is not visible, no data is sent to the Studentische Vertretung IRIS display.

--- a/webclient/content/en/about/privacy.md
+++ b/webclient/content/en/about/privacy.md
@@ -63,6 +63,14 @@ The processing is based on Art. 6 para. 1 lit. f GDPR (legitimate interest in of
 The user's browser contacts the [Transitous public-transport API](https://transitous.org) (`https://api.transitous.org`) **directly** to fetch real-time departures.
 NavigaTUM does not proxy these requests and does not see the response.
 
+#### Learning-room availability
+
+Detail pages of buildings or areas that have learning-room coverage include a "Learning rooms" section showing the current occupancy status of the building's learning rooms.
+The processing is based on Art. 6 para. 1 lit. f GDPR (legitimate interest in showing the current learning-room availability for the displayed building).
+For this, the user's browser contacts the [AStA Iris learning-room display](https://iris.asta.tum.de) (`https://iris.asta.tum.de/api/`) **directly**.
+Unlike the public-transport feature, this request is not triggered by an explicit action: it is sent automatically once the section becomes visible and then repeated roughly every 60 seconds (see the "Recipients" section for details).
+NavigaTUM does not proxy these requests and does not see the response.
+
 ### Recipients of personal data
 
 The technical operation of our data processing systems is carried out by:
@@ -77,7 +85,18 @@ E-mail: lrzpost(at)lrz.de
 www.lrz.de
 ```
 
-For the "Nearby public transport" feature, the user's browser additionally contacts a third-party service:
+#### Third-party services contacted from the browser
+
+Some features show live data by having the user's browser contact a third-party service **directly**.
+The same applies to all of these services: NavigaTUM does not proxy these requests, does not see the responses and stores no data from them.
+With every request, the technically necessary information reaches the respective third party - in particular the user's IP address and the browser-default HTTP headers (`User-Agent`, `Referer`).
+The `Referer` is restricted by NavigaTUM's referrer policy to the origin `https://nav.tum.de/`.
+**No** NavigaTUM identifier of the user and **no** search query entered elsewhere is sent along.
+NavigaTUM has no contract with any of these providers.
+
+This currently concerns the following services:
+
+**Nearby public transport - Transitous**
 
 ```plain
 Transitous - community-run free and open public-transport routing
@@ -85,13 +104,27 @@ https://transitous.org
 Source / contact: https://github.com/public-transport/transitous
 ```
 
-The following data is transmitted to `api.transitous.org` by the user's browser when the user expands a station:
+The browser contacts `https://api.transitous.org` only once the user expands a specific station.
+In addition to the information listed above, the following is transmitted:
 
 - the public-transport stop identifier (e.g. a DELFI/GTFS stop ID) for the station the user opened
 - the requested language tag (`de` or `en`)
-- the browser-default HTTP request headers, in particular the IP address, the `User-Agent` and the `Referer` - the latter is restricted by NavigaTUM's referrer policy to the origin `https://nav.tum.de/`.
 
-NavigaTUM has no contract with Transitous and does not see the response. Transitous's own handling of these requests is described in their [privacy policy](https://transitous.org/privacy/) (summary: IP, time, requested URL and `User-Agent` are logged for up to 2 days).
+Transitous's own handling of these requests is described in their [privacy policy](https://transitous.org/privacy/) (summary: IP, time, requested URL and `User-Agent` are logged for up to 2 days).
+
+**Learning-room availability - AStA Iris**
+
+```plain
+AStA Iris - learning-room display of the student representation of TU Munich
+Responsible body: Technical University of Munich, Arcisstraße 21, 80333 Munich
+https://iris.asta.tum.de
+```
+
+On building/area pages that have learning-room coverage, the browser contacts `https://iris.asta.tum.de/api/` automatically once the "Learning rooms" section becomes visible, and then again roughly every 60 seconds.
+As soon as the section scrolls out of view or the browser tab moves to the background, the refresh pauses.
+Beyond the information listed above, **no** further parameters are transmitted: the request always fetches the full Iris room list, which is identical for every user, and in particular contains **no** indication of which building the user is currently viewing.
+
+How these requests are processed is described in the [AStA Iris privacy policy](https://www.devapp.it.tum.de/iris/app/about) (summary: the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address; operated by the LRZ).
 
 If necessary, your data will be transmitted to the competent supervisory and auditing authorities for the exercise of
 the respective control rights.
@@ -132,6 +165,12 @@ Per the [Transitous privacy policy](https://transitous.org/privacy/), Transitous
 - the `User-Agent` header
 
 After 2 days the log entries are deleted. Earlier deletion of entries that can be attributed to you (for example by IP address and timeframe) can be requested by e-mail directly from the Transitous server maintainer; the address is published on <https://transitous.org/privacy/>.
+
+#### Learning-room availability
+
+NavigaTUM does not store any data from the "Learning rooms" feature.
+The request leaves the user's browser directly for the AStA Iris display and the response is rendered client-side only.
+Any logging takes place solely at AStA Iris as the operator: per its [privacy policy](https://www.devapp.it.tum.de/iris/app/about), the web server logs the IP address, time and requested URL among others; log entries older than seven days are anonymized by truncating the IP address (operated by the LRZ).
 
 ## Your rights
 
@@ -351,3 +390,13 @@ The request goes directly from the user's browser to the Transitous public-trans
 
 **Provision prescribed or required:**
 The provision of the stop identifier and the request itself is voluntary; if the user does not expand the section no data is sent to Transitous.
+
+#### Learning-room availability
+
+On building/area pages that have learning-room coverage, the "Learning rooms" section shows the current occupancy status of the learning rooms. Once this section is visible, the browser loads the status automatically and refreshes it roughly every 60 seconds; while the section is off-screen or the tab is in the background, the refresh pauses.
+
+**Recipient:**
+The request goes directly from the user's browser to the AStA Iris display (`https://iris.asta.tum.de/api/`). NavigaTUM does not proxy these requests, does not see the response and does not store any data from this feature. The request contains no NavigaTUM identifier and no indication of the building being viewed. How AStA Iris, as the operator, processes these requests is described in its [privacy policy](https://www.devapp.it.tum.de/iris/app/about).
+
+**Provision prescribed or required:**
+The provision is voluntary; if the user does not open a building/area page that has learning-room coverage, or the section is not visible, no data is sent to the AStA Iris display.

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -10,7 +10,8 @@
 		"type-check": "nuxt typecheck",
 		"type-refresh": "openapi-typescript ../openapi.yaml --output app/api_types/index.ts --export-type --immutable-types --support-array-length && pnpm run format && pnpm run lint && pnpm run type-check",
 		"lint": "biome lint --write --error-on-warnings . ",
-		"format": "biome format --write && biome check --formatter-enabled=false --linter-enabled=false --write"
+		"format": "biome format --write && biome check --formatter-enabled=false --linter-enabled=false --write",
+		"test": "vitest run"
 	},
 	"dependencies": {
 		"@fullcalendar/core": "6.1.20",
@@ -48,6 +49,7 @@
 		"openapi-typescript": "7.13.0",
 		"tailwindcss": "4.3.0",
 		"typescript": "6.0.3",
+		"vitest": "4.1.8",
 		"vue-tsc": "3.3.3"
 	},
 	"type": "module",

--- a/webclient/pnpm-lock.yaml
+++ b/webclient/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(vite@8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       vue-tsc:
         specifier: 3.3.3
         version: 3.3.3(typescript@6.0.3)
@@ -288,28 +291,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
@@ -801,105 +800,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1284,56 +1267,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-yqskeIapQvx7Tu/OLsepLPcGsHGzfYy9PX6gIbhaOHfF+LA2zHBKnKb587FGx+lQjHLQR0llfmoSuXQ6q2EN+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-r7PnUNxRB9D/gQjCVeasoieJVUF48n43rvk/jYbGAw9sRfYGoEo/rOs0GyTZU9ttss8HzjBaerAbADbAL8K8vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-omXWC8I9lAMMjQIeadfItP5H4VDAiuU2BiVCtHMH3ktTbFq04sxscZhK4NFUUuw3fApDdXmfd7LW18q0JBHarg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-LtFA3Hi8LVD/zuiPLKy9Aiz7N1IOj8rRhdXiW38GKQ9mAhj+Ko6IHGcTk2A7yNDA1DZBl7r+Qd4PEGWgVelPPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-rFsPDsT1j3beSInbrFukAAlTg101PcqdVMXDioR9AgJ1180tZ8s8D+pNDpQTRmPd3956mnpAE+Cs77Xoo/QZAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-xlrtAmDWZI8BEmsaXMYfblWuLIY5UnnRkit1VLkmVDb5ceZRZf4oEXK1QeYf5Z33dT0WK1Ek++P+TL/ZMCpyGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-kd36CDkTkZDMNfVceNTSfpWnitE1+GjZmzJCeq8yaxsgvs/MXg8aauI2RgFjElYZIHSMyZku4pQ7Jtl3ZEYI6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.133.0':
     resolution: {integrity: sha512-pI38dJBqfkNbFoL/GEarAzGDjKGVCZTdg0a8NKh1PP9GqWleXT6HLtXE4CZ+54e+2u68qVYVBwhbWAiRfwlUZA==}
@@ -1453,112 +1428,96 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-gnu@0.133.0':
     resolution: {integrity: sha512-hvpbqT5pN2rR+3+xtWeizwfR/aZ0vGceg6TqYMl+ToxMpk9/tmnX7kSvQnfEUkoua8mhogzvIKsAkn0wxgblBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.128.0':
     resolution: {integrity: sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.128.0':
     resolution: {integrity: sha512-21LGNIZb1Pcfk5/EGsqabrxv4yqQOWis1407JJrClS7XpFCrbvr74YAB1V+m54cYbwvO6UWwQqS4WecxiyfCRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.128.0':
     resolution: {integrity: sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.128.0':
     resolution: {integrity: sha512-X6Q2oKUrP5GyDd2xniuEBLk6aFQCZ97W2+aVXGgJXdjx5t4/oFuA9ri0wLOUrBIX+qdSuK581snMBio4z910eA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.128.0':
     resolution: {integrity: sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.128.0':
     resolution: {integrity: sha512-OO1nW2Q7sSYYvJZpDHdvyFSdRaVcQqRijZSSmWVMqFxPYy8cEF45zJ9fcdIYuzIT3jYq6YRhEFm/VMWNWhE22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.128.0':
     resolution: {integrity: sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.128.0':
     resolution: {integrity: sha512-kVbqgW9xLL8bh8oc7aYOJilRKXE5G33+tE0jan+duo/9OriaFRpijcCwT2waWs2oqYROYq0GlE7/p3ywoshVeg==}
@@ -1716,112 +1675,96 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-gnu@0.133.0':
     resolution: {integrity: sha512-VstR+NEQAJb80ysWk2vPjEvg0JzwEjKn2hDbC/joa5zGXkCnVVCWgAGG8c6o23S981a7XRpCMcClBgeD1q9H2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.128.0':
     resolution: {integrity: sha512-dPSjyd0gQ9dE3mpdJi0BHNJaqQz4V7mVW6Fbs6jRSiGnrxwGfXdMJFInXoJ49B3k5Zhfa9Is9Ixp6St7c6ouCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-Ec7xJdDrnukgiz20E3iDNzAIgx1XXn8cVVsNNUpgEIAvNlXZaocqlQT8Zalk0Lv3fbkxcJ+9BuWB0ndBRHQtzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.128.0':
     resolution: {integrity: sha512-YNa9XAotPKvAXFJrHC7kBsHMVg0HOB4vRiKuYUjzFsfLkxTbuztKHTKG/gW5kjp7dBw+TNFofTaVCVZgOnHXPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-6YX38grimcigz20eYpyz6e4c9rDKzwK3i+tcDpgwYj0bWreaAOwrABmSmKplPJOorkDVlbT69wPCN+d11irBQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.128.0':
     resolution: {integrity: sha512-jjSiG9H8ya/U3igW5DdIBFIDwhffF7Vbc7th2tcHV73eg0DQz75n36a9RmQ1/0aS9vknUuNtY6SODr8/gmuzsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-WxMIzItRJR66lgaAyyqj0FFwLMpcuCV9mTFcUMQpIz8+Hey1Enk8xuv+7QpSsqCR5zRlwNr092dsFkz5cbvtrw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.128.0':
     resolution: {integrity: sha512-FVUr/XNT7BfQA4XVMel/HTCJi5mQyEitslgX42ztYPnCFMRFG1sQQKgnlLJdl7qifuyxpvKLR1f7h7HEuwWw1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-+x6dnO87986rjVNjcF0tg8wVS0e/SH8nzLa/X0Wsh7jtEniN7buvR8iqZm8pnsfaZ8DH5F4GCSZpoPRrd9jJ6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.128.0':
     resolution: {integrity: sha512-caJnVw5PG8v339zAyHgA7p34xXa3A4Kc9VyrDgsT1znr51qacaUv4BRlgRi0qkqxRWXYNVFfsbU2g0t1qS7E9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-oEyQudXIwWM/+v0vZzPbAi25YMWyvjtQYYjuSrhMEQwe7ZEMDXscX7U1j6alrVdZq2DtCMeror3X/Dv7p/JUwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.128.0':
     resolution: {integrity: sha512-zkQKjsHEUX3ckQBcZTtHE/7pgFMkWQp6y/4t7N8eT3j8wnoL+vapv7l4ISjgx1/EePRJN1HErYXmriz7tPVKRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-G8P/OadKTbyUHz5TK63sDDtUHwn2SXG/o0oGo4GGTzBu70xmUSN5/ZUgpyl6ypAmbshoyw8nC7+msb3BjzHxaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.128.0':
     resolution: {integrity: sha512-NjYtwl9ijp34iisHxYBvE7nii1Ac0QPP3doHv8MQHhDA3zjUcDCROuBNybfaEYCxnJ1aF+cAPqsyeopnAGsyuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-Oi/fyOzZ+aytmmsRND5pGgvux4n++v9cG4qNFiXj7qFwSqBKWZHBq7cJLXqbH1I81pyI3kvU1Za+1qk3afXuwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.128.0':
     resolution: {integrity: sha512-itsi0tVkVdrYphSppdFChLq9tD0pvbRRS3EV8NQYKZ/NWHMoxzjlf9TFA/ZZYV113juYo1Dq3glVX48knhBeFQ==}
@@ -1910,42 +1853,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -2036,42 +1973,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -2214,79 +2145,66 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -2422,28 +2340,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2510,8 +2424,14 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2615,6 +2535,35 @@ packages:
     peerDependencies:
       vite: ^8.0.0-beta.8
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^8.0.0-beta.8
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2828,6 +2777,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -3010,6 +2963,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
@@ -3512,6 +3469,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -4076,28 +4037,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5157,6 +5114,9 @@ packages:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5226,6 +5186,9 @@ packages:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -5350,6 +5313,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -5368,6 +5334,10 @@ packages:
 
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -5744,6 +5714,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^8.0.0-beta.8
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -5828,6 +5839,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -8125,9 +8141,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -8251,6 +8274,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vue: 3.5.35(typescript@6.0.3)
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -8539,6 +8603,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.3
@@ -8720,6 +8786,8 @@ snapshots:
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   change-case@5.4.4: {}
 
@@ -9235,6 +9303,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
 
@@ -11605,6 +11675,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -11677,6 +11749,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   srvx@0.11.16: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -11834,6 +11908,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@1.2.2: {}
@@ -11849,6 +11925,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyqueue@3.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -12186,6 +12264,33 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(vite@8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.2.0:
@@ -12282,6 +12387,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/webclient/test/iris.test.ts
+++ b/webclient/test/iris.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  bookedUntilTime,
+  buildRoomRows,
+  isKnownStatus,
+  occupancyPercent,
+  parseIrisRooms,
+  roomsForBuilding,
+} from "../app/utils/iris";
+
+// A small slice of a real `GET https://iris.asta.tum.de/api/` response, covering each status and
+// the WAAS occupancy fields. The `BC2 ...` arch-name and `D 5@4113` are genuine roster entries that
+// have no NavigaTUM alias - they exercise the silent-omission path.
+const IRIS_FIXTURE = {
+  raeume: [
+    {
+      raum_nr_architekt: "1450@5504",
+      raum_name: "Zeichensaal",
+      raum_code: "MW 1450",
+      gebaeude_code: "5504",
+      status: "WAAS",
+      belegung_durch: "",
+      belegung_bis: "",
+      color: "#5cb85c",
+      percent: 0.03,
+      subtitle: "frei",
+    },
+    {
+      raum_nr_architekt: "D 5@4113",
+      raum_name: "Karaokeraum",
+      raum_code: "D 5",
+      gebaeude_code: "4113",
+      status: "belegt",
+      belegung_durch: "IRIS",
+      belegung_bis: "2026-06-06 19:28:40",
+    },
+    {
+      raum_nr_architekt: "BC2 0.01.18@8102",
+      raum_name: "Seminarraum",
+      raum_code: "BC2 0.01.18",
+      gebaeude_code: "8102",
+      status: "frei",
+      belegung_durch: "",
+      belegung_bis: "",
+    },
+    {
+      raum_nr_architekt: "0.01.19@8102",
+      raum_name: "Übungsraum",
+      raum_code: "BC2 0.01.19",
+      gebaeude_code: "8102",
+      status: "unbekannt",
+      belegung_durch: "",
+      belegung_bis: "",
+    },
+    {
+      // A WAAS reading can dip slightly negative around an empty room; it must clamp to 0.
+      raum_nr_architekt: "U1@5532",
+      raum_name: "Foyer",
+      raum_code: "MW U1",
+      gebaeude_code: "5532",
+      status: "WAAS",
+      belegung_durch: "",
+      belegung_bis: "",
+      color: "#5cb85c",
+      percent: -0.0667,
+      subtitle: "frei",
+    },
+  ],
+};
+
+describe("parseIrisRooms", () => {
+  it("extracts every room with its core fields", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    expect(rooms.map((r) => r.archName)).toEqual([
+      "1450@5504",
+      "D 5@4113",
+      "BC2 0.01.18@8102",
+      "0.01.19@8102",
+      "U1@5532",
+    ]);
+    expect(rooms[0]).toMatchObject({
+      name: "Zeichensaal",
+      code: "MW 1450",
+      buildingId: "5504",
+      status: "WAAS",
+    });
+  });
+
+  it("reads booker and booked-until only for booked rooms, mapping empty strings to null", () => {
+    const [waas, belegt, frei] = parseIrisRooms(IRIS_FIXTURE);
+    expect(belegt).toMatchObject({ bookedBy: "IRIS", bookedUntil: "2026-06-06 19:28:40" });
+    expect(waas).toMatchObject({ bookedBy: null, bookedUntil: null });
+    expect(frei).toMatchObject({ bookedBy: null, bookedUntil: null });
+  });
+
+  it("attaches occupancy only to WAAS rooms and clamps a negative reading to zero", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    expect(rooms[0]?.occupancy).toEqual({ percent: 0.03, color: "#5cb85c" });
+    expect(rooms[1]?.occupancy).toBeNull();
+    expect(rooms[2]?.occupancy).toBeNull();
+    expect(rooms[4]?.occupancy).toEqual({ percent: 0, color: "#5cb85c" });
+  });
+
+  it("degrades gracefully on malformed input", () => {
+    expect(parseIrisRooms(null)).toEqual([]);
+    expect(parseIrisRooms({})).toEqual([]);
+    expect(parseIrisRooms({ raeume: "nope" })).toEqual([]);
+    expect(parseIrisRooms("garbage")).toEqual([]);
+  });
+
+  it("skips rooms missing a key field rather than emitting partial rows", () => {
+    const rooms = parseIrisRooms({
+      raeume: [
+        { raum_name: "no arch name", gebaeude_code: "5504", status: "frei" },
+        { raum_nr_architekt: "9@5504", gebaeude_code: "5504", status: "frei" },
+      ],
+    });
+    expect(rooms.map((r) => r.archName)).toEqual(["9@5504"]);
+  });
+});
+
+describe("roomsForBuilding", () => {
+  it("keeps only the rooms Iris attributes to the building", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    expect(roomsForBuilding(rooms, "8102").map((r) => r.archName)).toEqual([
+      "BC2 0.01.18@8102",
+      "0.01.19@8102",
+    ]);
+    expect(roomsForBuilding(rooms, "0000")).toEqual([]);
+  });
+});
+
+describe("buildRoomRows (alias join)", () => {
+  it("keeps resolved rooms in order, omitting unmatched (null) and unresolved (absent) aliases", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    const resolved = new Map<string, string | null>([
+      ["1450@5504", "/room/5504.01.450"],
+      ["D 5@4113", null], // looked up, no NavigaTUM match → omit.
+      ["U1@5532", "/room/5532.EG.U1"],
+      // "BC2 0.01.18@8102" and "0.01.19@8102" are absent → not yet resolved → omit.
+    ]);
+    const rows = buildRoomRows(rooms, resolved);
+    expect(rows.map((r) => r.archName)).toEqual(["1450@5504", "U1@5532"]);
+    expect(rows[0]?.path).toBe("/room/5504.01.450");
+  });
+
+  it("returns nothing when no alias resolved", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    expect(buildRoomRows(rooms, new Map())).toEqual([]);
+  });
+});
+
+describe("display helpers", () => {
+  it("rounds occupancy to a whole percentage", () => {
+    expect(occupancyPercent({ percent: 0.75, color: "#000" })).toBe(75);
+    expect(occupancyPercent({ percent: 0.3, color: "#000" })).toBe(30);
+    expect(occupancyPercent({ percent: 0, color: "#000" })).toBe(0);
+  });
+
+  it("extracts a padded HH:MM from an Iris timestamp, falling back to the raw value", () => {
+    expect(bookedUntilTime("2026-06-06 19:28:40")).toBe("19:28");
+    expect(bookedUntilTime("2026-06-06 9:05:00")).toBe("09:05");
+    expect(bookedUntilTime("sometime")).toBe("sometime");
+  });
+
+  it("recognizes the four documented statuses and nothing else", () => {
+    expect(isKnownStatus("frei")).toBe(true);
+    expect(isKnownStatus("WAAS")).toBe(true);
+    expect(isKnownStatus("reserviert")).toBe(false);
+  });
+});

--- a/webclient/vitest.config.ts
+++ b/webclient/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// Unit tests cover the pure logic in `app/utils` (no Nuxt runtime needed), so they live outside
+// `app/` to stay clear of Nuxt's auto-import scanning.
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Live learning-room availability on covered building pages: browser-side Iris snapshot, per-room status with WAAS occupancy, 60s polling that pauses off-screen/hidden, plus the data-protection disclosure.

Stacked on #3111 — its commit shows here until that merges.

Closes #3094
Closes #3095

🤖 Generated with [Claude Code](https://claude.com/claude-code)