### PR TITLE
feat(webclient): demote start-navigation link to a toolbar icon button

### DIFF
--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -131,8 +131,8 @@ test.describe("Details Page - Navigation Actions", () => {
     // view -> building redirect
     await expect(page).toHaveURL("building/mi");
 
-    const navButton = page.getByRole("link", { name: "BETA Navigation starten" }).first();
-    expect(navButton).toBeVisible();
+    const navButton = page.getByRole("link", { name: "Navigation starten (BETA)" }).first();
+    await expect(navButton).toBeVisible();
     await expect(navButton).toHaveCount(1);
     // Scroll element into view before clicking
     await navButton.scrollIntoViewIfNeeded();

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { mdiCalendarMonth, mdiClipboardCheck, mdiLink, mdiPencil, mdiPlus } from "@mdi/js";
+import {
+  mdiCalendarMonth,
+  mdiClipboardCheck,
+  mdiDirections,
+  mdiLink,
+  mdiPencil,
+  mdiPlus,
+} from "@mdi/js";
 import { useClipboard } from "@vueuse/core";
 import type { components } from "~/api_types";
 import { emptyPropertyFields, useEditProposal } from "~/composables/editProposal";
@@ -18,6 +25,9 @@ const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const editProposal = useEditProposal();
 const calendar = useCalendar();
+
+// Navigation is a beta gimmick that only makes sense when we know the location more precisely than the building level.
+const navigationEnabled = computed(() => props.data.coords.accuracy !== "building");
 
 const clipboardSource = computed(() => `https://nav.tum.de${route.fullPath}`);
 const {
@@ -159,6 +169,16 @@ const suggestLocationFix = () => {
     <div class="flex flex-wrap items-center justify-between gap-y-2 mb-6">
       <span class="text-zinc-500 dark:text-zinc-400 text-sm font-medium">{{ data.type_common_name }}</span>
       <div class="flex flex-row items-center gap-3">
+        <NuxtLinkLocale
+          v-if="navigationEnabled"
+          :to="`/navigate?coming_from=${data.id}&to=${data.id}&q_to=${data.name}`"
+          class="focusable rounded-sm print:hidden"
+          :title="t('header.start_navigation')"
+          :aria-label="t('header.start_navigation')"
+          prefetch-on="interaction"
+        >
+          <MdiIcon :path="mdiDirections" :size="26" class="text-blue-600 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-50"/>
+        </NuxtLinkLocale>
         <button
           v-if="data.props?.calendar_url"
           type="button"
@@ -205,8 +225,7 @@ const suggestLocationFix = () => {
 
     <!-- Property Table -->
     <div class="mb-8">
-      <DetailsPropertyTable :id="data.id" :props="data.props" :name="data.name"
-                            :navigation-enabled="data.coords.accuracy !== 'building'"/>
+      <DetailsPropertyTable :props="data.props"/>
     </div>
 
     <!-- Extra Sections -->
@@ -232,6 +251,7 @@ de:
   header:
     calendar: Kalender öffnen
     copy_link: Link kopieren
+    start_navigation: Navigation starten (BETA)
     suggest_edit: Änderung vorschlagen
   add_first_image: Erstes Bild hinzufügen
   suggest_edit: Ich weiß wo es liegt
@@ -243,6 +263,7 @@ en:
   header:
     calendar: Open calendar
     copy_link: Copy link
+    start_navigation: Start navigation (BETA)
     suggest_edit: Suggest edit
   add_first_image: Add first image
   suggest_edit: I know where it is

--- a/webclient/app/components/DetailsPropertyTable.vue
+++ b/webclient/app/components/DetailsPropertyTable.vue
@@ -6,15 +6,12 @@ type Props = components["schemas"]["PropsResponse"];
 
 defineProps<{
   props: Props;
-  id: string;
-  name: string;
-  navigationEnabled: boolean;
 }>();
 const { t } = useI18n({ useScope: "local" });
 </script>
 
 <template>
-  <div v-if="props.links || props.computed || navigationEnabled" class="text-zinc-800 dark:text-zinc-100 flex flex-col gap-3">
+  <div v-if="props.links || props.computed" class="text-zinc-800 dark:text-zinc-100 flex flex-col gap-3">
     <p v-for="prop in props.computed" :key="prop.name" class="flex flex-col">
       <span class="text-zinc-500 dark:text-zinc-400 text-xs font-semibold uppercase">{{ prop.name }}</span>
       <span>{{ prop.text }}</span>
@@ -24,20 +21,7 @@ const { t } = useI18n({ useScope: "local" });
         </template>
       </TinyModal>
     </p>
-    <ul v-if="navigationEnabled || props.links" class="flex flex-col gap-1.5">
-      <li v-if="navigationEnabled" class="print:!hidden">
-        <Btn
-          size="text-md gap-2.5 px-3 py-1.5 rounded leading-snug"
-          variant="secondary"
-          :to="`/navigate?coming_from=${id}&to=${id}&q_to=${name}`"
-        >
-          <span
-            class="text-blue-800 bg-blue-100 my-auto me-2 h-5 min-h-5 min-w-5 rounded px-2.5 py-0.5 text-xs font-medium dark:text-blue-600 dark:bg-blue-50"
-            >BETA</span
-          >
-          {{ t("start navigation") }}
-        </Btn>
-      </li>
+    <ul v-if="props.links" class="flex flex-col gap-1.5">
       <li v-for="link in props.links" :key="link.text">
         <Btn
           size="text-md gap-2.5 px-3 py-1.5 rounded leading-snug print:!text-blue-500 dark:print:!text-blue-400"
@@ -59,9 +43,7 @@ const { t } = useI18n({ useScope: "local" });
 de:
   links: Links
   no_information_known: Keine Informationen bekannt
-  start navigation: Navigation starten
 en:
   links: Links
   no_information_known: No information known
-  start navigation: Start navigation
 </i18n>


### PR DESCRIPTION
The beta "Navigation starten" feature sat prominently in the property table with a loud BETA badge, overselling what is more of a gimmick than a real feature.

This moves it into the detail-page action toolbar as an icon button (`mdiDirections`) next to calendar, edit, share, and feedback — styled identically to those siblings. It stays a real link (`NuxtLinkLocale`) so middle-click / open-in-new-tab keep working, with the BETA disclaimer retained in the tooltip. The same `accuracy !== "building"` gating is preserved.

`type-check` and `biome check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)