### PR TITLE
fix(webclient): repair type-refresh flags renamed in openapi-typescript 7.13

### DIFF
--- a/webclient/package.json
+++ b/webclient/package.json
@@ -8,7 +8,7 @@
 		"preview": "nuxt preview",
 		"postinstall": "nuxt prepare",
 		"type-check": "nuxt typecheck",
-		"type-refresh": "openapi-typescript ../openapi.yaml --output app/api_types/index.ts --export-type --immutable-types --support-array-length && pnpm run format && pnpm run lint && pnpm run type-check",
+		"type-refresh": "openapi-typescript ../openapi.yaml --output app/api_types/index.ts --export-type --immutable --array-length && pnpm run format && pnpm run lint && pnpm run type-check",
 		"lint": "biome lint --write --error-on-warnings . ",
 		"format": "biome format --write && biome check --formatter-enabled=false --linter-enabled=false --write",
 		"test": "vitest run"


### PR DESCRIPTION
## What

`openapi-typescript` 7.13 renamed two flags that the `webclient` `type-refresh` script passes:

- `--immutable-types` → `--immutable`
- `--support-array-length` → `--array-length`