### PR TITLE
fix(data): propagate Iris learning-room coverage to ancestor containers

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2697,14 +2697,18 @@ components:
             For buildings, this may contain multiple floors while rooms usually only have one floor.
             POIs inherit floors from their immediate parent: a single floor when parented to a room,
             or the full building list when parented to a building.
-        has_iris_coverage:
-          type: boolean
+        iris_coverage_building_ids:
+          type: array
+          items:
+            type: string
           description: |-
-            Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
+            Building ids whose Studentische Vertretung IRIS learning rooms fall under this entry.
 
+            A covered building lists itself.
+            An ancestor container (area, campus, or a joined building such as MI) lists every covered building among its descendants.
             Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
-            When `true`, the page can offer a learning-room availability view without a second request.
-            Absent (rather than `false`) for entries without coverage.
+            When non-empty, the page can offer a learning-room availability view without a second request.
+            Empty (and omitted) for entries without coverage.
         links:
           type: array
           items:

--- a/data/processors/df_utils.py
+++ b/data/processors/df_utils.py
@@ -278,9 +278,8 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
         props["generic"] = orjson.loads(generic_json)
     if comment_de := row.get("props_comment_de"):
         props["comment"] = {"en": row.get("props_comment_en", ""), "de": comment_de}
-    # Absent reads as "no coverage" on the info card; we only emit when present.
-    if row.get("has_iris_coverage"):
-        props["has_iris_coverage"] = True
+    if iris_coverage_building_ids := row.get("iris_coverage_building_ids"):
+        props["iris_coverage_building_ids"] = iris_coverage_building_ids
 
     if props:
         result["props"] = props

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -213,7 +213,7 @@ def extract_exported_item(data: dict[str, Any], entry: dict[str, Any]) -> dict[s
             "calendar_url",
             "tumonline_room_nr",
             "operator",
-            "has_iris_coverage",
+            "iris_coverage_building_ids",
         }
         to_delete = [e for e in result["props"] if e not in prop_keys_to_keep]
         for k in to_delete:

