### PR TITLE
feat: expose parent types so breadcrumbs & bare-ID back-links emit /{type}/{id} (#3099)

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1521,6 +1521,7 @@ components:
         - aliases
         - parents
         - parent_names
+        - parent_types
         - props
         - ranking_factors
         - sources
@@ -1581,9 +1582,7 @@ components:
             See `parents` for their actual ids.
           minItems: 1
         parent_types:
-          type:
-            - array
-            - "null"
+          type: array
           items:
             $ref: '#/components/schemas/ParentLocationTypeResponse'
           description: |-

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1585,12 +1585,7 @@ components:
             - array
             - "null"
           items:
-            type: string
-            examples:
-              - - root
-                - site
-                - area
-                - building
+            $ref: '#/components/schemas/ParentLocationTypeResponse'
           description: |-
             The types of the parents.
 
@@ -2393,6 +2388,22 @@ components:
             - We suggest, you don't show a map by default.
             - This is only the case for buildings or other such entities and not for rooms, if we know where they are and a map exists
           example: 0
+    ParentLocationTypeResponse:
+      type: string
+      description: |-
+        The type of a parent (ancestor) in a location's breadcrumb hierarchy.
+
+        Mirrors a location's `type`, plus the synthetic `root` ancestor at the top of every chain.
+      enum:
+        - root
+        - site
+        - campus
+        - area
+        - joined_building
+        - building
+        - room
+        - virtual_room
+        - poi
     PlaceResponse:
       type: object
       required:

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1594,13 +1594,8 @@ components:
           description: |-
             The types of the parents.
 
-            They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
-            and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
-            breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
-            the type `root`.
-
-            Optional so the server still deserializes data emitted by an older pipeline (where
-            this field is absent) during the rollout window before the data job repopulates the CDN.
+            They are ordered as they would appear in a Breadcrumb menu.
+            See `parents` for their actual ids.
           minItems: 1
         parents:
           type: array

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1575,10 +1575,32 @@ components:
                 - Fakultät Mathematik & Informatik (FMI oder MI)
                 - Finger 06 (BT06)
           description: |-
-            The ids of the parents.
+            The human names of the parents.
 
             They are ordered as they would appear in a Breadcrumb menu.
             See `parents` for their actual ids.
+          minItems: 1
+        parent_types:
+          type:
+            - array
+            - "null"
+          items:
+            type: string
+            examples:
+              - - root
+                - site
+                - area
+                - building
+          description: |-
+            The types of the parents.
+
+            They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
+            and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
+            breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
+            the type `root`.
+
+            Optional so the server still deserializes data emitted by an older pipeline (where
+            this field is absent) during the rollout window before the data job repopulates the CDN.
           minItems: 1
         parents:
           type: array

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -186,8 +186,12 @@ def export_for_api(data: dict[str, Any]) -> None:
 def extract_exported_item(data, entry):
     """Extract the item that will be finally exported to the api"""
     parent_names = [data[p]["name"] if p != "root" else _("Standorte", "Sites") for p in entry["parents"]]
+    # Parallel to `parents`/`parent_names`: each parent's type lets the client build the canonical
+    # /{type}/{id} breadcrumb link without a per-id round-trip. `root` is synthetic (no data entry).
+    parent_types = [data[p]["type"] if p != "root" else "root" for p in entry["parents"]]
     result = {
         "parent_names": parent_names,
+        "parent_types": parent_types,
         **entry,
     }
     if "children" in result:

--- a/data/processors/test_export.py
+++ b/data/processors/test_export.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from utils import TranslatableStr
 
 from processors.export import extract_exported_item
 
 
-def _data() -> dict:
-    """A minimal ancestor chain root -> garching -> mi, keyed by id as the pipeline keys it."""
+def _data() -> dict[str, dict[str, Any]]:
+    """Build a minimal ancestor chain root -> garching -> mi, keyed by id as the pipeline keys it."""
     return {
         "root": {"id": "root", "type": "root", "name": TranslatableStr("Standorte", "Sites"), "parents": []},
         "garching": {

--- a/data/processors/test_export.py
+++ b/data/processors/test_export.py
@@ -1,0 +1,46 @@
+from processors.export import extract_exported_item
+from utils import TranslatableStr
+
+
+def _data() -> dict:
+    """A minimal ancestor chain root -> garching -> mi, keyed by id as the pipeline keys it."""
+    return {
+        "root": {"id": "root", "type": "root", "name": TranslatableStr("Standorte", "Sites"), "parents": []},
+        "garching": {
+            "id": "garching",
+            "type": "site",
+            "name": TranslatableStr("Garching", "Garching"),
+            "parents": ["root"],
+        },
+        "mi": {
+            "id": "mi",
+            "type": "building",
+            "name": TranslatableStr("MI", "MI"),
+            "parents": ["root", "garching"],
+        },
+    }
+
+
+def test_parent_types_parallel_array_carries_each_parents_type():
+    """`parent_types` mirrors `parents`/`parent_names` so the client can build /{type}/{id} links."""
+    data = _data()
+    result = extract_exported_item(data, data["mi"])
+
+    assert result["parent_types"] == ["root", "site"]
+
+
+def test_parents_and_parent_names_are_unchanged():
+    """The additive `parent_types` field leaves the existing parallel arrays intact (rollout-safe)."""
+    data = _data()
+    result = extract_exported_item(data, data["mi"])
+
+    assert result["parents"] == ["root", "garching"]
+    assert result["parent_names"] == [TranslatableStr("Standorte", "Sites"), TranslatableStr("Garching", "Garching")]
+
+
+def test_root_parent_type_is_synthesised_without_a_data_entry():
+    """`root` has no real data entry, so its type is supplied directly rather than looked up."""
+    data = _data()
+    result = extract_exported_item(data, data["garching"])
+
+    assert result["parent_types"] == ["root"]

--- a/data/processors/test_export.py
+++ b/data/processors/test_export.py
@@ -1,5 +1,6 @@
-from processors.export import extract_exported_item
 from utils import TranslatableStr
+
+from processors.export import extract_exported_item
 
 
 def _data() -> dict:

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -140,7 +140,7 @@ struct LocationDetailsResponse {
     /// They are ordered as they would appear in a Breadcrumb menu.
     /// See `parents` for their actual ids.
     #[schema(min_items = 1)]
-    parent_types: Option<Vec<ParentLocationTypeResponse>>,
+    parent_types: Vec<ParentLocationTypeResponse>,
     /// Data for the info-card table
     props: PropsResponse,
     /// The information you need to request Images from the `/cdn/{size}/{id}_{counter}.webp` endpoint

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -129,12 +129,23 @@ struct LocationDetailsResponse {
     /// See `parent_names` for their human names.
     #[schema(min_items=1, examples(json!(["root","garching","mi", "5602"])))]
     parents: Vec<String>,
-    /// The ids of the parents.
+    /// The human names of the parents.
     ///
     /// They are ordered as they would appear in a Breadcrumb menu.
     /// See `parents` for their actual ids.
     #[schema(min_items=1, examples(json!(["Standorte","Garching Forschungszentrum","Fakultät Mathematik & Informatik (FMI oder MI)", "Finger 06 (BT06)"])))]
     parent_names: Vec<String>,
+    /// The types of the parents.
+    ///
+    /// They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
+    /// and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
+    /// breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
+    /// the type `root`.
+    ///
+    /// Optional so the server still deserializes data emitted by an older pipeline (where
+    /// this field is absent) during the rollout window before the data job repopulates the CDN.
+    #[schema(min_items=1, examples(json!(["root","site","area","building"])))]
+    parent_types: Option<Vec<String>>,
     /// Data for the info-card table
     props: PropsResponse,
     /// The information you need to request Images from the `/cdn/{size}/{id}_{counter}.webp` endpoint
@@ -589,6 +600,50 @@ mod tests {
 
     use super::*;
     use crate::{AppData, setup::tests::PostgresTestContainer};
+
+    /// A minimal-but-complete details payload, matching the shape the data pipeline stores.
+    fn base_details_json() -> serde_json::Value {
+        serde_json::json!({
+            "id": "5602.EG.001",
+            "type": "room",
+            "type_common_name": "Büro",
+            "name": "5602.EG.001",
+            "aliases": [],
+            "parents": ["root", "garching", "5602"],
+            "parent_names": ["Standorte", "Garching Forschungszentrum", "Finger 06 (BT06)"],
+            "props": {"computed": []},
+            "ranking_factors": {"rank_combined": 0, "rank_type": 0, "rank_usage": 0},
+            "sources": {"base": []},
+            "coords": {"lat": 0.0, "lon": 0.0, "source": "navigatum"},
+            "maps": {"default": "interactive"},
+        })
+    }
+
+    #[test]
+    fn parent_types_is_parsed_when_present() {
+        let mut value = base_details_json();
+        value["parent_types"] = serde_json::json!(["root", "site", "building"]);
+
+        let res = serde_json::from_value::<LocationDetailsResponse>(value).unwrap();
+
+        assert_eq!(
+            res.parent_types,
+            Some(vec![
+                "root".to_string(),
+                "site".to_string(),
+                "building".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn parent_types_absent_on_legacy_data_deserialises_to_none() {
+        // Data emitted by the currently-deployed pipeline has no `parent_types`; it must
+        // still deserialize (the field is Optional) rather than 500 during the rollout window.
+        let res = serde_json::from_value::<LocationDetailsResponse>(base_details_json()).unwrap();
+
+        assert!(res.parent_types.is_none());
+    }
 
     /// Allows testing if a modification has changed the output of the details API
     ///

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -139,8 +139,8 @@ struct LocationDetailsResponse {
     ///
     /// They are ordered as they would appear in a Breadcrumb menu.
     /// See `parents` for their actual ids.
-    #[schema(min_items=1, examples(json!(["root","site","area","building"])))]
-    parent_types: Option<Vec<String>>,
+    #[schema(min_items = 1)]
+    parent_types: Option<Vec<ParentLocationTypeResponse>>,
     /// Data for the info-card table
     props: PropsResponse,
     /// The information you need to request Images from the `/cdn/{size}/{id}_{counter}.webp` endpoint
@@ -180,6 +180,23 @@ enum LocationTypeResponse {
     Campus,
     Poi,
     Other,
+}
+
+/// The type of a parent (ancestor) in a location's breadcrumb hierarchy.
+///
+/// Mirrors a location's `type`, plus the synthetic `root` ancestor at the top of every chain.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+enum ParentLocationTypeResponse {
+    Root,
+    Site,
+    Campus,
+    Area,
+    JoinedBuilding,
+    Building,
+    Room,
+    VirtualRoom,
+    Poi,
 }
 
 /// Operator of a location
@@ -595,50 +612,6 @@ mod tests {
 
     use super::*;
     use crate::{AppData, setup::tests::PostgresTestContainer};
-
-    /// A minimal-but-complete details payload, matching the shape the data pipeline stores.
-    fn base_details_json() -> serde_json::Value {
-        serde_json::json!({
-            "id": "5602.EG.001",
-            "type": "room",
-            "type_common_name": "Büro",
-            "name": "5602.EG.001",
-            "aliases": [],
-            "parents": ["root", "garching", "5602"],
-            "parent_names": ["Standorte", "Garching Forschungszentrum", "Finger 06 (BT06)"],
-            "props": {"computed": []},
-            "ranking_factors": {"rank_combined": 0, "rank_type": 0, "rank_usage": 0},
-            "sources": {"base": []},
-            "coords": {"lat": 0.0, "lon": 0.0, "source": "navigatum"},
-            "maps": {"default": "interactive"},
-        })
-    }
-
-    #[test]
-    fn parent_types_is_parsed_when_present() {
-        let mut value = base_details_json();
-        value["parent_types"] = serde_json::json!(["root", "site", "building"]);
-
-        let res = serde_json::from_value::<LocationDetailsResponse>(value).unwrap();
-
-        assert_eq!(
-            res.parent_types,
-            Some(vec![
-                "root".to_string(),
-                "site".to_string(),
-                "building".to_string()
-            ])
-        );
-    }
-
-    #[test]
-    fn parent_types_absent_on_legacy_data_deserialises_to_none() {
-        // Data emitted by the currently-deployed pipeline has no `parent_types`; it must
-        // still deserialize (the field is Optional) rather than 500 during the rollout window.
-        let res = serde_json::from_value::<LocationDetailsResponse>(base_details_json()).unwrap();
-
-        assert!(res.parent_types.is_none());
-    }
 
     /// Allows testing if a modification has changed the output of the details API
     ///

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -137,13 +137,8 @@ struct LocationDetailsResponse {
     parent_names: Vec<String>,
     /// The types of the parents.
     ///
-    /// They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
-    /// and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
-    /// breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
-    /// the type `root`.
-    ///
-    /// Optional so the server still deserializes data emitted by an older pipeline (where
-    /// this field is absent) during the rollout window before the data job repopulates the CDN.
+    /// They are ordered as they would appear in a Breadcrumb menu.
+    /// See `parents` for their actual ids.
     #[schema(min_items=1, examples(json!(["root","site","area","building"])))]
     parent_types: Option<Vec<String>>,
     /// Data for the info-card table

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-2.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-2.snap
@@ -9,43 +9,43 @@ info: parsed_id=roomfinder
     - id: 5508.02.801
       type: room
       name: 5508.02.801 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1801@5508
       parsed_id: 1801@5508
     - id: 5510.02.001
       type: room
       name: "5510.02.001 (\u0019MW\u0017 2001 Rudolf-Diesel-Hörsaal)"
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 2001@5510
       parsed_id: 2001@5510
     - id: 5502.01.250
       type: room
       name: 5502.01.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1250@5502
       parsed_id: 1250@5502
     - id: 5502.EG.250
       type: room
       name: 5502.EG.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0250@5502
       parsed_id: 0250@5502
     - id: 5503.EG.350
       type: room
       name: 5503.EG.350 (Egbert-von-Hoyer-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0350@5503
       parsed_id: 0350@5503
     - id: 5506.EG.608M
       type: room
       name: 5506.EG.608M (Otto-Lilienthal-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0608M@5506
       parsed_id: 0608M@5506
     - id: 5510.EG.001
       type: room
       name: 5510.EG.001 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0001@5510
       parsed_id: 0001@5510
     - id: 5539.EG.001A
@@ -72,7 +72,7 @@ info: parsed_id=roomfinder
   entries:
     - id: mw
       type: joined_building
-      name: "Maschinenwesen (\u0019MW\u0017)"
+      name: Maschinenwesen
       subtext: Gebäudekomplex
     - id: "5506"
       type: building

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-3.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-3.snap
@@ -8,7 +8,7 @@ info: parsed_id=prefixed
   entries:
     - id: "5601"
       type: building
-      name: Magistrale / Foyer (BT01)
+      name: Magistrale / Foyer
       subtext: Gebäudeteil
   n_visible: 1
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-4.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats-4.snap
@@ -8,7 +8,7 @@ info: parsed_id=roomfinder
   entries:
     - id: "5601"
       type: building
-      name: Magistrale / Foyer (BT01)
+      name: Magistrale / Foyer
       subtext: Gebäudeteil
   n_visible: 1
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats.snap
@@ -9,37 +9,37 @@ info: parsed_id=prefixed
     - id: 5508.02.801
       type: room
       name: 5508.02.801 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1801@5508
     - id: 5510.02.001
       type: room
       name: "5510.02.001 (\u0019MW\u0017 2001 Rudolf-Diesel-Hörsaal)"
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 2001@5510
     - id: 5502.01.250
       type: room
       name: 5502.01.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1250@5502
     - id: 5502.EG.250
       type: room
       name: 5502.EG.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0250@5502
     - id: 5503.EG.350
       type: room
       name: 5503.EG.350 (Egbert-von-Hoyer-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0350@5503
     - id: 5506.EG.608M
       type: room
       name: 5506.EG.608M (Otto-Lilienthal-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0608M@5506
     - id: 5510.EG.001
       type: room
       name: 5510.EG.001 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0001@5510
     - id: 5539.EG.001A
       type: room
@@ -62,7 +62,7 @@ info: parsed_id=prefixed
   entries:
     - id: mw
       type: joined_building
-      name: "Maschinenwesen (\u0019MW\u0017)"
+      name: Maschinenwesen
       subtext: Gebäudekomplex
     - id: "5506"
       type: building

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010-2.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010-2.snap
@@ -9,12 +9,12 @@ info: cropping=full
     - id: 5115.01.010
       type: room
       name: 5115.01.010 (Elt. Transport)
-      subtext: "garching, Zentrum für Nanotechnologie & -materialien (ZNN)"
+      subtext: "garching, ZNN"
       subtext_bold: 1.010@5115
     - id: 5510.01.010
       type: room
       name: 5510.01.010 (Seminarraum)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1010@5510
       parsed_id: "MW \u00191010\u0017"
     - id: 0510.01.010
@@ -43,7 +43,7 @@ info: cropping=full
     - id: 0401.U1.010
       type: room
       name: 0401.U1.010 (Archiv)
-      subtext: "stammgelände, SW1)"
+      subtext: "stammgelände, SW1"
       subtext_bold: "-1010@0401"
     - id: 2906.U1.010
       type: room
@@ -59,9 +59,9 @@ info: cropping=full
     - id: 5414.01.010
       type: room
       name: 5414.01.010 (Lager)
-      subtext: "garching, Zentrum für Energie u. Information (ZEI)"
+      subtext: "garching, ZEI"
       subtext_bold: 1010@5414
-      parsed_id: "\u00191010\u0017 Zentrum für Energie u. Information (ZEI)"
+      parsed_id: "\u00191010\u0017 ZEI"
   n_visible: 10
   estimatedTotalHits: "[estimatedTotalHits]"
 - facet: sites

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010.snap
@@ -9,12 +9,12 @@ info: cropping=crop
     - id: 5115.01.010
       type: room
       name: 5115.01.010 (Elt. Transport)
-      subtext: "garching, Zentrum für Nanotechnologie & -materialien (ZNN)"
+      subtext: "garching, ZNN"
       subtext_bold: 1.010@5115
     - id: 5510.01.010
       type: room
       name: 5510.01.010 (Seminarraum)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1010@5510
       parsed_id: "MW \u00191010\u0017"
     - id: 0510.01.010
@@ -43,7 +43,7 @@ info: cropping=crop
     - id: 0401.U1.010
       type: room
       name: 0401.U1.010 (Archiv)
-      subtext: "stammgelände, SW1)"
+      subtext: "stammgelände, SW1"
       subtext_bold: "-1010@0401"
     - id: 2906.U1.010
       type: room
@@ -59,9 +59,9 @@ info: cropping=crop
     - id: 5414.01.010
       type: room
       name: 5414.01.010 (Lager)
-      subtext: "garching, Zentrum für Energie u. Information (ZEI)"
+      subtext: "garching, ZEI"
       subtext_bold: 1010@5414
-      parsed_id: "\u00191010\u0017 Zentrum…tion (ZEI)"
+      parsed_id: "\u00191010\u0017 ZEI"
   n_visible: 10
   estimatedTotalHits: "[estimatedTotalHits]"
 - facet: sites

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__custom_highlighting_with_formatting.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__custom_highlighting_with_formatting.snap
@@ -9,37 +9,37 @@ info: highlighting=<em>
     - id: 5508.02.801
       type: room
       name: 5508.02.801 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1801@5508
     - id: 5510.02.001
       type: room
       name: 5510.02.001 (<em>MW</em> 2001 Rudolf-Diesel-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 2001@5510
     - id: 5502.01.250
       type: room
       name: 5502.01.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 1250@5502
     - id: 5502.EG.250
       type: room
       name: 5502.EG.250 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0250@5502
     - id: 5503.EG.350
       type: room
       name: 5503.EG.350 (Egbert-von-Hoyer-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0350@5503
     - id: 5506.EG.608M
       type: room
       name: 5506.EG.608M (Otto-Lilienthal-Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0608M@5506
     - id: 5510.EG.001
       type: room
       name: 5510.EG.001 (Hörsaal)
-      subtext: "garching, Maschinenwesen (MW)"
+      subtext: "garching, MW"
       subtext_bold: 0001@5510
     - id: 5539.EG.001A
       type: room
@@ -62,7 +62,7 @@ info: highlighting=<em>
   entries:
     - id: mw
       type: joined_building
-      name: Maschinenwesen (<em>MW</em>)
+      name: Maschinenwesen
       subtext: Gebäudekomplex
     - id: "5506"
       type: building

--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -343,8 +343,7 @@ test.describe("Details Page - Breadcrumbs", () => {
     // Assert last breadcrumb label (current context)
     await expect(items.nth(3)).toContainText("Hörsaal 1");
 
-    // Click parent (building) breadcrumb. Breadcrumbs now emit the canonical
-    // /{type}/{id} path (here /building/5602) rather than the redirecting /view/{id}.
+    // Click parent (building) breadcrumb.
     const parentLink = items.nth(3).locator('a[href="/building/5602"]');
     await expect(parentLink).toBeVisible();
 

--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -343,8 +343,9 @@ test.describe("Details Page - Breadcrumbs", () => {
     // Assert last breadcrumb label (current context)
     await expect(items.nth(3)).toContainText("Hörsaal 1");
 
-    // Click parent (building) breadcrumb
-    const parentLink = items.nth(3).locator('a[href="/view/5602"]');
+    // Click parent (building) breadcrumb. Breadcrumbs now emit the canonical
+    // /{type}/{id} path (here /building/5602) rather than the redirecting /view/{id}.
+    const parentLink = items.nth(3).locator('a[href="/building/5602"]');
     await expect(parentLink).toBeVisible();
 
     await parentLink.click();

--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -246,9 +246,13 @@ test.describe("Navigation Page - Search route button", () => {
 
 test.describe("Navigation Page - Back Navigation", () => {
   test("should show and use back button when coming from details page", async ({ page }) => {
-    await page.goto("/navigate?from=mi&to=mw&coming_from=mi", { waitUntil: "networkidle" });
+    // The detail page passes `coming_from_type` so the back-link targets the canonical
+    // /{type}/{id} (here `mi` is a joined_building -> /building/mi), not a /view/{id} redirect.
+    await page.goto("/navigate?from=mi&to=mw&coming_from=mi&coming_from_type=joined_building", {
+      waitUntil: "networkidle",
+    });
 
-    const backButton = page.locator('a[href*="/view/mi"]').first();
+    const backButton = page.locator('a[href*="/building/mi"]').first();
     await expect(backButton).toBeVisible();
   });
 });

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -597,12 +597,24 @@ export type components = {
       /** @description The name of the entry in a human-readable form */
       readonly name: string;
       /**
-       * @description The ids of the parents.
+       * @description The human names of the parents.
        *
        * They are ordered as they would appear in a Breadcrumb menu.
        * See `parents` for their actual ids.
        */
       readonly parent_names: readonly [string, ...string[]];
+      /**
+       * @description The types of the parents.
+       *
+       * They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
+       * and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
+       * breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
+       * the type `root`.
+       *
+       * Optional so the server still deserializes data emitted by an older pipeline (where
+       * this field is absent) during the rollout window before the data job repopulates the CDN.
+       */
+      readonly parent_types?: readonly [string, ...string[]] | null;
       /**
        * @description The ids of the parents.
        *

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -606,15 +606,10 @@ export type components = {
       /**
        * @description The types of the parents.
        *
-       * They are ordered as they would appear in a Breadcrumb menu, parallel to `parents`
-       * and `parent_names`. The client uses each type to build the canonical `/{type}/{id}`
-       * breadcrumb link without a per-id round-trip. The synthetic `root` ancestor reports
-       * the type `root`.
-       *
-       * Optional so the server still deserializes data emitted by an older pipeline (where
-       * this field is absent) during the rollout window before the data job repopulates the CDN.
+       * They are ordered as they would appear in a Breadcrumb menu.
+       * See `parents` for their actual ids.
        */
-      readonly parent_types?: readonly [string, ...string[]] | null;
+      readonly parent_types?: readonly components["schemas"]["ParentLocationTypeResponse"][] | null;
       /**
        * @description The ids of the parents.
        *
@@ -1125,6 +1120,22 @@ export type components = {
        */
       readonly default?: number | null;
     };
+    /**
+     * @description The type of a parent (ancestor) in a location's breadcrumb hierarchy.
+     *
+     * Mirrors a location's `type`, plus the synthetic `root` ancestor at the top of every chain.
+     * @enum {string}
+     */
+    readonly ParentLocationTypeResponse:
+      | "root"
+      | "site"
+      | "campus"
+      | "area"
+      | "joined_building"
+      | "building"
+      | "room"
+      | "virtual_room"
+      | "poi";
     readonly PlaceResponse: {
       /** @description Alerts for this stop. */
       readonly alerts?: readonly components["schemas"]["AlertResponse"][];

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -609,7 +609,10 @@ export type components = {
        * They are ordered as they would appear in a Breadcrumb menu.
        * See `parents` for their actual ids.
        */
-      readonly parent_types?: readonly components["schemas"]["ParentLocationTypeResponse"][] | null;
+      readonly parent_types: readonly [
+        components["schemas"]["ParentLocationTypeResponse"],
+        ...components["schemas"]["ParentLocationTypeResponse"][],
+      ];
       /**
        * @description The ids of the parents.
        *

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -5,8 +5,10 @@ import { useDebounceFn } from "@vueuse/core";
 import type { components } from "~/api_types";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { type AdditionKind, emptyAdditionDraft, useEditProposal } from "~/composables/editProposal";
+import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 type FacetFilter = components["schemas"]["FacetFilter"];
+type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 
 const editProposal = useEditProposal();
 const { t } = useI18n({ useScope: "local" });
@@ -290,7 +292,25 @@ async function editExistingEntry() {
   editProposal.value.selected = { id, name: null };
   // Open the edit modal once we land on the entry's detail page.
   editProposal.value.open = true;
-  await navigateTo(localePath(`/view/${id}`));
+  // Resolve the entity's type up front so we land on its canonical /{type}/{id} path directly
+  // instead of bouncing through the /view/{id} redirect. On any failure (network, unknown type),
+  // fall back to /view/{id}, which the server redirects to the canonical path.
+  let target = `/view/${id}`;
+  try {
+    const res = await fetch(
+      `${runtimeConfig.public.apiURL}/api/locations/${encodeURIComponent(id)}`,
+      {
+        credentials: "omit",
+      }
+    );
+    if (res.ok) {
+      const details = (await res.json()) as Pick<LocationDetailsResponse, "type">;
+      if (isRoutableEntityType(details.type)) target = entityPath(id, details.type);
+    }
+  } catch {
+    // Network failure: keep the /view/{id} fallback.
+  }
+  await navigateTo(localePath(target));
 }
 provide("addProposal:editExistingEntry", editExistingEntry);
 

--- a/webclient/app/components/BreadcrumbList.vue
+++ b/webclient/app/components/BreadcrumbList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// `to` is optional: an ancestor without a canonical entity route renders as plain text.
+// `to` optional: items without a route render as plain text.
 type Item = { to?: string; name: string };
 const props = withDefaults(defineProps<{ items: Item[]; class?: string }>(), {
   class: "",

--- a/webclient/app/components/BreadcrumbList.vue
+++ b/webclient/app/components/BreadcrumbList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-type Item = { to: string; name: string };
+// `to` is optional: an ancestor without a canonical entity route renders as plain text.
+type Item = { to?: string; name: string };
 const props = withDefaults(defineProps<{ items: Item[]; class?: string }>(), {
   class: "",
 });
@@ -12,10 +13,11 @@ const props = withDefaults(defineProps<{ items: Item[]; class?: string }>(), {
     class="flex flex-row flex-wrap gap-2 text-sm"
     :class="props.class"
   >
-    <template v-for="(item, i) in props.items" :key="item.to">
+    <template v-for="(item, i) in props.items" :key="i">
       <span v-if="i > 0" aria-hidden="true" class="text-zinc-500 dark:text-zinc-400">/</span>
       <li property="itemListElement" typeof="ListItem">
         <NuxtLinkLocale
+          v-if="item.to"
           :to="item.to"
           property="item"
           typeof="WebPage"
@@ -31,6 +33,7 @@ const props = withDefaults(defineProps<{ items: Item[]; class?: string }>(), {
         >
           <span property="name">{{ item.name }}</span>
         </NuxtLinkLocale>
+        <span v-else property="name" class="text-zinc-500 dark:text-zinc-400">{{ item.name }}</span>
         <meta property="position" :content="`${i + 1}`" />
       </li>
     </template>

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -34,16 +34,16 @@ const navigationEnabled = computed(() => props.data.coords.accuracy !== "buildin
 const shareModalOpen = ref(false);
 
 // Breadcrumb ancestors link straight to their canonical /{type}/{id} path via the parent's type
-// (parallel to parents/parent_names). Index 0 is the synthetic `root` and links home. When
-// `parent_types` is absent (data from an older pipeline) or non-routable, fall back to /view/{id},
-// which the server redirects to the canonical path.
+// (parallel to parents/parent_names). Index 0 is the synthetic `root` and links home. An ancestor
+// whose type is missing (data from an older pipeline) or non-routable renders as plain, unlinked
+// text - we only link entities that have a canonical entity route.
 const breadcrumbItems = computed(() =>
   props.data.parent_names.map((name, i) => {
     const id = props.data.parents[i];
     // Index 0 is the synthetic `root`; a missing id (parallel arrays out of sync) also links home.
     if (i === 0 || !id) return { name, to: "/" };
     const type = props.data.parent_types?.[i];
-    return { name, to: type && isRoutableEntityType(type) ? entityPath(id, type) : `/view/${id}` };
+    return { name, to: type && isRoutableEntityType(type) ? entityPath(id, type) : undefined };
   })
 );
 

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -33,16 +33,13 @@ const navigationEnabled = computed(() => props.data.coords.accuracy !== "buildin
 
 const shareModalOpen = ref(false);
 
-// Breadcrumb ancestors link straight to their canonical /{type}/{id} path via the parent's type
-// (parallel to parents/parent_names). Index 0 is the synthetic `root` and links home. An ancestor
-// whose type is missing (data from an older pipeline) or non-routable renders as plain, unlinked
-// text - we only link entities that have a canonical entity route.
+// Only ancestors with a routable type get a canonical /{type}/{id} link; the rest render as plain text.
 const breadcrumbItems = computed(() =>
   props.data.parent_names.map((name, i) => {
     const id = props.data.parents[i];
-    // Index 0 is the synthetic `root`; a missing id (parallel arrays out of sync) also links home.
+    // Index 0 (synthetic `root`) and any missing id link home.
     if (i === 0 || !id) return { name, to: "/" };
-    const type = props.data.parent_types?.[i];
+    const type = props.data.parent_types[i];
     return { name, to: type && isRoutableEntityType(type) ? entityPath(id, type) : undefined };
   })
 );

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -12,6 +12,7 @@ import { useClipboard } from "@vueuse/core";
 import type { components } from "~/api_types";
 import type { DetailAction } from "~/components/DetailActionToolbar.vue";
 import { emptyPropertyFields, useEditProposal } from "~/composables/editProposal";
+import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 
@@ -31,6 +32,20 @@ const calendar = useCalendar();
 const navigationEnabled = computed(() => props.data.coords.accuracy !== "building");
 
 const shareModalOpen = ref(false);
+
+// Breadcrumb ancestors link straight to their canonical /{type}/{id} path via the parent's type
+// (parallel to parents/parent_names). Index 0 is the synthetic `root` and links home. When
+// `parent_types` is absent (data from an older pipeline) or non-routable, fall back to /view/{id},
+// which the server redirects to the canonical path.
+const breadcrumbItems = computed(() =>
+  props.data.parent_names.map((name, i) => {
+    const id = props.data.parents[i];
+    // Index 0 is the synthetic `root`; a missing id (parallel arrays out of sync) also links home.
+    if (i === 0 || !id) return { name, to: "/" };
+    const type = props.data.parent_types?.[i];
+    return { name, to: type && isRoutableEntityType(type) ? entityPath(id, type) : `/view/${id}` };
+  })
+);
 
 const clipboardSource = computed(() => `https://nav.tum.de${route.fullPath}`);
 const {
@@ -121,7 +136,7 @@ const actions = computed<DetailAction[]>(() => [
     label: t("header.start_navigation"),
     shortLabel: t("header.start_navigation_short"),
     visible: navigationEnabled.value,
-    href: `/navigate?coming_from=${props.data.id}&to=${props.data.id}&q_to=${props.data.name}`,
+    href: `/navigate?coming_from=${props.data.id}&coming_from_type=${props.data.type}&to=${props.data.id}&q_to=${props.data.name}`,
   },
   {
     key: "share",
@@ -179,15 +194,7 @@ const actions = computed<DetailAction[]>(() => [
   <!-- Content Padding -->
   <div class="px-5 pb-8 pt-4 bg-zinc-50 dark:bg-zinc-900">
     <!-- Breadcrumbs -->
-    <BreadcrumbList
-      :items="
-        data.parent_names.map((n, i) => ({
-          name: n,
-          to: i > 0 ? '/view/' + data?.parents[i] : '/',
-        }))
-      "
-      class="mb-2"
-    />
+    <BreadcrumbList :items="breadcrumbItems" class="mb-2" />
 
     <!-- Title & Actions -->
     <div class="group flex py-1 rounded transition-colors flex-row items-center gap-2">

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -39,7 +39,8 @@ const breadcrumbItems = computed(() =>
     const id = props.data.parents[i];
     // Index 0 (synthetic `root`) and any missing id link home.
     if (i === 0 || !id) return { name, to: "/" };
-    const type = props.data.parent_types[i];
+    // `?.` is load-bearing: a deployed server / CDN cache that predates this field omits it.
+    const type = props.data.parent_types?.[i];
     return { name, to: type && isRoutableEntityType(type) ? entityPath(id, type) : undefined };
   })
 );

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -38,12 +38,13 @@ const { t, locale } = useI18n({ useScope: "local" });
 const { preferences } = useUserPreferences();
 const coming_from = computed<string>(() => firstOrDefault(route.query.coming_from, ""));
 // The detail page passes the entity type so the back-link can target the canonical /{type}/{id}
-// directly. Absent or non-routable (e.g. an older link) falls back to /view/{id}, which redirects.
+// directly. If the type is absent or non-routable (e.g. an older link), we have no canonical route,
+// so the back-link is omitted rather than pointing at a non-canonical /view/{id}.
 const coming_from_type = computed<string>(() => firstOrDefault(route.query.coming_from_type, ""));
 const comingFromTo = computed<string>(() =>
   isRoutableEntityType(coming_from_type.value)
     ? entityPath(coming_from.value, coming_from_type.value)
-    : `/view/${coming_from.value}`
+    : ""
 );
 const selected_from = computed<string>(() => firstOrDefault(route.query.from, ""));
 const selected_to = computed<string>(() => firstOrDefault(route.query.to, ""));
@@ -249,7 +250,7 @@ function handleSelectItinerary(itineraryIndex: number) {
     </div>
     <div class="bg-zinc-100 dark:bg-zinc-800 flex min-w-96 flex-col gap-3 overflow-auto p-4 lg:max-w-96">
       <NuxtLinkLocale
-        v-if="coming_from"
+        v-if="coming_from && comingFromTo"
         :to="comingFromTo"
         property="item"
         class="focusable text-blue-400 dark:text-blue-500 rounded-md pb-2 hover:text-blue-500 dark:hover:text-blue-400 hover:underline"

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -7,8 +7,8 @@ import type { components, operations } from "~/api_types";
 import IndoorMap from "~/components/IndoorMap.vue";
 import Toast from "~/components/Toast.vue";
 import { firstOrDefault } from "~/composables/common";
-
 import type { TimeSelection } from "~/types/navigation";
+import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 // Utility function to parse coordinate IDs and convert to coordinate objects
 function parseCoordinateId(value: string): { lat: number; lon: number } | string {
@@ -37,6 +37,14 @@ const runtimeConfig = useRuntimeConfig();
 const { t, locale } = useI18n({ useScope: "local" });
 const { preferences } = useUserPreferences();
 const coming_from = computed<string>(() => firstOrDefault(route.query.coming_from, ""));
+// The detail page passes the entity type so the back-link can target the canonical /{type}/{id}
+// directly. Absent or non-routable (e.g. an older link) falls back to /view/{id}, which redirects.
+const coming_from_type = computed<string>(() => firstOrDefault(route.query.coming_from_type, ""));
+const comingFromTo = computed<string>(() =>
+  isRoutableEntityType(coming_from_type.value)
+    ? entityPath(coming_from.value, coming_from_type.value)
+    : `/view/${coming_from.value}`
+);
 const selected_from = computed<string>(() => firstOrDefault(route.query.from, ""));
 const selected_to = computed<string>(() => firstOrDefault(route.query.to, ""));
 const mode = useRouteQuery<RequestQuery["route_costing"]>(
@@ -242,7 +250,7 @@ function handleSelectItinerary(itineraryIndex: number) {
     <div class="bg-zinc-100 dark:bg-zinc-800 flex min-w-96 flex-col gap-3 overflow-auto p-4 lg:max-w-96">
       <NuxtLinkLocale
         v-if="coming_from"
-        :to="'/view/' + coming_from"
+        :to="comingFromTo"
         property="item"
         class="focusable text-blue-400 dark:text-blue-500 rounded-md pb-2 hover:text-blue-500 dark:hover:text-blue-400 hover:underline"
       >

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -37,15 +37,13 @@ const runtimeConfig = useRuntimeConfig();
 const { t, locale } = useI18n({ useScope: "local" });
 const { preferences } = useUserPreferences();
 const coming_from = computed<string>(() => firstOrDefault(route.query.coming_from, ""));
-// The detail page passes the entity type so the back-link can target the canonical /{type}/{id}
-// directly. If the type is absent or non-routable (e.g. an older link), we have no canonical route,
-// so the back-link is omitted rather than pointing at a non-canonical /view/{id}.
-const coming_from_type = computed<string>(() => firstOrDefault(route.query.coming_from_type, ""));
-const comingFromTo = computed<string>(() =>
-  isRoutableEntityType(coming_from_type.value)
-    ? entityPath(coming_from.value, coming_from_type.value)
-    : ""
-);
+// Only a routable type produces a canonical back-link; otherwise omit it (never a /view/{id}).
+const comingFromTo = computed(() => {
+  const type = firstOrDefault(route.query.coming_from_type, "");
+  return coming_from.value && isRoutableEntityType(type)
+    ? entityPath(coming_from.value, type)
+    : undefined;
+});
 const selected_from = computed<string>(() => firstOrDefault(route.query.from, ""));
 const selected_to = computed<string>(() => firstOrDefault(route.query.to, ""));
 const mode = useRouteQuery<RequestQuery["route_costing"]>(
@@ -250,7 +248,7 @@ function handleSelectItinerary(itineraryIndex: number) {
     </div>
     <div class="bg-zinc-100 dark:bg-zinc-800 flex min-w-96 flex-col gap-3 overflow-auto p-4 lg:max-w-96">
       <NuxtLinkLocale
-        v-if="coming_from && comingFromTo"
+        v-if="comingFromTo"
         :to="comingFromTo"
         property="item"
         class="focusable text-blue-400 dark:text-blue-500 rounded-md pb-2 hover:text-blue-500 dark:hover:text-blue-400 hover:underline"


### PR DESCRIPTION
Closes #3099.

Detail-page breadcrumbs, the navigate back-link, and the post-proposal redirect all linked via `/view/{id}`, which triggers a client-side redirect to reach the canonical `/{type}/{id}` (the type→route mapping lived only on the server). This slice exposes each parent's type so the client builds the canonical path directly via the `entityPath` helper from #3096.