### PR TITLE
feat(data): publish known_orgs.json for the event-submission org picker (#3142)

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -283,6 +283,7 @@ def _run_pipeline(
     export.export_for_status()
     export.export_known_usages(df)
     export.export_tumonline_orgs_parquet()
+    export.export_known_orgs()
     export.export_events_parquet()
     ranking_factors_export.export_ranking_factors_parquet(df)
     operators_export.export_operators_de_parquet(df)

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -273,6 +273,23 @@ def export_tumonline_orgs_parquet() -> None:
     TumonlineOrgsSchema.write_parquet(load_tumonline_orgs(), OUTPUT_DIR_PATH / "tumonline_orgs.parquet")
 
 
+# The fields the event-submission org picker needs to display, filter, and submit an org.
+# `org_id` is the value submitted as `events.organising_org_id`; `code` is the human-readable
+# disambiguator for the ~100 orgs that share a localized name; the names drive display and filtering.
+KNOWN_ORGS_FIELDS = ["org_id", "code", "name_de", "name_en"]
+
+
+def export_known_orgs() -> None:
+    """Export the known TUMonline orgs (JSON mirror of tumonline_orgs.parquet for the event-submission org picker)."""
+    # Mirror of known_usages.json: a client-side filterable combobox reads JSON directly
+    # rather than a parquet reader. Sort by name_de for a stable, reproducible default order.
+    result_df = load_tumonline_orgs().select(KNOWN_ORGS_FIELDS).sort("name_de")
+
+    (OUTPUT_DIR_PATH / "known_orgs.json").write_bytes(
+        orjson.dumps(result_df.to_dicts(), option=orjson.OPT_INDENT_2) + b"\n"
+    )
+
+
 def export_events_parquet() -> None:
     """
     Read events.csv and write events.parquet.

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -273,8 +273,6 @@ def export_tumonline_orgs_parquet() -> None:
     TumonlineOrgsSchema.write_parquet(load_tumonline_orgs(), OUTPUT_DIR_PATH / "tumonline_orgs.parquet")
 
 
-
-
 def export_known_orgs() -> None:
     """Export the known TUMonline orgs as json"""
     # `org_id` is the value submitted as `events.organising_org_id`

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -273,17 +273,13 @@ def export_tumonline_orgs_parquet() -> None:
     TumonlineOrgsSchema.write_parquet(load_tumonline_orgs(), OUTPUT_DIR_PATH / "tumonline_orgs.parquet")
 
 
-# The fields the event-submission org picker needs to display, filter, and submit an org.
-# `org_id` is the value submitted as `events.organising_org_id`; `code` is the human-readable
-# disambiguator for the ~100 orgs that share a localized name; the names drive display and filtering.
-KNOWN_ORGS_FIELDS = ["org_id", "code", "name_de", "name_en"]
 
 
 def export_known_orgs() -> None:
-    """Export the known TUMonline orgs (JSON mirror of tumonline_orgs.parquet for the event-submission org picker)."""
-    # Mirror of known_usages.json: a client-side filterable combobox reads JSON directly
-    # rather than a parquet reader. Sort by name_de for a stable, reproducible default order.
-    result_df = load_tumonline_orgs().select(KNOWN_ORGS_FIELDS).sort("name_de")
+    """Export the known TUMonline orgs as json"""
+    # `org_id` is the value submitted as `events.organising_org_id`
+    # `code` is the human-readable disambiguator for the ~100 orgs that share a localized name
+    result_df = load_tumonline_orgs().select(["org_id", "code", "name_de", "name_en"]).sort("code")
 
     (OUTPUT_DIR_PATH / "known_orgs.json").write_bytes(
         orjson.dumps(result_df.to_dicts(), option=orjson.OPT_INDENT_2) + b"\n"

--- a/data/processors/test_export_known_orgs.py
+++ b/data/processors/test_export_known_orgs.py
@@ -16,7 +16,9 @@ def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
     assert len(orgs) == expected_count, "one row per validated TUMonline org"
 
     for org in orgs:
-        assert list(org.keys()) == ["org_id", "code", "name_de", "name_en"], "stable field set and order for the frontend contract"
+        assert list(org.keys()) == ["org_id", "code", "name_de", "name_en"], (
+            "stable field set and order for the frontend contract"
+        )
         assert isinstance(org["org_id"], int)
         assert org["org_id"] > 0, "org_id is the positive key submitted as organising_org_id"
         assert org["code"].strip(), "code is the non-empty TUMonline org code"

--- a/data/processors/test_export_known_orgs.py
+++ b/data/processors/test_export_known_orgs.py
@@ -16,9 +16,7 @@ def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
     assert len(orgs) == expected_count, "one row per validated TUMonline org"
 
     for org in orgs:
-        assert list(org.keys()) == ["org_id", "code", "name_de", "name_en"], (
-            "stable field set and order for the frontend contract"
-        )
+        assert list(org.keys()) == ["org_id", "code", "name_de", "name_en"]
         assert isinstance(org["org_id"], int)
         assert org["org_id"] > 0, "org_id is the positive key submitted as organising_org_id"
         assert org["code"].strip(), "code is the non-empty TUMonline org code"

--- a/data/processors/test_export_known_orgs.py
+++ b/data/processors/test_export_known_orgs.py
@@ -4,8 +4,8 @@ from external.loaders.tumonline_orgs import load_tumonline_orgs
 from processors.export import OUTPUT_DIR_PATH, export_known_orgs
 
 
-def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
-    """`known_orgs.json` lists every org with exactly the picker fields, sorted by `name_de`."""
+def test_export_known_orgs_writes_picker_fields_sorted_by_code() -> None:
+    """`known_orgs.json` lists every org with exactly the picker fields, sorted by `code`."""
     export_known_orgs()
 
     raw = (OUTPUT_DIR_PATH / "known_orgs.json").read_bytes()
@@ -23,5 +23,5 @@ def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
         assert org["name_de"], "German name is required for display and filtering"
         assert org["name_en"], "English name is required for display and filtering"
 
-    names = [org["name_de"] for org in orgs]
-    assert names == sorted(names), "deterministic default order for the combobox"
+    codes = [org["code"] for org in orgs]
+    assert codes == sorted(codes), "deterministic default order for the combobox"

--- a/data/processors/test_export_known_orgs.py
+++ b/data/processors/test_export_known_orgs.py
@@ -1,0 +1,27 @@
+import orjson
+from external.loaders.tumonline_orgs import load_tumonline_orgs
+
+from processors.export import KNOWN_ORGS_FIELDS, OUTPUT_DIR_PATH, export_known_orgs
+
+
+def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
+    """`known_orgs.json` lists every org with exactly the picker fields, sorted by `name_de`."""
+    export_known_orgs()
+
+    raw = (OUTPUT_DIR_PATH / "known_orgs.json").read_bytes()
+    assert raw.endswith(b"\n"), "must mirror known_usages.json's trailing newline"
+    orgs = orjson.loads(raw)
+
+    expected_count = load_tumonline_orgs().height
+    assert len(orgs) == expected_count, "one row per validated TUMonline org"
+
+    for org in orgs:
+        assert list(org.keys()) == KNOWN_ORGS_FIELDS, "stable field set and order for the frontend contract"
+        assert isinstance(org["org_id"], int)
+        assert org["org_id"] > 0, "org_id is the positive key submitted as organising_org_id"
+        assert org["code"].strip(), "code is the non-empty TUMonline org code"
+        assert org["name_de"], "German name is required for display and filtering"
+        assert org["name_en"], "English name is required for display and filtering"
+
+    names = [org["name_de"] for org in orgs]
+    assert names == sorted(names), "deterministic default order for the combobox"

--- a/data/processors/test_export_known_orgs.py
+++ b/data/processors/test_export_known_orgs.py
@@ -1,7 +1,7 @@
 import orjson
 from external.loaders.tumonline_orgs import load_tumonline_orgs
 
-from processors.export import KNOWN_ORGS_FIELDS, OUTPUT_DIR_PATH, export_known_orgs
+from processors.export import OUTPUT_DIR_PATH, export_known_orgs
 
 
 def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
@@ -16,7 +16,7 @@ def test_export_known_orgs_writes_picker_fields_sorted_by_name() -> None:
     assert len(orgs) == expected_count, "one row per validated TUMonline org"
 
     for org in orgs:
-        assert list(org.keys()) == KNOWN_ORGS_FIELDS, "stable field set and order for the frontend contract"
+        assert list(org.keys()) == ["org_id", "code", "name_de", "name_en"], "stable field set and order for the frontend contract"
         assert isinstance(org["org_id"], int)
         assert org["org_id"] > 0, "org_id is the positive key submitted as organising_org_id"
         assert org["code"].strip(), "code is the non-empty TUMonline org code"


### PR DESCRIPTION
## What

Publishes a `known_orgs.json` static file from the data pipeline so the event-submission frontend can offer a client-side filterable org combobox, mirroring `known_usages.json` / `useKnownUsages`.

Closes #3142