### PR TITLE
chore(data): enable ANN/PLC/INP lints for stronger type safety

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
@@ -6,6 +7,7 @@ from typing import Any
 
 import polars as pl
 import processors.areatree.process as areatree
+import yaml
 from external.loaders.opening_hours import load_opening_hours
 from processors import (
     aliases,
@@ -195,15 +197,11 @@ def _run_pipeline(
     # at step 02, so they don't have NavigaTUM source. Prepend it now.
     comment_ids: set[str] = set()
     if merge.COMMENTS_CSV.exists():
-        import csv as csv_mod
-
         with merge.COMMENTS_CSV.open() as f:
-            comment_ids.update(row["id"] for row in csv_mod.DictReader(f))
+            comment_ids.update(row["id"] for row in csv.DictReader(f))
     if merge.LINKS_YAML.exists():
-        import yaml as yaml_mod
-
         with merge.LINKS_YAML.open() as f:
-            links_data = yaml_mod.safe_load(f) or {}
+            links_data = yaml.safe_load(f) or {}
         comment_ids.update(str(k) for k in links_data)
     if comment_ids:
         df = df.with_columns(

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -6,7 +6,11 @@ import orjson
 import polars as pl
 import xxhash
 import yaml
+from external.loaders.events import load_events
+from external.loaders.tumonline_orgs import load_tumonline_orgs
 from external.models.common import PydanticConfiguration
+from external.schemas.events import EventsSchema
+from external.schemas.tumonline_orgs import TumonlineOrgsSchema
 from utils import TranslatableStr
 from utils import TranslatableStr as _
 
@@ -184,7 +188,7 @@ def export_for_api(data: dict[str, Any]) -> None:
     df.write_parquet(OUTPUT_DIR_PATH / "alias_data.parquet", use_pyarrow=True, compression_level=3)
 
 
-def extract_exported_item(data, entry):
+def extract_exported_item(data: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
     """Extract the item that will be finally exported to the api"""
     parent_names = [data[p]["name"] if p != "root" else _("Standorte", "Sites") for p in entry["parents"]]
     # Parallel to `parents`/`parent_names`: each parent's type lets the client build the canonical
@@ -266,9 +270,6 @@ def export_known_usages(df: pl.DataFrame) -> None:
 
 def export_tumonline_orgs_parquet() -> None:
     """Build the bilingual TUMonline orgs frame and write tumonline_orgs.parquet."""
-    from external.loaders.tumonline_orgs import load_tumonline_orgs
-    from external.schemas.tumonline_orgs import TumonlineOrgsSchema
-
     TumonlineOrgsSchema.write_parquet(load_tumonline_orgs(), OUTPUT_DIR_PATH / "tumonline_orgs.parquet")
 
 
@@ -281,7 +282,4 @@ def export_events_parquet() -> None:
     datetime serialization specifics. EventsSchema enforces the RFC 3339 shape
     and `ends_at >= starts_at` (matching the DB CHECK constraint).
     """
-    from external.loaders.events import load_events
-    from external.schemas.events import EventsSchema
-
     EventsSchema.write_parquet(load_events(), OUTPUT_DIR_PATH / "events.parquet")

--- a/data/processors/images.py
+++ b/data/processors/images.py
@@ -115,7 +115,7 @@ def parse_image_filename(image_name: str) -> tuple[str, int]:
     return _id, _index
 
 
-def _add_source_info(fname, source_data):
+def _add_source_info(fname: str, source_data: dict[int, dict[str, Any]]) -> dict[str, Any] | None:
     _id, _index = parse_image_filename(fname)
 
     required_fields = ["author", "license"]
@@ -124,7 +124,7 @@ def _add_source_info(fname, source_data):
             _logger.warning(f"No {field} information for image '{fname}', it will not be used")
             return None
 
-    def _parse(obj):
+    def _parse(obj: str | dict[str, Any]) -> dict[str, Any]:
         return {"text": obj, "url": None} if isinstance(obj, str) else obj
 
     return {
@@ -135,7 +135,7 @@ def _add_source_info(fname, source_data):
 
 
 class Resizer:
-    def __init__(self, source: Path):
+    def __init__(self, source: Path) -> None:
         self.source = source
         self.img = Image.open(source)
 

--- a/data/processors/merge.py
+++ b/data/processors/merge.py
@@ -230,9 +230,7 @@ def add_links(df: pl.DataFrame) -> pl.DataFrame:
     if not LINKS_YAML.exists():
         raise FileNotFoundError(f"Required source file not found: {LINKS_YAML}")
     with LINKS_YAML.open(encoding="utf-8") as f:
-        import yaml as yaml_mod
-
-        links_data = yaml_mod.safe_load(f)
+        links_data = yaml.safe_load(f)
     if not links_data:
         return df
 

--- a/data/processors/roomfinder.py
+++ b/data/processors/roomfinder.py
@@ -323,7 +323,7 @@ def _find_room_id(
 
 
 class RoomNotFoundError(Exception):
-    def __init__(self, known_issue, message=None):
+    def __init__(self, known_issue: bool, message: str | None = None) -> None:
         self.known_issue = known_issue
         self.message = message
         super().__init__(self.message)

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,6 +1,6 @@
 import logging
 import typing
-from typing import Any
+from typing import Any, TypedDict
 
 import orjson
 import polars as pl
@@ -9,6 +9,25 @@ from utils import TranslatableStr
 _logger = logging.getLogger(__name__)
 
 _ = TranslatableStr
+
+
+class Room(TypedDict):
+    """A room as aggregated into a parent's floor list: its id and TUMonline floor name."""
+
+    id: str
+    floor: str
+
+
+class FloorDetails(TypedDict):
+    """Resolved metadata for one physical floor, serialised into `props_floors_json`."""
+
+    id: int
+    floor: str
+    tumonline: str
+    type: str
+    name: TranslatableStr | str
+    mezzanine_shift: int
+    trivial: bool
 
 
 def extract_tumonline_props(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -129,7 +148,7 @@ def compute_floor_prop(df: pl.DataFrame) -> pl.DataFrame:
         if not rooms:
             continue
         generators = orjson.loads(row["generators_json"]) if row["generators_json"] else {}
-        floor_details = _get_floor_details({"generators": generators}, rooms)
+        floor_details = _get_floor_details(generators, rooms)
         floor_updates[row["parent_id"]] = orjson.dumps(floor_details).decode()
         lookup = {f["tumonline"]: f for f in floor_details}
         for room in rooms:
@@ -150,7 +169,7 @@ def compute_floor_prop(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def _build_sorted_floor_list(room_data):
+def _build_sorted_floor_list(room_data: list[Room]) -> list[str]:
     """Build a physically sorted list of floors (using TUMonline floor names)"""
     floors = {room["floor"] for room in room_data}
 
@@ -175,12 +194,12 @@ def _build_sorted_floor_list(room_data):
     return sorted(floors, key=floor_quantifier)
 
 
-def _get_floor_details(entry, room_data):
+def _get_floor_details(generators: dict[str, Any], room_data: list[Room]) -> list[FloorDetails]:
     """Infer for each floor the metadata and name string"""
     floors = _build_sorted_floor_list(room_data)
-    floors_details = []
+    floors_details: list[FloorDetails] = []
 
-    patches = entry.get("generators", {}).get("floors", {}).get("floor_patches", {})
+    patches = generators.get("floors", {}).get("floor_patches", {})
 
     eg_index = floors.index("EG") if "EG" in floors else 0
     mezzanine_shift = 0

--- a/data/processors/test_export.py
+++ b/data/processors/test_export.py
@@ -24,7 +24,7 @@ def _data() -> dict[str, dict[str, Any]]:
     }
 
 
-def test_parent_types_parallel_array_carries_each_parents_type():
+def test_parent_types_parallel_array_carries_each_parents_type() -> None:
     """`parent_types` mirrors `parents`/`parent_names` so the client can build /{type}/{id} links."""
     data = _data()
     result = extract_exported_item(data, data["mi"])
@@ -32,7 +32,7 @@ def test_parent_types_parallel_array_carries_each_parents_type():
     assert result["parent_types"] == ["root", "site"]
 
 
-def test_parents_and_parent_names_are_unchanged():
+def test_parents_and_parent_names_are_unchanged() -> None:
     """The additive `parent_types` field leaves the existing parallel arrays intact (rollout-safe)."""
     data = _data()
     result = extract_exported_item(data, data["mi"])
@@ -41,7 +41,7 @@ def test_parents_and_parent_names_are_unchanged():
     assert result["parent_names"] == [TranslatableStr("Standorte", "Sites"), TranslatableStr("Garching", "Garching")]
 
 
-def test_root_parent_type_is_synthesised_without_a_data_entry():
+def test_root_parent_type_is_synthesised_without_a_data_entry() -> None:
     """`root` has no real data entry, so its type is supplied directly rather than looked up."""
     data = _data()
     result = extract_exported_item(data, data["garching"])

--- a/data/processors/test_iris.py
+++ b/data/processors/test_iris.py
@@ -1,6 +1,7 @@
 import logging
 
 import polars as pl
+import pytest
 from external.schemas.iris import IrisRoomsSchema
 
 from processors.iris import add_iris_coverage, derive_coverage_building_ids
@@ -12,21 +13,21 @@ def _rooms(*raum_nr_architekt: str) -> pl.DataFrame:
     return pl.DataFrame(rows, schema=IrisRoomsSchema.to_polars_schema())
 
 
-def test_matched_room_yields_its_building_id():
+def test_matched_room_yields_its_building_id() -> None:
     """A single Iris room whose arch_name NavigaTUM knows contributes its building id."""
     coverage = derive_coverage_building_ids(_rooms("D 11@4113"), navigatum_arch_names={"D 11@4113"})
 
     assert coverage == {"4113"}
 
 
-def test_room_unknown_to_navigatum_is_ignored():
+def test_room_unknown_to_navigatum_is_ignored() -> None:
     """An Iris room whose arch_name NavigaTUM does not know contributes no coverage."""
     coverage = derive_coverage_building_ids(_rooms("GHOST@9999"), navigatum_arch_names={"D 11@4113"})
 
     assert coverage == set()
 
 
-def test_join_includes_building_with_any_match_excludes_buildings_with_none():
+def test_join_includes_building_with_any_match_excludes_buildings_with_none() -> None:
     """
     A building with >=1 matched room is covered; a building with none is not.
 
@@ -40,7 +41,7 @@ def test_join_includes_building_with_any_match_excludes_buildings_with_none():
     assert coverage == {"4113", "5606"}
 
 
-def test_building_in_iris_without_alias_match_is_warned_as_coverage_gap(caplog):
+def test_building_in_iris_without_alias_match_is_warned_as_coverage_gap(caplog: pytest.LogCaptureFixture) -> None:
     """
     Iris lists a `gebaeude_code` whose rooms NavigaTUM cannot alias-match -> warn, don't cover.
 
@@ -65,7 +66,7 @@ def _sample_entries() -> pl.DataFrame:
     )
 
 
-def test_add_coverage_marks_only_matched_buildings():
+def test_add_coverage_marks_only_matched_buildings() -> None:
     """add_iris_coverage flags the matched building, leaving its rooms and other buildings False."""
     df = add_iris_coverage(_sample_entries(), rooms=_rooms("01.06.011@5606"))
 
@@ -73,7 +74,7 @@ def test_add_coverage_marks_only_matched_buildings():
     assert coverage == {"5606": True, "5606.EG.011": False, "0001": False}
 
 
-def test_add_coverage_with_no_rooms_marks_nothing():
+def test_add_coverage_with_no_rooms_marks_nothing() -> None:
     """First build (no scraped roster) marks no coverage and produces a non-null column."""
     df = add_iris_coverage(_sample_entries(), rooms=_rooms())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,14 +122,18 @@ select = [
   "ICN",   # canonical aliases (np, pd, pl, …)
   "TID",   # tidy-imports (no relative, no banned)
   "FA",    # `from __future__ import annotations` where it helps
+  "INP",   # implicit-namespace-package (a dir without `__init__.py`)
   # logging
   "LOG",   # mis-use of the `logging` stdlib module
   "G",     # logging format (G004 disabled below)
   # naming
   "N",     # pep8-naming
-  # pylint subsets - errors and warnings only; PLR (refactor) overlaps with C90 which is excluded
+  # type annotations
+  "ANN",   # flake8-annotations (functions must declare argument & return types; ANN401 relaxed below)
+  # pylint subsets - errors, warnings, conventions; PLR (refactor) stays out (complexity overlaps C90, magic-values too noisy)
   "PLE",   # pylint errors
   "PLW",   # pylint warnings
+  "PLC",   # pylint conventions (import-outside-top-level, …)
   # comprehensions, performance, simplification
   "C4",    # flake8-comprehensions
   "FURB",  # refurb-style modernizations
@@ -163,6 +167,7 @@ ignore = [
   "TD", # too many todos/fixmes
 
   #### rules
+  "ANN401", # `Any` is legitimate at the orjson/yaml/`*args` boundaries; require *an* annotation, not a specific type
   "SIM108", # ternary operator should be used without a concearn for the code complexity
   "G004", # f-strings in logging are fine; lazy %-formatting rarely worth the readability cost
   "S101", # `assert` is used as a runtime guard in CLI/scraping code; this matched bandit's prior `B101` skip
@@ -213,6 +218,10 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # pytest activates fixtures via parameter name; the body may not reference them.
 "**/test_*.py" = ["ARG001", "ARG002"]
 "**/tests/**" = ["ARG001", "ARG002"]
+# Root entry scripts, deliberately not a package: importing them relies on `data/` being
+# the path root, which adding an `__init__.py` (INP001's fix) would break.
+"data/compile.py" = ["INP001"]
+"data/utils.py" = ["INP001"]
 
 [tool.ruff.lint.pep8-naming]
 # `dataframely` rules and pydantic validators receive the class as first argument.


### PR DESCRIPTION
## What & why

The `data/` lint config (after #3123) was thorough but still left the canonical **type-safety** group, `ANN` (flake8-annotations), disabled. This enables three rule groups and fixes every finding — with **honest types, not `Any`**, wherever a real shape exists.

| Rule | Why | Findings fixed |
|------|-----|----------------|
| **`ANN`** (flake8-annotations) | Enforces functions *declare* argument & return types — complements mypy, which checks the types but not their presence | 27 missing annotations |
| **`PLC`** (pylint conventions) | Surfaced `PLC0415` import-outside-top-level | 7 inline imports hoisted to module top |
| **`INP`** | Regression guard for a missing `__init__.py` in real subpackages | 2 root scripts per-file-ignored |

## Avoiding `Any`

ANN's value is partly in forcing you to *think* about the shape — filling it with `dict[str, Any]` defeats that. So:

- **`sections.py`** — the room and floor-detail dicts have stable shapes, modelled as `Room` / `FloorDetails` **TypedDicts**. `_get_floor_details` now takes `generators` directly, dropping a pointless `{"generators": …}` wrapper at its only call site.
- **`images.py`** — annotating `_add_source_info` surfaced a **latent shape bug**: the source map is keyed by int index (`dict[int, …]`, per `ImageSource.load_all`), not a `list`. `Any` had masked the mismatch. Corrected.
- The **remaining `Any`** is confined to genuinely dynamic data and is called out as such: the incrementally-built export entry (matches the existing `export_for_api(data: dict[str, Any])`) and user-authored yaml/JSON source / floor-patch blobs.

### Deliberately out of scope

`images.py` has an `ImageSource` pydantic model that `add_img` bypasses in favour of raw yaml. Migrating to it would be the ideal fix, but it converts the current *warn-and-skip on missing fields* into a *validation error* — a behavior change that doesn't belong in a lint PR. Flagged as a follow-up.

## Decisions

- **`ANN401` relaxed** (consistent with the existing `FBT`/`TRY003` ignores): `Any` is genuine at the orjson-default, yaml-load, and `*args`/`**kwargs` boundaries. The rule requires *an* annotation, not a specific type.
- **`INP001` per-file-ignored** for `compile.py`/`utils.py` rather than adding `__init__.py` — these are path-root entry scripts, and a package init would break their `from utils import …` imports.
- **`export.py` import hoist is cycle-safe** — verified nothing under `external/` imports `processors`, then smoke-imported to confirm.
- **`ERA` evaluated and dropped** — three of its four hits were false positives on descriptive comments (`# column: type_common_name_de`), not worth the noqa noise.
- New `caplog` annotation typed as `pytest.LogCaptureFixture`, not `Any`.

## Verification

- `uv run ruff check .` — clean
- `mypy` — clean
- 139 data tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)