### PR TITLE
feat(webclient): move nearby-transport above rooms and collapse past 5

### DIFF
--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -244,10 +244,10 @@ const actions = computed<DetailAction[]>(() => [
     <div class="flex flex-col gap-6">
       <DetailsBuildingOverviewSection :buildings="data.sections?.buildings_overview"/>
       <ClientOnly>
+        <LazyDetailsNearbyTransportSection :id="data.id"/>
         <!-- Browser-side live status; gated on the build-time signal so uncovered pages issue no Iris request. -->
         <LazyDetailsIrisCoverageCard v-if="data.props.has_iris_coverage" :building-id="data.id"/>
         <LazyDetailsRoomOverviewSection :rooms="data.sections?.rooms_overview"/>
-        <LazyDetailsNearbyTransportSection :id="data.id"/>
       </ClientOnly>
       <DetailsSources
         :coords="data.coords"

--- a/webclient/app/components/DetailsNearbyTransportSection.vue
+++ b/webclient/app/components/DetailsNearbyTransportSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { mdiArrowRightThin, mdiChevronDown, mdiChevronUp, mdiHelpCircle } from "@mdi/js";
+import { useToggle } from "@vueuse/core";
 import type { components } from "~/api_types";
 import {
   boardingRestriction,
@@ -24,7 +25,7 @@ const { t } = useI18n({ useScope: "local" });
 const { stations, toggleExpand, now } = await useNearbyDepartures(() => props.id);
 
 const INITIAL_VISIBLE = 5;
-const showAll = ref(false);
+const [showAll, toggleShowAll] = useToggle(false);
 const visibleStations = computed(() =>
   showAll.value ? stations.value : stations.value.slice(0, INITIAL_VISIBLE)
 );
@@ -207,7 +208,7 @@ function rowTitle(entry: StopTimeEntry): string {
       type="button"
       class="focusable self-start flex items-center gap-1 rounded-sm px-2 py-1 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100"
       :aria-expanded="showAll"
-      @click="showAll = !showAll"
+      @click="toggleShowAll()"
     >
       <MdiIcon :path="showAll ? mdiChevronUp : mdiChevronDown" :size="16" />
       {{ showAll ? t("show_less") : t("show_more", { count: hiddenCount }) }}

--- a/webclient/app/components/DetailsNearbyTransportSection.vue
+++ b/webclient/app/components/DetailsNearbyTransportSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { mdiArrowRightThin, mdiChevronDown, mdiHelpCircle } from "@mdi/js";
+import { mdiArrowRightThin, mdiChevronDown, mdiChevronUp, mdiHelpCircle } from "@mdi/js";
 import type { components } from "~/api_types";
 import {
   boardingRestriction,
@@ -22,6 +22,13 @@ const props = defineProps<{
 
 const { t } = useI18n({ useScope: "local" });
 const { stations, toggleExpand, now } = await useNearbyDepartures(() => props.id);
+
+const INITIAL_VISIBLE = 5;
+const showAll = ref(false);
+const visibleStations = computed(() =>
+  showAll.value ? stations.value : stations.value.slice(0, INITIAL_VISIBLE)
+);
+const hiddenCount = computed(() => Math.max(0, stations.value.length - INITIAL_VISIBLE));
 
 function modeLabel(mode: ModeResponse | undefined | null): string {
   if (!mode) return "";
@@ -88,7 +95,7 @@ function rowTitle(entry: StopTimeEntry): string {
     <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold">{{ t("title") }}</p>
     <ul class="flex flex-col gap-2">
       <li
-        v-for="{ station, state } in stations"
+        v-for="{ station, state } in visibleStations"
         :key="station.id"
         class="bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-sm"
       >
@@ -195,6 +202,16 @@ function rowTitle(entry: StopTimeEntry): string {
         </template>
       </li>
     </ul>
+    <button
+      v-if="hiddenCount > 0"
+      type="button"
+      class="focusable self-start flex items-center gap-1 rounded-sm px-2 py-1 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100"
+      :aria-expanded="showAll"
+      @click="showAll = !showAll"
+    >
+      <MdiIcon :path="showAll ? mdiChevronUp : mdiChevronDown" :size="16" />
+      {{ showAll ? t("show_less") : t("show_more", { count: hiddenCount }) }}
+    </button>
   </div>
 </template>
 
@@ -204,6 +221,8 @@ de:
   loading: Lädt Abfahrten…
   error: 'Abfahrten konnten nicht geladen werden: {msg}'
   no_departures: Keine bevorstehenden Abfahrten.
+  show_more: "{count} weitere anzeigen"
+  show_less: Weniger anzeigen
   now: jetzt
   departed: abgefahren
   in_minutes: "in {count} min"
@@ -251,6 +270,8 @@ en:
   loading: Loading departures…
   error: 'Could not load departures: {msg}'
   no_departures: No upcoming departures.
+  show_more: "Show {count} more"
+  show_less: Show less
   now: now
   departed: departed
   in_minutes: "in {count} min"


### PR DESCRIPTION
## Summary

- Reorder the details sidebar so **Nearby transport** appears above **Rooms in this building** — transport is more often the user's actual goal when landing on a building page.
- Collapse the nearby-transport list past the first 5 stations behind a "Show N more" / "Show less" toggle so long lists don't push the rest of the sidebar far below the fold.

## Test plan

- [ ] Open a building detail page (e.g. a campus building with both rooms and nearby stops) and confirm the transport section now renders before the room overview.
- [ ] Verify the first 5 stations render by default and the toggle reveals/hides the remainder; `aria-expanded` flips with state.
- [ ] On a building with ≤5 nearby stations, confirm the toggle button is hidden.
- [ ] Check both light and dark mode styling of the toggle button.
- [ ] German + English copy: "{count} weitere anzeigen" / "Show {count} more" pluralization reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)