--- a/data/processors/iris.py
+++ b/data/processors/iris.py
@@ -32,23 +32,36 @@ def derive_coverage_building_ids(iris_rooms: pl.DataFrame, navigatum_arch_names:
 
 def add_iris_coverage(df: pl.DataFrame, *, rooms: pl.DataFrame | None = None) -> pl.DataFrame:
     """
-    Add the non-nullable `has_iris_coverage` flag to every entry.
+    Add the non-nullable `iris_coverage_building_ids` list to every entry.
 
-    The roster comes from the committed scrape; on the first build (before any scrape) it is
-    empty, so nothing is marked. Only building/area entries can match (their `id` equals the
-    building id), so rooms get `False`.
+    A container (area, campus, the MI `joined_building`, …) inherits the coverage of its descendant
+    buildings via `children_flat`, so the aggregate page can offer the learning-room view too.
+
+    On the first build there is no scrape yet, so every list comes out empty.
     """
     if rooms is None:
         rooms = _load_stored_rooms()
     arch_names = set(df.get_column("arch_name").drop_nulls().to_list())
     building_ids = derive_coverage_building_ids(rooms, arch_names)
     _logger.info("Iris learning-room coverage derived for %d building(s)", len(building_ids))
-    return df.with_columns(pl.col("id").is_in(list(building_ids)).alias("has_iris_coverage"))
+
+    # children_flat is null for leaves, so coalesce before concatenating.
+    candidates = pl.concat_list(
+        pl.col("id"),
+        pl.col("children_flat").fill_null(pl.lit([], dtype=pl.List(pl.Utf8))),
+    )
+    coverage = (
+        candidates.list.eval(pl.element().filter(pl.element().is_in(list(building_ids))))
+        .list.unique()
+        .list.sort()
+        .alias("iris_coverage_building_ids")
+    )
+    return df.with_columns(coverage)
 
 
 def _load_stored_rooms() -> pl.DataFrame:
     try:
         return load_iris_rooms()
     except FileNotFoundError:
-        _logger.warning("No stored Iris roster yet; has_iris_coverage will be empty this build")
+        _logger.warning("No stored Iris roster yet; iris_coverage_building_ids will be empty this build")
         return pl.DataFrame(schema=IrisRoomsSchema.to_polars_schema())

--- a/data/processors/schema.py
+++ b/data/processors/schema.py
@@ -115,7 +115,7 @@ class LocationSchema(dy.Schema):
     external_data_json = dy.String()
 
     # --- Studentische Vertretung IRIS learning-room coverage ---
-    has_iris_coverage = dy.Bool(nullable=False)
+    iris_coverage_building_ids = dy.List(inner=dy.String(), nullable=False)
 
     @dy.rule()
     def type_is_valid(cls) -> pl.Expr:

--- a/data/processors/test_iris.py
+++ b/data/processors/test_iris.py
@@ -56,27 +56,45 @@ def test_building_in_iris_without_alias_match_is_warned_as_coverage_gap(caplog: 
 
 
 def _sample_entries() -> pl.DataFrame:
-    """Build a tiny entry frame: a covered building, one of its rooms, and an unrelated building."""
+    """
+    Build a tiny entry frame mirroring the MI shape.
+
+    The `mi` joined_building has child building `5606` (holding a room) and an empty sibling `5607`.
+    `0001` is an unrelated building.
+    `children_flat` is null for leaves, matching the left-join in `structure.add_children_properties`.
+    """
     return pl.DataFrame(
         {
-            "id": ["5606", "5606.EG.011", "0001"],
-            "type": ["building", "room", "building"],
-            "arch_name": ["@5606", "01.06.011@5606", "@0001"],
+            "id": ["mi", "5606", "5607", "5606.EG.011", "0001"],
+            "type": ["joined_building", "building", "building", "room", "building"],
+            "arch_name": [None, "@5606", "@5607", "01.06.011@5606", "@0001"],
+            "children_flat": [["5606", "5607", "5606.EG.011"], None, None, None, None],
         }
     )
 
 
-def test_add_coverage_marks_only_matched_buildings() -> None:
-    """add_iris_coverage flags the matched building, leaving its rooms and other buildings False."""
+def test_add_coverage_lists_matched_buildings_and_propagates_to_joined_building() -> None:
+    """
+    The matched building lists itself and its joined_building parent inherits it.
+
+    Regression for the MI bug, where `mi` stayed empty although child `5606` has a learning room.
+    Empty siblings, rooms, and unrelated buildings stay empty.
+    """
     df = add_iris_coverage(_sample_entries(), rooms=_rooms("01.06.011@5606"))
 
-    coverage = dict(zip(df["id"], df["has_iris_coverage"], strict=True))
-    assert coverage == {"5606": True, "5606.EG.011": False, "0001": False}
+    coverage = dict(zip(df["id"].to_list(), df["iris_coverage_building_ids"].to_list(), strict=True))
+    assert coverage == {
+        "mi": ["5606"],
+        "5606": ["5606"],
+        "5607": [],
+        "5606.EG.011": [],
+        "0001": [],
+    }
 
 
 def test_add_coverage_with_no_rooms_marks_nothing() -> None:
-    """First build (no scraped roster) marks no coverage and produces a non-null column."""
+    """First build (no scraped roster) lists no coverage and produces a non-null column."""
     df = add_iris_coverage(_sample_entries(), rooms=_rooms())
 
-    assert df["has_iris_coverage"].to_list() == [False, False, False]
-    assert df["has_iris_coverage"].null_count() == 0
+    assert df["iris_coverage_building_ids"].to_list() == [[], [], [], [], []]
+    assert df["iris_coverage_building_ids"].null_count() == 0

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -414,13 +414,15 @@ struct PropsResponse {
     /// or the full building list when parented to a building.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     floors: Vec<FloorResponse>,
-    /// Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
+    /// Building ids whose Studentische Vertretung IRIS learning rooms fall under this entry.
     ///
+    /// A covered building lists itself.
+    /// An ancestor container (area, campus, or a joined building such as MI) lists every covered building among its descendants.
     /// Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
-    /// When `true`, the page can offer a learning-room availability view without a second request.
-    /// Absent (rather than `false`) for entries without coverage.
-    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
-    has_iris_coverage: bool,
+    /// When non-empty, the page can offer a learning-room availability view without a second request.
+    /// Empty (and omitted) for entries without coverage.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    iris_coverage_building_ids: Vec<String>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1285,13 +1285,15 @@ export type components = {
        */
       readonly floors?: readonly components["schemas"]["FloorResponse"][];
       /**
-       * @description Whether this building/area has Studentische Vertretung IRIS learning-room coverage.
+       * @description Building ids whose Studentische Vertretung IRIS learning rooms fall under this entry.
        *
+       * A covered building lists itself.
+       * An ancestor container (area, campus, or a joined building such as MI) lists every covered building among its descendants.
        * Derived at data-build time by matching the Studentische Vertretung IRIS room roster against our aliases.
-       * When `true`, the page can offer a learning-room availability view without a second request.
-       * Absent (rather than `false`) for entries without coverage.
+       * When non-empty, the page can offer a learning-room availability view without a second request.
+       * Empty (and omitted) for entries without coverage.
        */
-      readonly has_iris_coverage?: boolean;
+      readonly iris_coverage_building_ids?: readonly string[];
       readonly links?: readonly components["schemas"]["PossibleURLRefResponse"][];
       readonly operator?: null | components["schemas"]["OperatorResponse"];
     };

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -250,8 +250,11 @@ const actions = computed<DetailAction[]>(() => [
       <DetailsBuildingOverviewSection :buildings="data.sections?.buildings_overview"/>
       <ClientOnly>
         <LazyDetailsNearbyTransportSection :id="data.id"/>
-        <!-- Browser-side live status; gated on the build-time signal so uncovered pages issue no Iris request. -->
-        <LazyDetailsIrisCoverageCard v-if="data.props.has_iris_coverage" :building-id="data.id"/>
+        <!-- Gated on the build-time signal, so uncovered pages issue no Iris request. -->
+        <LazyDetailsIrisCoverageCard
+          v-if="data.props.iris_coverage_building_ids?.length"
+          :building-ids="data.props.iris_coverage_building_ids"
+        />
         <LazyDetailsRoomOverviewSection :rooms="data.sections?.rooms_overview"/>
       </ClientOnly>
       <DetailsSources

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -14,15 +14,15 @@ import { useIrisAvailability } from "~/composables/irisAvailability";
 import { bookedUntilTime, IRIS_SITE_URL, type IrisRoomRow, occupancyPercent } from "~/utils/iris";
 
 const props = defineProps<{
-  // The NavigaTUM building id whose Iris learning rooms to show. Only passed for entries whose
-  // build-time `has_iris_coverage` signal is true, so the parent gates the browser-side fetch.
-  readonly buildingId: string;
+  // A joined building (e.g. MI) passes every covered finger id, not just its own.
+  // The parent renders this only when non-empty, so an uncovered page issues no Iris request.
+  readonly buildingIds: readonly string[];
 }>();
 
 const { t } = useI18n({ useScope: "local" });
 
 const cardEl = ref<HTMLElement | null>(null);
-const { rooms, loading } = useIrisAvailability(() => props.buildingId, cardEl);
+const { rooms, loading } = useIrisAvailability(() => props.buildingIds, cardEl);
 
 // Hide once the first snapshot settled with nothing to show (a failed first load, or no room that
 // resolved to a NavigaTUM page) - that is the silent-degradation path. The card stays mounted while

--- a/webclient/app/composables/irisAvailability.ts
+++ b/webclient/app/composables/irisAvailability.ts
@@ -5,21 +5,21 @@ import {
   useTimeoutPoll,
 } from "@vueuse/core";
 import { useIrisSnapshot } from "~/composables/irisSnapshot";
-import { buildRoomRows, type IrisRoomRow, roomsForBuilding } from "~/utils/iris";
+import { buildRoomRows, type IrisRoomRow, roomsForBuildings } from "~/utils/iris";
 
 // Iris recomputes room status roughly once a minute, so polling faster would only repeat work.
 const POLL_INTERVAL_MS = 60_000;
 
 /**
- * Drive the live Iris learning-room availability for one building.
+ * Drive the live Iris learning-room availability for one or more buildings.
  *
- * Builds on {@link useIrisSnapshot} for the browser-side roster fetch, filters it to the building,
+ * Builds on {@link useIrisSnapshot} for the browser-side roster fetch, filters it to the buildings,
  * resolves each room's `raum_nr_architekt` to a NavigaTUM room via the alias lookup (caching results,
  * omitting misses), and refreshes every {@link POLL_INTERVAL_MS} while the card is both on-screen and
  * in a foreground tab. Every fetch degrades silently: a failed poll keeps the last good snapshot.
  */
 export function useIrisAvailability(
-  buildingId: MaybeRefOrGetter<string>,
+  buildingIds: MaybeRefOrGetter<readonly string[]>,
   target: MaybeRefOrGetter<HTMLElement | null | undefined>
 ) {
   const { locale } = useI18n();
@@ -69,7 +69,7 @@ export function useIrisAvailability(
     resolveBatch?.abort();
     const controller = new AbortController();
     resolveBatch = controller;
-    const buildingRooms = roomsForBuilding(all, toValue(buildingId));
+    const buildingRooms = roomsForBuildings(all, toValue(buildingIds));
     await Promise.all(buildingRooms.map((room) => resolveAlias(room.archName, controller.signal)));
     if (controller.signal.aborted) return;
 

--- a/webclient/app/utils/iris.ts
+++ b/webclient/app/utils/iris.ts
@@ -104,9 +104,13 @@ export function parseIrisRooms(json: unknown): IrisRoom[] {
   return rooms;
 }
 
-/** Keep only the rooms Iris attributes to `buildingId`. */
-export function roomsForBuilding(rooms: readonly IrisRoom[], buildingId: string): IrisRoom[] {
-  return rooms.filter((room) => room.buildingId === buildingId);
+/** A joined building (e.g. MI) passes every covered finger id, so its page unions them. */
+export function roomsForBuildings(
+  rooms: readonly IrisRoom[],
+  buildingIds: readonly string[]
+): IrisRoom[] {
+  const wanted = new Set(buildingIds);
+  return rooms.filter((room) => wanted.has(room.buildingId));
 }
 
 /** The integer occupancy percentage (`0`..`100`) to display for a WAAS room. */

--- a/webclient/test/iris.test.ts
+++ b/webclient/test/iris.test.ts
@@ -5,7 +5,7 @@ import {
   isKnownStatus,
   occupancyPercent,
   parseIrisRooms,
-  roomsForBuilding,
+  roomsForBuildings,
 } from "../app/utils/iris";
 
 // A small slice of a real `GET https://iris.asta.tum.de/api/` response, covering each status and
@@ -119,14 +119,25 @@ describe("parseIrisRooms", () => {
   });
 });
 
-describe("roomsForBuilding", () => {
-  it("keeps only the rooms Iris attributes to the building", () => {
+describe("roomsForBuildings", () => {
+  it("keeps only the rooms Iris attributes to the buildings", () => {
     const rooms = parseIrisRooms(IRIS_FIXTURE);
-    expect(roomsForBuilding(rooms, "8102").map((r) => r.archName)).toEqual([
+    expect(roomsForBuildings(rooms, ["8102"]).map((r) => r.archName)).toEqual([
       "BC2 0.01.18@8102",
       "0.01.19@8102",
     ]);
-    expect(roomsForBuilding(rooms, "0000")).toEqual([]);
+    expect(roomsForBuildings(rooms, ["0000"])).toEqual([]);
+  });
+
+  it("unions rooms across several buildings (a joined building's fingers)", () => {
+    const rooms = parseIrisRooms(IRIS_FIXTURE);
+    // A joined building passes every covered child id; the union spans all of them.
+    expect(roomsForBuildings(rooms, ["5504", "8102"]).map((r) => r.buildingId)).toEqual([
+      "5504",
+      "8102",
+      "8102",
+    ]);
+    expect(roomsForBuildings(rooms, [])).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Entries now emit `iris_coverage_building_ids` (the covered buildings among `{id} ∪ children_flat`) so a joined building such as MI inherits its fingers' Iris learning-room coverage, and the webclient card unions live availability across them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)