### PR TITLE
feat(data): add GARNIX open-air festival to events.csv

### DIFF
--- a/data/sources/events.csv
+++ b/data/sources/events.csv
@@ -1,3 +1,4 @@
 event_image,event_lat,event_lon,event_name,event_datetime_start_at,event_datetime_end_at,event_description,event_organising_org_id
 https://www.tum.de/fileadmin/_processed_/c/5/csm_1584780_0346e6dc92.webp,48.149678,11.567909,TUM Open Campus Day,2026-06-15T10:00:00+02:00,2026-06-15T18:00:00+02:00,Annual open-campus event with lab tours and student-life booths across the main campus.,14146
 https://www.mw.tum.de/fileadmin/_processed_/open-day.jpg,48.149974,11.568029,Mechanical Engineering Open Day,2026-07-04T10:00:00+02:00,2026-07-04T17:00:00+02:00,Open day with lab demos and student-project showcases at the MW central services.,15252
+https://garnix-openair.de/_garnix/grill.BkbKSC4u_2qH9Pw.webp,48.262908,11.669102,GARNIX Festival,2026-06-05T16:00:00+02:00,2026-06-19T23:59:00+02:00,"Open-air student festival on the Garching research campus with live music, food trucks, and faculty club stands.",51897


### PR DESCRIPTION
## What

Adds the **GARNIX open-air festival** (Garching research campus) to `data/sources/events.csv`, so the active-event photo markers from #3136 have a real, currently-active datapoint to render and iterate against.

## Details

- Coordinates `48.262908, 11.669102` point at the festival grounds on the Garching campus.
- `event_organising_org_id = 51897` (TUM School of Computation, Information and Technology), FK-valid against `orgs-en_tumonline.csv`.
- Image uses the official GARNIX asset.
- Validates against `EventsSchema` — `test_schemas_events.py` passes.

## ⚠️ Date window

`starts_at`/`ends_at` are set to `2026-06-05` → `2026-06-19` to keep the row inside the `events_active` view window during local iteration on #3136. Please sanity-check against the real 2026 GARNIX dates before merge — the span is intentionally wide for development, not a verified festival duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)