### PR TITLE
feat(data): mensa opening hours from the eat-api canteen feed (#3107)

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -46,6 +46,10 @@ jobs:
         continue-on-error: true # an outage leaves the previous roster in place => coverage degrades, build still works
         run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/iris.py
         working-directory: data/external
+      - name: Download Studierendenwerk canteen opening hours
+        continue-on-error: true # an outage leaves the previous hours in place => coverage degrades, build still works
+        run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/studierendenwerk.py
+        working-directory: data/external
       - continue-on-error: true # a PR deleting all data will be created if this fails => fail obvious
         run: ls -lah data/external/results
       - continue-on-error: true # a PR deleting all data will be created if this fails => fail obvious

--- a/data/compile.py
+++ b/data/compile.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import polars as pl
 import processors.areatree.process as areatree
+from external.loaders.opening_hours import load_opening_hours
 from processors import (
     aliases,
     coords,
@@ -20,6 +21,7 @@ from processors import (
     sections,
     sitemap,
     structure,
+    studierendenwerk,
     tumonline,
 )
 from processors.df_utils import ensure_columns
@@ -182,8 +184,12 @@ def _run_pipeline(
     _logger.info("-- 22 Decomposed overrides (comments, links, opening hours)")
     df = merge.add_comments(df)
     df = merge.add_links(df)
+    # Hand-authored schedules win over scraped mensa hours on an id collision.
+    schedules = pl.concat([load_opening_hours(), studierendenwerk.mensa_opening_hours()], how="vertical").unique(
+        subset="id", keep="first", maintain_order=True
+    )
     # Fails the build if a schedule targets an unknown entry id.
-    df = opening_hours.merge_opening_hours(df)
+    df = opening_hours.merge_opening_hours(df, schedules=schedules)
 
     # Entries that only appear in comments/links CSVs (not in names.csv) were not created
     # at step 02, so they don't have NavigaTUM source. Prepend it now.

--- a/data/external/freshness.py
+++ b/data/external/freshness.py
@@ -1,0 +1,51 @@
+"""
+Build-time staleness check for scraped opening-hours sources.
+
+A source whose feed has not refreshed in months is a signal that an upstream layout
+change broke the scraper before users notice stale hours (cf. #1087). `today` is
+injected so the check is deterministic under test. Shared so #3106's UB-library
+scraper can reuse the same threshold.
+"""
+
+import calendar
+import logging
+from datetime import date
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_AGE_MONTHS = 6
+
+
+def _months_before(reference: date, months: int) -> date:
+    """Return the date `months` calendar months before `reference`, clamping the day-of-month."""
+    month_index = reference.month - 1 - months
+    year = reference.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(reference.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def is_stale(last_update: date, *, today: date, max_age_months: int = DEFAULT_MAX_AGE_MONTHS) -> bool:
+    """Return True when `last_update` is more than `max_age_months` calendar months before `today`."""
+    return last_update < _months_before(today, max_age_months)
+
+
+def warn_if_stale(
+    last_update: date,
+    *,
+    today: date,
+    source: str,
+    max_age_months: int = DEFAULT_MAX_AGE_MONTHS,
+    logger: logging.Logger = _logger,
+) -> bool:
+    """Log a warning and return `True` when `source` is stale; otherwise return `False`."""
+    if is_stale(last_update, today=today, max_age_months=max_age_months):
+        logger.warning(
+            "opening-hours source %r is stale: last refreshed %s, more than %d months before %s",
+            source,
+            last_update.isoformat(),
+            max_age_months,
+            today.isoformat(),
+        )
+        return True
+    return False

--- a/data/external/loaders/studierendenwerk.py
+++ b/data/external/loaders/studierendenwerk.py
@@ -1,0 +1,13 @@
+import dataframely as dy
+import polars as pl
+
+from external.models.common import RESULTS_PATH
+from external.schemas.studierendenwerk import StudierendenwerkSchema
+
+STUDIERENDENWERK_CSV = RESULTS_PATH / "studierendenwerk.csv"
+
+
+def load_studierendenwerk() -> dy.DataFrame[StudierendenwerkSchema]:
+    """Load and validate the cached `studierendenwerk.csv` canteen opening hours."""
+    df = pl.read_csv(STUDIERENDENWERK_CSV, schema=StudierendenwerkSchema.to_polars_schema())
+    return StudierendenwerkSchema.validate(df)

--- a/data/external/results/studierendenwerk.csv
+++ b/data/external/results/studierendenwerk.csv
@@ -1,0 +1,26 @@
+canteen_id,name,opening_hours,last_update,source_url
+fmi-bistro,FMI Bistro Garching,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/fmi-bistro
+mediziner-mensa,Mediziner Mensa,Mo-Fr 08:00-15:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mediziner-mensa
+mensa-arcisstr,Mensa Arcisstraße,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-arcisstr
+mensa-bildungscampus-heilbronn,Mensa Bildungscampus Heilbronn,Mo-Fr 11:00-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-bildungscampus-heilbronn
+mensa-garching,Mensa Garching,Mo-Fr 10:45-14:15,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-garching
+mensa-leopoldstr,Mensa Leopoldstraße,Mo-Th 11:00-14:30; Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-leopoldstr
+mensa-lothstr,Mensa Lothstraße,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-lothstr
+mensa-martinsried,Mensa Martinsried,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-martinsried
+mensa-pasing,Mensa Pasing,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-pasing
+mensa-straubing,Mensa Straubing,Mo-Th 07:30-15:00; Fr 07:30-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-straubing
+mensa-weihenstephan,Mensa Weihenstephan,Mo-Fr 11:00-13:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/mensa-weihenstephan
+stubistro-arcisstr,StuBistro Arcisstraße,Mo-Fr 09:00-15:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-arcisstr
+stubistro-butenandstr,StuBistro Butenandstraße,Mo-Th 09:00-15:00; Fr 09:00-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-butenandstr
+stubistro-goethestr,StuBistro Goethestraße,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-goethestr
+stubistro-martinsried,StuBistro Martinsried,Mo-Fr 08:30-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-martinsried
+stubistro-rosenheim,StuBistro Rosenheim,Mo-Th 09:00-15:30; Fr 09:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-rosenheim
+stubistro-schellingstr,StuBistro Schellingstraße,Mo-Th 09:00-16:30; Fr 09:00-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stubistro-schellingstr
+stucafe-adalbertstr,StuCafé Adalbertstraße,Mo-Fr 11:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-adalbertstr
+stucafe-akademie-weihenstephan,StuCafé Akademie Weihenstephan,Mo-Th 08:00-14:30; Fr 08:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-akademie-weihenstephan
+stucafe-boltzmannstr,StuBistro Boltzmannstraße,Mo-Th 08:30-16:30; Fr 08:30-15:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-boltzmannstr
+stucafe-connollystr,StuCafé Connollystraße,Mo-Th 09:00-15:00; Fr 09:00-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-connollystr
+stucafe-garching,StuBistro Garching,Mo-Th 09:00-16:00; Fr 09:00-15:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-garching
+stucafe-karlstr,StuCafé Karlstraße,Mo-Fr 08:15-15:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-karlstr
+stucafe-pasing,StuCafé Pasing,Mo-Tu 07:45-16:15; We-Th 07:45-16:00; Fr 07:45-14:30,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-pasing
+stucafe-weihenstephan-maximus,StuCafé Weihenstephan-Maximus,Mo-Th 08:30-15:00; Fr 08:30-14:00,2026-06-05,https://tum-dev.github.io/eat-api/#!/de/stucafe-weihenstephan-maximus

--- a/data/external/schemas/_validators.py
+++ b/data/external/schemas/_validators.py
@@ -1,0 +1,33 @@
+"""
+Shared dataframely rule expressions for the opening-hours sources.
+
+`OpeningHoursSchema` (hand-authored schedules) and `StudierendenwerkSchema`
+(scraped canteen hours) must agree on what a valid OSM `opening_hours` string and
+a valid date look like, so the predicates live here rather than being copied into
+each schema and drifting apart.
+"""
+
+import polars as pl
+
+_ISO_DATE_REGEX = r"^\d{4}-\d{2}-\d{2}$"
+
+
+def is_iso_date(column: str) -> pl.Expr:
+    """Zero-padded `YYYY-MM-DD` and a real calendar date (rejects e.g. `2026-13-40`)."""
+    col = pl.col(column)
+    return col.str.contains(_ISO_DATE_REGEX) & col.str.to_date("%Y-%m-%d", strict=False).is_not_null()
+
+
+def is_http_url(column: str) -> pl.Expr:
+    """Match an absolute http(s) URL."""
+    return pl.col(column).str.contains(r"^https?://")
+
+
+def opening_hours_non_empty(column: str) -> pl.Expr:
+    """Match a non-empty OSM `opening_hours` string after trimming."""
+    return pl.col(column).str.strip_chars().str.len_chars() > 0
+
+
+def opening_hours_has_no_macros(column: str) -> pl.Expr:
+    """Reject `lecture:`/`break:` macros; only plain OSM is supported."""
+    return ~pl.col(column).str.contains(r"(?i)\b(lecture|break)\s*:")

--- a/data/external/schemas/opening_hours.py
+++ b/data/external/schemas/opening_hours.py
@@ -1,13 +1,12 @@
 import dataframely as dy
 import polars as pl
 
-_ISO_DATE_REGEX = r"^\d{4}-\d{2}-\d{2}$"
-
-
-def _is_iso_date(column: str) -> pl.Expr:
-    """Zero-padded `YYYY-MM-DD` and a real calendar date (rejects e.g. `2026-13-40`)."""
-    col = pl.col(column)
-    return col.str.contains(_ISO_DATE_REGEX) & col.str.to_date("%Y-%m-%d", strict=False).is_not_null()
+from external.schemas._validators import (
+    is_http_url,
+    is_iso_date,
+    opening_hours_has_no_macros,
+    opening_hours_non_empty,
+)
 
 
 class OpeningHoursSchema(dy.Schema):
@@ -30,32 +29,32 @@ class OpeningHoursSchema(dy.Schema):
     @dy.rule()
     def opening_hours_non_empty(cls) -> pl.Expr:
         """`opening_hours` must be a non-empty OSM string after trimming."""
-        return pl.col("opening_hours").str.strip_chars().str.len_chars() > 0
+        return opening_hours_non_empty("opening_hours")
 
     @dy.rule()
     def opening_hours_has_no_macros(cls) -> pl.Expr:
         """Reject `lecture:`/`break:` macros; only plain OSM is supported."""
-        return ~pl.col("opening_hours").str.contains(r"(?i)\b(lecture|break)\s*:")
+        return opening_hours_has_no_macros("opening_hours")
 
     @dy.rule()
     def source_url_is_http(cls) -> pl.Expr:
         """`source_url` must be an absolute http(s) URL."""
-        return pl.col("source_url").str.contains(r"^https?://")
+        return is_http_url("source_url")
 
     @dy.rule()
     def last_update_is_iso_date(cls) -> pl.Expr:
         """`last_update` must be a `YYYY-MM-DD` date."""
-        return _is_iso_date("last_update")
+        return is_iso_date("last_update")
 
     @dy.rule()
     def valid_from_is_iso_date(cls) -> pl.Expr:
         """`valid_from`, when present, must be a `YYYY-MM-DD` date."""
-        return pl.col("valid_from").is_null() | _is_iso_date("valid_from")
+        return pl.col("valid_from").is_null() | is_iso_date("valid_from")
 
     @dy.rule()
     def valid_until_is_iso_date(cls) -> pl.Expr:
         """`valid_until`, when present, must be a `YYYY-MM-DD` date."""
-        return pl.col("valid_until").is_null() | _is_iso_date("valid_until")
+        return pl.col("valid_until").is_null() | is_iso_date("valid_until")
 
     @dy.rule()
     def validity_range_ordered(cls) -> pl.Expr:

--- a/data/external/schemas/studierendenwerk.py
+++ b/data/external/schemas/studierendenwerk.py
@@ -1,0 +1,48 @@
+import dataframely as dy
+import polars as pl
+
+from external.schemas._validators import (
+    is_http_url,
+    is_iso_date,
+    opening_hours_has_no_macros,
+    opening_hours_non_empty,
+)
+
+
+class StudierendenwerkSchema(dy.Schema):
+    """
+    Canteen opening hours scraped from the TUM-Dev eat-api `canteens.json` feed.
+
+    Studierendenwerk München publishes no structured feed, so eat-api's MIT-licensed
+    JSON (which scrapes the HTML for us) is the source. `opening_hours` is already a
+    plain OSM string built from the feed's per-weekday start/end; the OSM-string parse
+    is gated by the test suite, not at runtime, exactly as for `OpeningHoursSchema`.
+    Keyed by the eat-api `canteen_id`; the canteen-to-NavigaTUM-entry mapping lives in
+    `sources/mensa_canteens.csv`.
+    """
+
+    canteen_id = dy.String(nullable=False, primary_key=True)
+    name = dy.String(nullable=False)
+    opening_hours = dy.String(nullable=False)
+    last_update = dy.String(nullable=False)
+    source_url = dy.String(nullable=False)
+
+    @dy.rule()
+    def opening_hours_non_empty(cls) -> pl.Expr:
+        """`opening_hours` must be a non-empty OSM string after trimming."""
+        return opening_hours_non_empty("opening_hours")
+
+    @dy.rule()
+    def opening_hours_has_no_macros(cls) -> pl.Expr:
+        """Reject `lecture:`/`break:` macros; only plain OSM is supported."""
+        return opening_hours_has_no_macros("opening_hours")
+
+    @dy.rule()
+    def source_url_is_http(cls) -> pl.Expr:
+        """`source_url` must be an absolute http(s) URL."""
+        return is_http_url("source_url")
+
+    @dy.rule()
+    def last_update_is_iso_date(cls) -> pl.Expr:
+        """`last_update` must be a `YYYY-MM-DD` date."""
+        return is_iso_date("last_update")

--- a/data/external/schemas/test_schemas_studierendenwerk.py
+++ b/data/external/schemas/test_schemas_studierendenwerk.py
@@ -1,0 +1,146 @@
+import dataframely as dy
+import opening_hours
+import polars as pl
+import pytest
+
+from external.loaders.studierendenwerk import load_studierendenwerk
+from external.schemas._drift_gate import assert_satisfies_schema
+from external.schemas.studierendenwerk import StudierendenwerkSchema
+from external.scrapers.studierendenwerk import open_hours_to_osm
+
+# A captured slice of the eat-api `canteens.json` `open_hours` shape, covering the cases the
+# converter must get right: a uniform Mo-Fr week, a week whose Friday differs, and a week with
+# three distinct day groups. Kept as fixtures so the converter is verified without a network call.
+_CAPTURED_OPEN_HOURS: dict[str, dict[str, dict[str, str]]] = {
+    "mensa-arcisstr": {day: {"start": "11:00", "end": "14:00"} for day in ("mon", "tue", "wed", "thu", "fri")},
+    "mensa-leopoldstr": {
+        "mon": {"start": "11:00", "end": "14:30"},
+        "tue": {"start": "11:00", "end": "14:30"},
+        "wed": {"start": "11:00", "end": "14:30"},
+        "thu": {"start": "11:00", "end": "14:30"},
+        "fri": {"start": "11:00", "end": "14:00"},
+    },
+    "stucafe-pasing": {
+        "mon": {"start": "07:45", "end": "16:15"},
+        "tue": {"start": "07:45", "end": "16:15"},
+        "wed": {"start": "07:45", "end": "16:00"},
+        "thu": {"start": "07:45", "end": "16:00"},
+        "fri": {"start": "07:45", "end": "14:30"},
+    },
+}
+
+
+def _valid_row() -> dict[str, list[object]]:
+    """Build a single valid canteen row."""
+    return {
+        "canteen_id": ["mensa-garching"],
+        "name": ["Mensa Garching"],
+        "opening_hours": ["Mo-Fr 10:45-14:15"],
+        "last_update": ["2026-06-05"],
+        "source_url": ["https://tum-dev.github.io/eat-api/#!/de/mensa-garching"],
+    }
+
+
+def _row_with(**overrides: object) -> pl.DataFrame:
+    """Build a one-row frame from the valid baseline, overriding named columns."""
+    row = _valid_row()
+    for key, value in overrides.items():
+        row[key] = [value]
+    return pl.DataFrame(row, schema=StudierendenwerkSchema.to_polars_schema())
+
+
+def test_committed_studierendenwerk_csv_satisfies_schema() -> None:
+    """The committed `studierendenwerk.csv` must satisfy `StudierendenwerkSchema` (drift gate)."""
+    assert_satisfies_schema(StudierendenwerkSchema, load_studierendenwerk())
+
+
+def test_committed_studierendenwerk_strings_parse_as_osm() -> None:
+    """Every committed OSM string must parse; the loader does not check this at runtime."""
+    for row in load_studierendenwerk().iter_rows(named=True):
+        assert opening_hours.validate(row["opening_hours"]), (
+            f"opening_hours for canteen {row['canteen_id']!r} does not parse: {row['opening_hours']!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("canteen_id", "expected"),
+    [
+        ("mensa-arcisstr", "Mo-Fr 11:00-14:00"),
+        ("mensa-leopoldstr", "Mo-Th 11:00-14:30; Fr 11:00-14:00"),
+        ("stucafe-pasing", "Mo-Tu 07:45-16:15; We-Th 07:45-16:00; Fr 07:45-14:30"),
+    ],
+)
+def test_open_hours_to_osm_groups_consecutive_days(canteen_id: str, expected: str) -> None:
+    """Captured feed fixtures must convert to the expected (and parseable) OSM string."""
+    osm = open_hours_to_osm(_CAPTURED_OPEN_HOURS[canteen_id])
+    assert osm == expected
+    assert opening_hours.validate(osm)
+
+
+def test_open_hours_to_osm_does_not_bridge_a_closed_day() -> None:
+    """A closed day between two identical days must not collapse into a range covering it."""
+    hours = {
+        "mon": {"start": "09:00", "end": "12:00"},
+        "wed": {"start": "09:00", "end": "12:00"},
+    }
+    assert open_hours_to_osm(hours) == "Mo 09:00-12:00; We 09:00-12:00"
+
+
+def test_open_hours_to_osm_empty_is_empty_string() -> None:
+    """A canteen with no open days converts to an empty string (the scraper then skips it)."""
+    assert open_hours_to_osm({}) == ""
+
+
+def test_studierendenwerk_schema_accepts_minimal_valid_row() -> None:
+    """A row matching every rule must validate cleanly (positive control)."""
+    StudierendenwerkSchema.validate(_row_with())
+
+
+def test_studierendenwerk_schema_rejects_duplicate_canteen() -> None:
+    """`StudierendenwerkSchema` must reject a duplicated `canteen_id`."""
+    duplicated = pl.DataFrame(
+        {
+            "canteen_id": ["mensa-garching", "mensa-garching"],
+            "name": ["Mensa Garching", "Mensa Garching"],
+            "opening_hours": ["Mo-Fr 10:45-14:15", "Mo-Fr 10:45-14:15"],
+            "last_update": ["2026-06-05", "2026-06-05"],
+            "source_url": ["https://x.tld", "https://x.tld"],
+        },
+        schema=StudierendenwerkSchema.to_polars_schema(),
+    )
+    with pytest.raises(dy.exc.ValidationError):
+        StudierendenwerkSchema.validate(duplicated)
+
+
+def test_studierendenwerk_schema_rejects_empty_opening_hours() -> None:
+    """An empty `opening_hours` string must be rejected."""
+    with pytest.raises(dy.exc.ValidationError):
+        StudierendenwerkSchema.validate(_row_with(opening_hours=""))
+
+
+@pytest.mark.parametrize("osm", ["lecture: Mo-Fr 08:00-20:00", "Mo-Fr 08:00-20:00; break: 12:00-13:00"])
+def test_studierendenwerk_schema_rejects_macros(osm: str) -> None:
+    """`lecture:`/`break:` macros must be rejected; only plain OSM is supported."""
+    with pytest.raises(dy.exc.ValidationError):
+        StudierendenwerkSchema.validate(_row_with(opening_hours=osm))
+
+
+@pytest.mark.parametrize("url", ["www.example.tld", "ftp://example.tld", "/relative", ""])
+def test_studierendenwerk_schema_rejects_non_http_source_url(url: str) -> None:
+    """`source_url` must be an absolute http(s) URL."""
+    with pytest.raises(dy.exc.ValidationError):
+        StudierendenwerkSchema.validate(_row_with(source_url=url))
+
+
+@pytest.mark.parametrize("bad_date", ["2026/06/05", "05-06-2026", "2026-6-5", "not-a-date"])
+def test_studierendenwerk_schema_rejects_non_iso_last_update(bad_date: str) -> None:
+    """`last_update` must be a `YYYY-MM-DD` date."""
+    with pytest.raises(dy.exc.ValidationError):
+        StudierendenwerkSchema.validate(_row_with(last_update=bad_date))
+
+
+def test_studierendenwerk_schema_rejects_missing_column() -> None:
+    """`StudierendenwerkSchema` must reject a frame missing required columns."""
+    incomplete = pl.DataFrame({"canteen_id": ["mensa-garching"]})
+    with pytest.raises(dy.exc.SchemaError):
+        StudierendenwerkSchema.validate(incomplete)

--- a/data/external/scrapers/studierendenwerk.py
+++ b/data/external/scrapers/studierendenwerk.py
@@ -1,0 +1,119 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import polars as pl
+import requests
+from utils import setup_logging
+
+from external.schemas.studierendenwerk import StudierendenwerkSchema
+from external.scraping_utils import CACHE_PATH
+
+# Studierendenwerk München publishes no structured feed; eat-api scrapes its HTML and
+# exposes the result as MIT-licensed JSON, so it is the source rather than re-scraping HTML.
+CANTEENS_URL = "https://tum-dev.github.io/eat-api/enums/canteens.json"
+# Human-facing menu page per canteen, mirroring the existing Speiseplan links in links.yaml.
+_MENU_URL = "https://tum-dev.github.io/eat-api/#!/de/{canteen_id}"
+
+# eat-api weekday keys in calendar order, paired with their OSM weekday abbreviations.
+_WEEKDAYS: list[tuple[str, str]] = [
+    ("mon", "Mo"),
+    ("tue", "Tu"),
+    ("wed", "We"),
+    ("thu", "Th"),
+    ("fri", "Fr"),
+    ("sat", "Sa"),
+    ("sun", "Su"),
+]
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _DayGroup:
+    """A run of consecutive weekdays sharing the same start/end, as one OSM rule."""
+
+    first_abbr: str
+    last_abbr: str
+    last_index: int
+    start: str
+    end: str
+
+    def to_osm(self) -> str:
+        days = self.first_abbr if self.first_abbr == self.last_abbr else f"{self.first_abbr}-{self.last_abbr}"
+        return f"{days} {self.start}-{self.end}"
+
+
+def open_hours_to_osm(open_hours: dict[str, dict[str, str]]) -> str:
+    """
+    Convert eat-api per-weekday `open_hours` into an OSM `opening_hours` string.
+
+    Consecutive weekdays sharing the same start/end collapse into one OSM day range
+    (e.g. `Mo-Fr 11:00-14:00`); a differing or closed day starts a new rule, so a gap
+    never produces a range that silently includes a closed day. Returns `""` when no
+    day is open.
+    """
+    groups: list[_DayGroup] = []
+    for index, (key, abbreviation) in enumerate(_WEEKDAYS):
+        slot = open_hours.get(key)
+        if not slot:
+            continue
+        start, end = slot["start"], slot["end"]
+        previous = groups[-1] if groups else None
+        if previous and previous.last_index == index - 1 and (previous.start, previous.end) == (start, end):
+            previous.last_abbr = abbreviation
+            previous.last_index = index
+        else:
+            groups.append(_DayGroup(abbreviation, abbreviation, index, start, end))
+
+    return "; ".join(group.to_osm() for group in groups)
+
+
+def _last_modified_date(response: requests.Response) -> str:
+    """Return the feed's `Last-Modified` as a `YYYY-MM-DD` date, falling back to today (UTC)."""
+    header = response.headers.get("Last-Modified")
+    if header:
+        return parsedate_to_datetime(header).date().isoformat()
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def scrape_studierendenwerk() -> None:
+    """
+    Write `studierendenwerk.csv` from the live eat-api canteen feed.
+
+    Refuses to overwrite with an empty roster, so a transient outage or an upstream
+    layout change that drops all opening hours leaves the previously scraped data in
+    place rather than wiping coverage.
+    """
+    response = requests.get(CANTEENS_URL, timeout=30)
+    response.raise_for_status()
+    last_update = _last_modified_date(response)
+
+    rows = []
+    for canteen in response.json():
+        opening_hours = open_hours_to_osm(canteen.get("open_hours") or {})
+        if not opening_hours:
+            continue
+        rows.append(
+            {
+                "canteen_id": canteen["canteen_id"],
+                "name": canteen["name"],
+                "opening_hours": opening_hours,
+                "last_update": last_update,
+                "source_url": _MENU_URL.format(canteen_id=canteen["canteen_id"]),
+            }
+        )
+    if not rows:
+        raise RuntimeError("eat-api returned no canteens with opening hours - refusing to overwrite the roster")
+
+    df = pl.DataFrame(rows, schema=StudierendenwerkSchema.to_polars_schema()).sort("canteen_id")
+    StudierendenwerkSchema.validate(df)
+    df.write_csv(CACHE_PATH / "studierendenwerk.csv")
+    _logger.info(f"Scraped opening hours for {df.height} canteens")
+
+
+if __name__ == "__main__":
+    setup_logging()
+    CACHE_PATH.mkdir(exist_ok=True)
+    scrape_studierendenwerk()

--- a/data/external/test_freshness.py
+++ b/data/external/test_freshness.py
@@ -1,0 +1,43 @@
+import logging
+from datetime import date
+
+import pytest
+
+from external.freshness import is_stale, warn_if_stale
+
+
+def test_recent_update_is_not_stale() -> None:
+    """An update inside the window is fresh."""
+    assert not is_stale(date(2026, 1, 15), today=date(2026, 6, 7))
+
+
+def test_old_update_is_stale() -> None:
+    """An update older than the window is stale."""
+    assert is_stale(date(2025, 11, 1), today=date(2026, 6, 7))
+
+
+def test_staleness_boundary_is_exclusive() -> None:
+    """Exactly `max_age_months` before today is the last fresh day; one day earlier is stale."""
+    assert not is_stale(date(2025, 12, 7), today=date(2026, 6, 7))
+    assert is_stale(date(2025, 12, 6), today=date(2026, 6, 7))
+
+
+def test_month_arithmetic_clamps_day_of_month() -> None:
+    """Six months before Aug 31 lands on the last day of February, not an invalid date."""
+    assert not is_stale(date(2026, 2, 28), today=date(2026, 8, 31))
+    assert is_stale(date(2026, 2, 27), today=date(2026, 8, 31))
+
+
+def test_warn_if_stale_logs_and_reports_true(caplog: pytest.LogCaptureFixture) -> None:
+    """A stale source logs a warning and returns True."""
+    with caplog.at_level(logging.WARNING):
+        assert warn_if_stale(date(2025, 1, 1), today=date(2026, 6, 7), source="https://x.tld")
+    assert "stale" in caplog.text
+    assert "https://x.tld" in caplog.text
+
+
+def test_warn_if_stale_is_quiet_when_fresh(caplog: pytest.LogCaptureFixture) -> None:
+    """A fresh source emits no warning and returns False."""
+    with caplog.at_level(logging.WARNING):
+        assert not warn_if_stale(date(2026, 6, 1), today=date(2026, 6, 7), source="https://x.tld")
+    assert caplog.text == ""

--- a/data/processors/studierendenwerk.py
+++ b/data/processors/studierendenwerk.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import dataframely as dy
+import polars as pl
+from external.freshness import warn_if_stale
+from external.loaders.studierendenwerk import load_studierendenwerk
+from external.schemas.opening_hours import OpeningHoursSchema
+from external.schemas.studierendenwerk import StudierendenwerkSchema
+
+_logger = logging.getLogger(__name__)
+
+SOURCES_PATH = Path(__file__).parent.parent / "sources"
+CANTEEN_MAPPING_CSV = SOURCES_PATH / "mensa_canteens.csv"
+_MAPPING_SCHEMA = {"canteen_id": pl.Utf8(), "id": pl.Utf8()}
+
+
+def _load_mapping() -> pl.DataFrame:
+    """Load the hand-authored canteen-id -> NavigaTUM entry-id mapping."""
+    return pl.read_csv(CANTEEN_MAPPING_CSV, schema=_MAPPING_SCHEMA)
+
+
+def _load_stored_canteens() -> pl.DataFrame:
+    try:
+        return load_studierendenwerk()
+    except FileNotFoundError:
+        _logger.warning("No stored canteen feed yet; no mensa opening hours will be attached this build")
+        return pl.DataFrame(schema=StudierendenwerkSchema.to_polars_schema())
+
+
+def mensa_opening_hours(
+    *,
+    canteens: pl.DataFrame | None = None,
+    mapping: pl.DataFrame | None = None,
+    today: date | None = None,
+) -> dy.DataFrame[OpeningHoursSchema]:
+    """
+    Map scraped canteen hours onto NavigaTUM entry ids as `OpeningHoursSchema` records.
+
+    Canteens are matched to entries via the hand-authored `mensa_canteens.csv`. A mapped
+    canteen absent from the feed is logged (mapping drift or an upstream rename); an
+    unmapped canteen is ignored. Emits a build-time staleness warning per feed snapshot.
+    `canteens`/`mapping`/`today` are injectable for tests.
+    """
+    canteens = _load_stored_canteens() if canteens is None else canteens
+    mapping = _load_mapping() if mapping is None else mapping
+    today = datetime.now(tz=timezone.utc).date() if today is None else today
+
+    joined = mapping.join(canteens, on="canteen_id", how="left")
+    for row in joined.filter(pl.col("opening_hours").is_null()).iter_rows(named=True):
+        _logger.warning("mensa mapping references canteen %r absent from the eat-api feed", row["canteen_id"])
+    joined = joined.filter(pl.col("opening_hours").is_not_null())
+
+    for row in joined.select("source_url", "last_update").unique().iter_rows(named=True):
+        warn_if_stale(date.fromisoformat(row["last_update"]), today=today, source=row["source_url"])
+
+    records = joined.select(
+        pl.col("id"),
+        pl.col("opening_hours"),
+        pl.col("source_url"),
+        pl.col("last_update"),
+        pl.lit(None, dtype=pl.Utf8()).alias("valid_from"),
+        pl.lit(None, dtype=pl.Utf8()).alias("valid_until"),
+        pl.lit(None, dtype=pl.Utf8()).alias("service"),
+    )
+    return OpeningHoursSchema.validate(records)

--- a/data/processors/test_studierendenwerk.py
+++ b/data/processors/test_studierendenwerk.py
@@ -1,0 +1,99 @@
+import logging
+from datetime import date
+
+import orjson
+import polars as pl
+import pytest
+from external.schemas.studierendenwerk import StudierendenwerkSchema
+
+from processors.opening_hours import merge_opening_hours
+from processors.studierendenwerk import mensa_opening_hours
+
+_TODAY = date(2026, 6, 7)
+
+
+def _canteens(**overrides: list[object]) -> pl.DataFrame:
+    """Build a two-canteen feed frame matching `StudierendenwerkSchema`."""
+    row: dict[str, list[object]] = {
+        "canteen_id": ["mensa-garching", "mensa-arcisstr"],
+        "name": ["Mensa Garching", "Mensa Arcisstraße"],
+        "opening_hours": ["Mo-Fr 10:45-14:15", "Mo-Fr 11:00-14:00"],
+        "last_update": ["2026-06-05", "2026-06-05"],
+        "source_url": [
+            "https://tum-dev.github.io/eat-api/#!/de/mensa-garching",
+            "https://tum-dev.github.io/eat-api/#!/de/mensa-arcisstr",
+        ],
+    }
+    return pl.DataFrame({**row, **overrides}, schema=StudierendenwerkSchema.to_polars_schema())
+
+
+def _mapping(canteen_ids: list[str], ids: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"canteen_id": canteen_ids, "id": ids}, schema={"canteen_id": pl.Utf8(), "id": pl.Utf8()})
+
+
+def test_maps_canteen_hours_onto_entry_ids() -> None:
+    """A mapped canteen yields an `OpeningHoursSchema` record keyed by the NavigaTUM entry id."""
+    records = mensa_opening_hours(
+        canteens=_canteens(),
+        mapping=_mapping(["mensa-garching"], ["5304"]),
+        today=_TODAY,
+    )
+
+    assert records["id"].to_list() == ["5304"]
+    record = records.row(0, named=True)
+    assert record["opening_hours"] == "Mo-Fr 10:45-14:15"
+    assert record["source_url"] == "https://tum-dev.github.io/eat-api/#!/de/mensa-garching"
+    assert record["valid_from"] is None
+    assert record["valid_until"] is None
+    assert record["service"] is None
+
+
+def test_ignores_unmapped_canteens() -> None:
+    """A canteen present in the feed but absent from the mapping is dropped."""
+    records = mensa_opening_hours(
+        canteens=_canteens(),
+        mapping=_mapping(["mensa-garching"], ["5304"]),
+        today=_TODAY,
+    )
+    assert records.height == 1
+
+
+def test_warns_when_mapping_targets_canteen_absent_from_feed(caplog: pytest.LogCaptureFixture) -> None:
+    """A mapping entry with no matching feed canteen is logged and produces no record."""
+    with caplog.at_level(logging.WARNING):
+        records = mensa_opening_hours(
+            canteens=_canteens(),
+            mapping=_mapping(["mensa-garching", "mensa-gone"], ["5304", "9999"]),
+            today=_TODAY,
+        )
+    assert records["id"].to_list() == ["5304"]
+    assert "mensa-gone" in caplog.text
+
+
+def test_warns_when_feed_is_stale(caplog: pytest.LogCaptureFixture) -> None:
+    """A feed snapshot older than the staleness window is flagged at build time."""
+    with caplog.at_level(logging.WARNING):
+        mensa_opening_hours(
+            canteens=_canteens(last_update=["2025-01-01", "2025-01-01"]),
+            mapping=_mapping(["mensa-garching"], ["5304"]),
+            today=_TODAY,
+        )
+    assert "stale" in caplog.text
+
+
+def test_records_merge_onto_entries() -> None:
+    """The produced records attach through the shared opening-hours merge."""
+    records = mensa_opening_hours(
+        canteens=_canteens(),
+        mapping=_mapping(["mensa-garching"], ["5304"]),
+        today=_TODAY,
+    )
+    entries = pl.DataFrame({"id": ["5304", "0001"], "type": ["building", "building"]})
+
+    merged = merge_opening_hours(entries, schedules=records)
+
+    by_id = dict(zip(merged["id"], merged["opening_hours_json"], strict=True))
+    assert by_id["0001"] is None
+    payload = orjson.loads(by_id["5304"])
+    assert payload["osm"] == "Mo-Fr 10:45-14:15"
+    assert "valid_from" not in payload

--- a/data/sources/mensa_canteens.csv
+++ b/data/sources/mensa_canteens.csv
@@ -1,0 +1,4 @@
+canteen_id,id
+mensa-arcisstr,0206
+mensa-garching,5304
+mensa-weihenstephan,4216


### PR DESCRIPTION
Closes part of #3107 (parent #3050).

## Source decision

Studierendenwerk München publishes **no** structured/OpenMensa feed — the TUM-Dev [eat-api](https://github.com/TUM-Dev/eat-api) scrapes its HTML and republishes it as MIT-licensed JSON. Re-scraping the HTML ourselves would only duplicate that brittle parser, so this consumes the structured feed (`enums/canteens.json`), which already carries per-weekday opening hours and a `Last-Modified` timestamp.

## What this does

- **Scraper** (`external/scrapers/studierendenwerk.py`) fetches the feed and converts each canteen's per-weekday hours into a canonical OSM `opening_hours` string (consecutive identical days collapse into ranges; a closed day is never bridged). The feed's `Last-Modified` becomes `last_update`. Refuses to overwrite on an empty feed, mirroring the IRIS scraper.
- **Schema + tests** (`external/schemas/studierendenwerk.py`, `test_schemas_studierendenwerk.py`) — drift gate on the committed CSV, OSM-parse check, captured-fixture conversion, and malformed-input rejection.
- **Mapping** (`sources/mensa_canteens.csv`) attaches canteens to the existing mensa building entries by id.
- **Processor** (`processors/studierendenwerk.py`) emits canonical `OpeningHoursSchema` records; `compile.py` concatenates them with the hand-authored schedules (hand-authored wins on an id collision) before the shared merge.
- **Staleness** (`external/freshness.py`) — a build-time warning when the feed has not refreshed in six months, so an upstream layout change surfaces before users see stale hours.
- Shared OSM/date rule expressions are factored into `schemas/_validators.py` so the two opening-hours schemas cannot drift apart.

## Scope

Data pipeline only. The server details response is still a typed struct without an opening-hours field, so surfacing these hours (server field + webclient card) and the live open/closed indicator are left to their follow-ups. The six-month staleness helper is written to be reused by the UB-library scraper.

## Testing

`uv run pytest data` (126 passed), `ruff` (lint + format), and `mypy` all clean.