### PR TITLE
feat(webclient): event submission with live marker preview

### DIFF
--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -563,6 +563,10 @@ export type components = {
             /** @enum {string} */
             readonly kind: "poi";
           },
+          components["schemas"]["NewEvent"] & {
+            /** @enum {string} */
+            readonly kind: "event";
+          },
         ]
       >;
     };
@@ -1008,6 +1012,18 @@ export type components = {
       readonly parent_id: string;
       readonly short_name?: string | null;
       readonly visible_id?: string | null;
+    };
+    /** @description A proposed campus event, appended as a row to `data/sources/events.csv`. */
+    readonly NewEvent: {
+      readonly coords: components["schemas"]["Coordinate"];
+      readonly description: string;
+      readonly ends_at: string;
+      readonly image: components["schemas"]["Image"];
+      readonly name: string;
+      /** Format: int32 */
+      readonly organising_org_id: number;
+      /** @description RFC3339 string, to match the CSV/parquet contract. */
+      readonly starts_at: string;
     };
     readonly NewPoi: {
       readonly comment?: null | components["schemas"]["TranslatableStr"];

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -509,7 +509,7 @@ de:
   crop_header: Header-Ausschnitt
   crop_header_help: Breiter Ausschnitt (512×210) für die Kopfzeile.
   preview: Vorschau auf der Karte
-  preview_help: So erscheint die Veranstaltung auf der Karte – als Foto-Marker mit Popup.
+  preview_help: So erscheint die Veranstaltung auf der Karte - als Foto-Marker mit Popup.
   error:
     name_required: Bitte gib einen Namen an.
     name_too_long: Der Name ist zu lang (max. 200 Zeichen).

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -175,8 +175,10 @@ async function processFile(file: File): Promise<void> {
   // A new image recentres both crops; their offset bounds depend on the new dimensions.
   draft.value.image_thumb_offset = 0;
   draft.value.image_header_offset = 0;
-  // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs).
-  draft.value.id = `event_${await sha256Hex(bytesFromBase64(base64))}`;
+  // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs). The full
+  // sha256 is overkill for a filename; 16 hex chars (64 bits) keep collisions negligible yet tidy.
+  const hash = await sha256Hex(bytesFromBase64(base64));
+  draft.value.id = `event_${hash.slice(0, 16)}`;
   regenerateCrops();
 }
 
@@ -370,6 +372,7 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
         v-model:lon="mapLon"
         :initial-lat="mapLat"
         :initial-lon="mapLon"
+        :awaiting-selection="!draft.coords.picked"
         container-class="h-44"
       />
       <p v-if="draft.coords.picked" class="text-zinc-600 dark:text-zinc-300 mt-1 text-xs">

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -383,7 +383,7 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
     <div>
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("image") }} <span class="text-red-700 dark:text-red-200">*</span></span>
       <div
-        class="cursor-pointer rounded-lg border-2 border-dashed p-4 text-center text-sm transition-colors"
+        class="cursor-pointer rounded border-2 border-dashed p-4 text-center text-sm transition-colors"
         :class="[
           isDragOver
             ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900'
@@ -457,7 +457,7 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
       />
     </div>
 
-    <div class="bg-blue-50 dark:bg-blue-900 border-blue-200 dark:border-blue-700 flex items-start gap-2 rounded-lg border p-3">
+    <div class="bg-blue-50 dark:bg-blue-900 border-blue-200 dark:border-blue-700 flex items-start gap-2 rounded border p-3">
       <MdiIcon :path="mdiInformation" :size="18" class="text-blue-500 dark:text-blue-400 mt-0.5 flex-shrink-0" />
       <div>
         <p class="text-blue-800 dark:text-blue-100 text-sm font-medium">{{ t("license_info_title") }}</p>

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -6,19 +6,17 @@ import {
   ComboboxOption,
   ComboboxOptions,
 } from "@headlessui/vue";
-import { mdiCheck, mdiClose, mdiImage, mdiUnfoldMoreHorizontal } from "@mdi/js";
+import { mdiCheck, mdiClose, mdiImage, mdiInformation, mdiUnfoldMoreHorizontal } from "@mdi/js";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { useEditProposal } from "~/composables/editProposal";
 import { type OrgOption, useKnownOrgs } from "~/composables/useKnownOrgs";
-import { cropToThumbBlobUrl } from "~/utils/imageCrop";
+import { type CropTarget, cropToBlobUrl, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
 
 const editProposal = useEditProposal();
 const { t } = useI18n({ useScope: "local" });
 
 const draft = computed(() => editProposal.value.pendingAddition);
 const fieldErrors = computed<AdditionFieldErrors>(() => validateAddition(draft.value));
-// Only surface a field's error once the user has touched the form enough for it to be actionable;
-// the disabled submit button already blocks an empty form, so eager red text would just be noise.
 function errorFor(path: string): string | null {
   const key = fieldErrors.value[path];
   return key ? t(key) : null;
@@ -36,6 +34,24 @@ const selectedOrg = computed<OrgOption | null>({
   },
 });
 
+// --- Coordinates. Events have no parent to centre on, so default to TUM main campus. ---
+const DEFAULT_LAT = 48.149;
+const DEFAULT_LON = 11.568;
+const mapLat = computed({
+  get: () => draft.value.coords.lat || DEFAULT_LAT,
+  set: (v: number) => {
+    draft.value.coords.lat = v;
+    draft.value.coords.picked = true;
+  },
+});
+const mapLon = computed({
+  get: () => draft.value.coords.lon || DEFAULT_LON,
+  set: (v: number) => {
+    draft.value.coords.lon = v;
+    draft.value.coords.picked = true;
+  },
+});
+
 // --- Image upload ---
 const VALID_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
@@ -43,11 +59,43 @@ const fileInput = ref<HTMLInputElement>();
 const isDragOver = ref(false);
 const fileError = ref("");
 // `blob:` URLs kept local (not in the persisted draft) and revoked on replace/unmount so they never
-// outlive the session: `previewUrl` is the full image (the cropper's source); `croppedThumbUrl` is
-// the offset 256² crop fed to the live marker so it matches what the pipeline will render.
+// outlive the session. `previewUrl` is the full image (the croppers' source); each crop preview
+// renders the offset thumb/header exactly as the pipeline will.
 const previewUrl = ref<string | null>(null);
-const croppedThumbUrl = ref<string | null>(null);
 const sourceImage = shallowRef<HTMLImageElement | null>(null);
+
+// A rendered preview of one crop target, regenerated as its offset changes. A token guards against
+// an earlier crop resolving after a later one and leaving a stale image.
+function makeCropPreview(target: CropTarget) {
+  const url = ref<string | null>(null);
+  let token = 0;
+  function set(next: string | null): void {
+    if (url.value) URL.revokeObjectURL(url.value);
+    url.value = next;
+  }
+  async function regenerate(offset: number): Promise<void> {
+    const img = sourceImage.value;
+    const w = draft.value.image_width;
+    const h = draft.value.image_height;
+    if (!img || !w || !h) {
+      set(null);
+      return;
+    }
+    const ticket = ++token;
+    const next = await cropToBlobUrl(img, w, h, target, offset);
+    if (ticket !== token) {
+      if (next) URL.revokeObjectURL(next);
+      return;
+    }
+    set(next);
+  }
+  return { url, set, regenerate };
+}
+const thumbPreview = makeCropPreview(THUMB_TARGET);
+const headerPreview = makeCropPreview(HEADER_TARGET);
+// Top-level refs so the template auto-unwraps them.
+const thumbUrl = thumbPreview.url;
+const headerUrl = headerPreview.url;
 
 function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
   const binary = atob(base64);
@@ -76,29 +124,10 @@ function setPreviewUrl(url: string | null): void {
   if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
   previewUrl.value = url;
 }
-function setCroppedThumbUrl(url: string | null): void {
-  if (croppedThumbUrl.value) URL.revokeObjectURL(croppedThumbUrl.value);
-  croppedThumbUrl.value = url;
-}
 
-// Dragging the offset fires this rapidly; a token guards against an earlier crop resolving after a
-// later one and leaving the marker on a stale thumb.
-let thumbToken = 0;
-async function regenerateThumb(): Promise<void> {
-  const img = sourceImage.value;
-  const w = draft.value.image_width;
-  const h = draft.value.image_height;
-  if (!img || !w || !h) {
-    setCroppedThumbUrl(null);
-    return;
-  }
-  const token = ++thumbToken;
-  const url = await cropToThumbBlobUrl(img, w, h, draft.value.image_thumb_offset);
-  if (token !== thumbToken) {
-    if (url) URL.revokeObjectURL(url);
-    return;
-  }
-  setCroppedThumbUrl(url);
+function regenerateCrops(): void {
+  void thumbPreview.regenerate(draft.value.image_thumb_offset);
+  void headerPreview.regenerate(draft.value.image_header_offset);
 }
 
 async function processFile(file: File): Promise<void> {
@@ -138,11 +167,12 @@ async function processFile(file: File): Promise<void> {
   draft.value.image = { base64, fileName: file.name || "event-image" };
   draft.value.image_width = image.naturalWidth;
   draft.value.image_height = image.naturalHeight;
-  // A new image recentres the crop; its offset bounds depend on the new dimensions.
+  // A new image recentres both crops; their offset bounds depend on the new dimensions.
   draft.value.image_thumb_offset = 0;
+  draft.value.image_header_offset = 0;
   // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs).
   draft.value.id = `event_${await sha256Hex(bytesFromBase64(base64))}`;
-  await regenerateThumb();
+  regenerateCrops();
 }
 
 function onFileChange(event: Event): void {
@@ -156,26 +186,35 @@ function onDrop(event: DragEvent): void {
 }
 function removeImage(): void {
   setPreviewUrl(null);
-  setCroppedThumbUrl(null);
+  thumbPreview.set(null);
+  headerPreview.set(null);
   sourceImage.value = null;
   draft.value.image = null;
   draft.value.image_width = null;
   draft.value.image_height = null;
   draft.value.image_thumb_offset = 0;
+  draft.value.image_header_offset = 0;
   draft.value.id = "";
   fileError.value = "";
   if (fileInput.value) fileInput.value.value = "";
 }
 
-// Re-crop as the user drags the offset, so the marker preview tracks the selection.
-watch(() => draft.value.image_thumb_offset, regenerateThumb);
+watch(
+  () => draft.value.image_thumb_offset,
+  (o) => thumbPreview.regenerate(o)
+);
+watch(
+  () => draft.value.image_header_offset,
+  (o) => headerPreview.regenerate(o)
+);
 
 onBeforeUnmount(() => {
   setPreviewUrl(null);
-  setCroppedThumbUrl(null);
+  thumbPreview.set(null);
+  headerPreview.set(null);
 });
 
-const showPreview = computed(() => Boolean(croppedThumbUrl.value) && draft.value.coords.picked);
+const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.value.coords.picked);
 </script>
 
 <template>
@@ -290,6 +329,22 @@ const showPreview = computed(() => Boolean(croppedThumbUrl.value) && draft.value
     </div>
 
     <div>
+      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
+        {{ t("coords") }} <span class="text-red-700 dark:text-red-200">*</span>
+      </label>
+      <LocationPickerInline
+        v-model:lat="mapLat"
+        v-model:lon="mapLon"
+        :initial-lat="mapLat"
+        :initial-lon="mapLon"
+        container-class="h-44"
+      />
+      <p v-if="draft.coords.picked" class="text-zinc-600 dark:text-zinc-300 mt-1 text-xs">
+        {{ draft.coords.lat.toFixed(5) }}, {{ draft.coords.lon.toFixed(5) }}
+      </p>
+    </div>
+
+    <div>
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("image") }} <span class="text-red-700 dark:text-red-200">*</span></span>
       <div
         class="cursor-pointer rounded-lg border-2 border-dashed p-4 text-center text-sm transition-colors"
@@ -324,59 +379,58 @@ const showPreview = computed(() => Boolean(croppedThumbUrl.value) && draft.value
       <p v-else-if="errorFor('image')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("image") }}</p>
     </div>
 
-    <div v-if="previewUrl && draft.image_width && draft.image_height">
-      <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("crop") }}</span>
-      <EventImageCropper
-        v-model="draft.image_thumb_offset"
-        :image-url="previewUrl"
-        :width="draft.image_width"
-        :height="draft.image_height"
+    <template v-if="previewUrl && draft.image_width && draft.image_height">
+      <div>
+        <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("crop_thumb") }}</span>
+        <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("crop_thumb_help") }}</p>
+        <EventImageCropper
+          v-model="draft.image_thumb_offset"
+          :image-url="previewUrl"
+          :width="draft.image_width"
+          :height="draft.image_height"
+          :target="THUMB_TARGET"
+        />
+      </div>
+
+      <div>
+        <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("crop_header") }}</span>
+        <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("crop_header_help") }}</p>
+        <EventImageCropper
+          v-model="draft.image_header_offset"
+          :image-url="previewUrl"
+          :width="draft.image_width"
+          :height="draft.image_height"
+          :target="HEADER_TARGET"
+        />
+        <img v-if="headerUrl" :src="headerUrl" alt="" class="border-zinc-300 dark:border-zinc-600 mt-2 w-full rounded border" />
+      </div>
+    </template>
+
+    <div>
+      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-author">
+        {{ t("image_author") }} <span class="text-red-700 dark:text-red-200">*</span>
+      </label>
+      <input
+        id="add-event-image-author"
+        v-model="draft.image_author"
+        type="text"
+        :placeholder="t('image_author_placeholder')"
+        class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
       />
     </div>
 
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+    <div class="bg-blue-50 dark:bg-blue-900 border-blue-200 dark:border-blue-700 flex items-start gap-2 rounded-lg border p-3">
+      <MdiIcon :path="mdiInformation" :size="18" class="text-blue-500 dark:text-blue-400 mt-0.5 flex-shrink-0" />
       <div>
-        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-author">
-          {{ t("image_author") }} <span class="text-red-700 dark:text-red-200">*</span>
-        </label>
-        <input
-          id="add-event-image-author"
-          v-model="draft.image_author"
-          type="text"
-          :placeholder="t('image_author_placeholder')"
-          class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
-        />
+        <p class="text-blue-800 dark:text-blue-100 text-sm font-medium">{{ t("license_info_title") }}</p>
+        <p class="text-blue-700 dark:text-blue-200 mt-0.5 text-xs">{{ t("license_info_description") }}</p>
       </div>
-      <div>
-        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-license">
-          {{ t("image_license") }} <span class="text-red-700 dark:text-red-200">*</span>
-        </label>
-        <input
-          id="add-event-image-license"
-          v-model="draft.image_license_text"
-          type="text"
-          :placeholder="t('image_license_placeholder')"
-          class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
-        />
-      </div>
-    </div>
-    <div>
-      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-license-url">
-        {{ t("image_license_url") }}
-      </label>
-      <input
-        id="add-event-image-license-url"
-        v-model="draft.image_license_url"
-        type="url"
-        placeholder="https://"
-        class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
-      />
     </div>
 
     <div v-if="showPreview">
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("preview") }}</span>
       <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("preview_help") }}</p>
-      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="croppedThumbUrl" />
+      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="thumbUrl" />
     </div>
   </div>
 </template>
@@ -395,6 +449,7 @@ de:
   organising_org_placeholder: Organisation suchen…
   organising_org_no_results: Keine passende Organisation gefunden
   organising_org_truncated: "Nur die ersten {0} Treffer werden angezeigt - bitte weiter eingrenzen."
+  coords: Ort
   image: Bild
   image_drop: Bild hierher ziehen oder klicken
   image_hint: JPG, PNG, GIF oder WebP, mind. 256px, max. 10MB
@@ -404,10 +459,12 @@ de:
   image_read_error: Das Bild konnte nicht gelesen werden.
   image_author: Urheber:in des Bildes
   image_author_placeholder: z.B. Studentische Vertretung TUM
-  image_license: Lizenz
-  image_license_placeholder: z.B. CC BY 4.0
-  image_license_url: Lizenz-URL (optional)
-  crop: Kartenausschnitt
+  license_info_title: CC BY 4.0 - Frei zu verwenden mit Namensnennung
+  license_info_description: Alle hochgeladenen Bilder werden unter der CC BY 4.0 Lizenz veröffentlicht. Das bedeutet, jeder kann das Bild verwenden, solange du als Urheber:in genannt wirst.
+  crop_thumb: Marker-Ausschnitt
+  crop_thumb_help: Quadratischer Ausschnitt für den Foto-Marker auf der Karte.
+  crop_header: Header-Ausschnitt
+  crop_header_help: Breiter Ausschnitt (512×210) für die Kopfzeile.
   preview: Vorschau auf der Karte
   preview_help: So erscheint die Veranstaltung als Foto-Marker.
   error:
@@ -424,7 +481,6 @@ de:
     image_required: Bitte lade ein Bild hoch.
     image_too_small: Das Bild muss mindestens 256px auf der kürzeren Seite haben.
     image_author_required: Bitte gib die Urheber:in des Bildes an.
-    image_license_required: Bitte gib die Lizenz des Bildes an.
 en:
   name: Name
   name_placeholder: e.g. GARNIX Festival
@@ -438,6 +494,7 @@ en:
   organising_org_placeholder: Search for an organisation…
   organising_org_no_results: No matching organisation found
   organising_org_truncated: "Showing the first {0} matches only - keep typing to narrow it down."
+  coords: Location
   image: Image
   image_drop: Drop an image here or click to browse
   image_hint: JPG, PNG, GIF or WebP, at least 256px, max 10MB
@@ -447,10 +504,12 @@ en:
   image_read_error: The image could not be read.
   image_author: Image author
   image_author_placeholder: e.g. Studentische Vertretung TUM
-  image_license: License
-  image_license_placeholder: e.g. CC BY 4.0
-  image_license_url: License URL (optional)
-  crop: Map crop
+  license_info_title: CC BY 4.0 - Free to use with attribution
+  license_info_description: All uploaded images are published under the CC BY 4.0 license. This means anyone can use the image as long as they credit you as the author.
+  crop_thumb: Marker crop
+  crop_thumb_help: Square crop used for the photo marker on the map.
+  crop_header: Header crop
+  crop_header_help: Wide crop (512×210) used for the page header.
   preview: Map preview
   preview_help: This is how the event will appear as a photo marker.
   error:
@@ -467,5 +526,4 @@ en:
     image_required: Please upload an image.
     image_too_small: The image must be at least 256px on its shorter edge.
     image_author_required: Please enter the image author.
-    image_license_required: Please enter the image license.
 </i18n>

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -1,0 +1,418 @@
+<script setup lang="ts">
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+} from "@headlessui/vue";
+import { mdiCheck, mdiClose, mdiImage, mdiUnfoldMoreHorizontal } from "@mdi/js";
+import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
+import { useEditProposal } from "~/composables/editProposal";
+import { type OrgOption, useKnownOrgs } from "~/composables/useKnownOrgs";
+
+const editProposal = useEditProposal();
+const { t } = useI18n({ useScope: "local" });
+
+const draft = computed(() => editProposal.value.pendingAddition);
+const fieldErrors = computed<AdditionFieldErrors>(() => validateAddition(draft.value));
+// Only surface a field's error once the user has touched the form enough for it to be actionable;
+// the disabled submit button already blocks an empty form, so eager red text would just be noise.
+function errorFor(path: string): string | null {
+  const key = fieldErrors.value[path];
+  return key ? t(key) : null;
+}
+
+// --- Organising org combobox (client-filtered, like the room usage picker) ---
+const knownOrgs = useKnownOrgs();
+const orgQuery = ref("");
+const filteredOrgs = computed<OrgOption[]>(() => knownOrgs.filter(orgQuery.value));
+const orgTruncated = computed(() => filteredOrgs.value.length >= knownOrgs.maxResults);
+const selectedOrg = computed<OrgOption | null>({
+  get: () => knownOrgs.byId(draft.value.organising_org_id),
+  set: (o) => {
+    draft.value.organising_org_id = o?.org_id ?? null;
+  },
+});
+
+// --- Image upload ---
+const VALID_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const fileInput = ref<HTMLInputElement>();
+const isDragOver = ref(false);
+const fileError = ref("");
+// `blob:` URL for the not-yet-uploaded image, used by the live preview marker. Kept local (not in
+// the persisted draft) and revoked on replace/unmount so it never outlives the session.
+const previewUrl = ref<string | null>(null);
+
+function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function measureDimensions(url: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const probe = new Image();
+    probe.onload = () => resolve({ width: probe.naturalWidth, height: probe.naturalHeight });
+    probe.onerror = () => reject(new Error("decode failed"));
+    probe.src = url;
+  });
+}
+
+function setPreviewUrl(url: string | null): void {
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
+  previewUrl.value = url;
+}
+
+async function processFile(file: File): Promise<void> {
+  fileError.value = "";
+  if (!VALID_IMAGE_TYPES.includes(file.type)) {
+    fileError.value = t("image_invalid_type");
+    return;
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    fileError.value = t("image_too_large");
+    return;
+  }
+
+  const base64 = await new Promise<string | null>((resolve) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(((e.target?.result as string) ?? "").split(",")[1] ?? null);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
+  if (!base64) {
+    fileError.value = t("image_read_error");
+    return;
+  }
+
+  const url = URL.createObjectURL(file);
+  let dimensions: { width: number; height: number };
+  try {
+    dimensions = await measureDimensions(url);
+  } catch {
+    URL.revokeObjectURL(url);
+    fileError.value = t("image_read_error");
+    return;
+  }
+
+  setPreviewUrl(url);
+  draft.value.image = { base64, fileName: file.name || "event-image" };
+  draft.value.image_width = dimensions.width;
+  draft.value.image_height = dimensions.height;
+  // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs).
+  draft.value.id = `event_${await sha256Hex(bytesFromBase64(base64))}`;
+}
+
+function onFileChange(event: Event): void {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) void processFile(file);
+}
+function onDrop(event: DragEvent): void {
+  isDragOver.value = false;
+  const file = event.dataTransfer?.files?.[0];
+  if (file) void processFile(file);
+}
+function removeImage(): void {
+  setPreviewUrl(null);
+  draft.value.image = null;
+  draft.value.image_width = null;
+  draft.value.image_height = null;
+  draft.value.id = "";
+  fileError.value = "";
+  if (fileInput.value) fileInput.value.value = "";
+}
+
+onBeforeUnmount(() => setPreviewUrl(null));
+
+const showPreview = computed(() => Boolean(previewUrl.value) && draft.value.coords.picked);
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-name">
+        {{ t("name") }} <span class="text-red-700 dark:text-red-200">*</span>
+      </label>
+      <input
+        id="add-event-name"
+        v-model="draft.name"
+        type="text"
+        :placeholder="t('name_placeholder')"
+        class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+      />
+    </div>
+
+    <div>
+      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-description">
+        {{ t("description") }} <span class="text-red-700 dark:text-red-200">*</span>
+      </label>
+      <textarea
+        id="add-event-description"
+        v-model="draft.description"
+        rows="3"
+        :placeholder="t('description_placeholder')"
+        class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full resize-y rounded border px-2 py-1 text-sm"
+      />
+      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("description_help") }}</p>
+    </div>
+
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div>
+        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-start">
+          {{ t("starts_at") }} <span class="text-red-700 dark:text-red-200">*</span>
+        </label>
+        <input
+          id="add-event-start"
+          v-model="draft.starts_at"
+          type="datetime-local"
+          class="focusable bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+          :class="errorFor('starts_at') ? 'border-red-500 dark:border-red-400' : 'border-zinc-400 dark:border-zinc-500'"
+        />
+        <p v-if="errorFor('starts_at')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("starts_at") }}</p>
+      </div>
+      <div>
+        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-end">
+          {{ t("ends_at") }} <span class="text-red-700 dark:text-red-200">*</span>
+        </label>
+        <input
+          id="add-event-end"
+          v-model="draft.ends_at"
+          type="datetime-local"
+          class="focusable bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+          :class="errorFor('ends_at') ? 'border-red-500 dark:border-red-400' : 'border-zinc-400 dark:border-zinc-500'"
+        />
+        <p v-if="errorFor('ends_at')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("ends_at") }}</p>
+      </div>
+    </div>
+    <p class="text-zinc-500 dark:text-zinc-400 -mt-1 text-xs">{{ t("timezone_help") }}</p>
+
+    <div>
+      <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("organising_org") }} <span class="text-red-700 dark:text-red-200">*</span></span>
+      <Combobox v-model="selectedOrg" :nullable="true" by="org_id">
+        <div class="relative">
+          <div
+            class="bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 focus-within:border-blue-500 dark:focus-within:border-blue-400 relative flex w-full items-center rounded-md border text-left text-sm"
+          >
+            <ComboboxInput
+              class="text-zinc-900 dark:text-zinc-50 w-full rounded-md border-none bg-transparent py-2 pl-3 pr-10 text-sm focus:outline-none"
+              :display-value="(o: unknown) => (o as OrgOption | null)?.label ?? ''"
+              :placeholder="t('organising_org_placeholder')"
+              @change="orgQuery = ($event.target as HTMLInputElement).value"
+            />
+            <ComboboxButton class="absolute inset-y-0 right-0 flex items-center pr-2">
+              <MdiIcon :path="mdiUnfoldMoreHorizontal" :size="20" class="text-zinc-600 dark:text-zinc-300" aria-hidden="true" />
+            </ComboboxButton>
+          </div>
+          <Transition leave-active-class="transition duration-100 ease-in" leave-from-class="opacity-100" leave-to-class="opacity-0">
+            <ComboboxOptions
+              class="ring-black/5 dark:ring-white/5 bg-zinc-50 dark:bg-zinc-900 absolute z-30 mt-1 max-h-72 w-full overflow-auto rounded-md py-1 shadow-lg ring-1 focus:outline-none"
+            >
+              <p v-if="filteredOrgs.length === 0" class="text-zinc-500 dark:text-zinc-400 px-3 py-2 text-sm">
+                {{ t("organising_org_no_results") }}
+              </p>
+              <ComboboxOption
+                v-for="o in filteredOrgs"
+                :key="o.org_id"
+                v-slot="{ active, selected }"
+                :value="o"
+                as="template"
+              >
+                <li
+                  class="relative cursor-pointer select-none py-2 pl-3 pr-8"
+                  :class="active ? 'bg-blue-100 dark:bg-blue-800 text-blue-900 dark:text-blue-50' : 'text-zinc-900 dark:text-zinc-50'"
+                >
+                  <div class="flex items-baseline gap-3">
+                    <OrgOptionContent :org="o" :emphasised="selected" />
+                  </div>
+                  <span v-if="selected" class="text-blue-600 dark:text-blue-300 absolute inset-y-0 right-0 flex items-center pr-2">
+                    <MdiIcon :path="mdiCheck" :size="16" aria-hidden="true" />
+                  </span>
+                </li>
+              </ComboboxOption>
+              <p v-if="orgTruncated" class="text-zinc-400 dark:text-zinc-500 border-zinc-200 dark:border-zinc-700 mt-1 border-t px-3 py-2 text-xs">
+                {{ t("organising_org_truncated", [knownOrgs.maxResults]) }}
+              </p>
+            </ComboboxOptions>
+          </Transition>
+        </div>
+      </Combobox>
+    </div>
+
+    <div>
+      <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("image") }} <span class="text-red-700 dark:text-red-200">*</span></span>
+      <div
+        class="cursor-pointer rounded-lg border-2 border-dashed p-4 text-center text-sm transition-colors"
+        :class="[
+          isDragOver
+            ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900'
+            : 'border-zinc-300 dark:border-zinc-600 hover:border-blue-400 dark:hover:border-blue-500',
+          errorFor('image') ? 'border-red-500 dark:border-red-400' : '',
+        ]"
+        @click="fileInput?.click()"
+        @dragover.prevent="isDragOver = true"
+        @dragleave.prevent="isDragOver = false"
+        @drop.prevent="onDrop"
+      >
+        <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileChange" />
+        <template v-if="draft.image">
+          <p class="text-blue-700 dark:text-blue-200 font-medium">{{ draft.image.fileName }}</p>
+          <p v-if="draft.image_width && draft.image_height" class="text-zinc-500 dark:text-zinc-400 text-xs">
+            {{ draft.image_width }}×{{ draft.image_height }}px
+          </p>
+          <button type="button" class="text-blue-600 dark:text-blue-300 hover:underline mt-1 inline-flex items-center gap-1 text-xs" @click.stop="removeImage">
+            <MdiIcon :path="mdiClose" :size="12" /> {{ t("image_remove") }}
+          </button>
+        </template>
+        <template v-else>
+          <MdiIcon :path="mdiImage" :size="32" class="text-zinc-400 dark:text-zinc-500 mx-auto" />
+          <p class="text-zinc-600 dark:text-zinc-300 mt-1">{{ t("image_drop") }}</p>
+          <p class="text-zinc-500 dark:text-zinc-400 text-xs">{{ t("image_hint") }}</p>
+        </template>
+      </div>
+      <p v-if="fileError" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ fileError }}</p>
+      <p v-else-if="errorFor('image')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("image") }}</p>
+    </div>
+
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div>
+        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-author">
+          {{ t("image_author") }} <span class="text-red-700 dark:text-red-200">*</span>
+        </label>
+        <input
+          id="add-event-image-author"
+          v-model="draft.image_author"
+          type="text"
+          :placeholder="t('image_author_placeholder')"
+          class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+        />
+      </div>
+      <div>
+        <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-license">
+          {{ t("image_license") }} <span class="text-red-700 dark:text-red-200">*</span>
+        </label>
+        <input
+          id="add-event-image-license"
+          v-model="draft.image_license_text"
+          type="text"
+          :placeholder="t('image_license_placeholder')"
+          class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+        />
+      </div>
+    </div>
+    <div>
+      <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-license-url">
+        {{ t("image_license_url") }}
+      </label>
+      <input
+        id="add-event-image-license-url"
+        v-model="draft.image_license_url"
+        type="url"
+        placeholder="https://"
+        class="focusable bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 text-zinc-900 dark:text-zinc-50 w-full rounded border px-2 py-1 text-sm"
+      />
+    </div>
+
+    <div v-if="showPreview">
+      <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("preview") }}</span>
+      <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("preview_help") }}</p>
+      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="previewUrl" />
+    </div>
+  </div>
+</template>
+
+<i18n lang="yaml">
+de:
+  name: Name
+  name_placeholder: z.B. GARNIX Festival
+  description: Beschreibung
+  description_placeholder: Was passiert bei dieser Veranstaltung?
+  description_help: Wird unverändert angezeigt - bitte in der Sprache der Veranstaltung.
+  starts_at: Beginn
+  ends_at: Ende
+  timezone_help: Zeiten in der Zeitzone Europe/Berlin.
+  organising_org: Veranstaltende Organisation
+  organising_org_placeholder: Organisation suchen…
+  organising_org_no_results: Keine passende Organisation gefunden
+  organising_org_truncated: "Nur die ersten {0} Treffer werden angezeigt - bitte weiter eingrenzen."
+  image: Bild
+  image_drop: Bild hierher ziehen oder klicken
+  image_hint: JPG, PNG, GIF oder WebP, mind. 256px, max. 10MB
+  image_remove: Entfernen
+  image_invalid_type: Nicht unterstütztes Dateiformat.
+  image_too_large: Die Datei ist größer als 10MB.
+  image_read_error: Das Bild konnte nicht gelesen werden.
+  image_author: Urheber:in des Bildes
+  image_author_placeholder: z.B. Studentische Vertretung TUM
+  image_license: Lizenz
+  image_license_placeholder: z.B. CC BY 4.0
+  image_license_url: Lizenz-URL (optional)
+  preview: Vorschau auf der Karte
+  preview_help: So erscheint die Veranstaltung als Foto-Marker.
+  error:
+    name_required: Bitte gib einen Namen an.
+    name_too_long: Der Name ist zu lang (max. 200 Zeichen).
+    description_required: Bitte gib eine Beschreibung an.
+    starts_at_required: Bitte gib einen gültigen Beginn an.
+    ends_at_required: Bitte gib ein gültiges Ende an.
+    event_ends_before_start: Das Ende muss nach dem Beginn liegen.
+    event_ended: Die Veranstaltung liegt bereits in der Vergangenheit.
+    event_too_far_out: Der Beginn liegt mehr als ein Jahr in der Zukunft.
+    event_too_long: Die Veranstaltung darf höchstens 30 Tage dauern.
+    org_required: Bitte wähle eine Organisation aus.
+    image_required: Bitte lade ein Bild hoch.
+    image_too_small: Das Bild muss mindestens 256px auf der kürzeren Seite haben.
+    image_author_required: Bitte gib die Urheber:in des Bildes an.
+    image_license_required: Bitte gib die Lizenz des Bildes an.
+en:
+  name: Name
+  name_placeholder: e.g. GARNIX Festival
+  description: Description
+  description_placeholder: What happens at this event?
+  description_help: Shown verbatim - please use the event's own language.
+  starts_at: Starts
+  ends_at: Ends
+  timezone_help: Times are in the Europe/Berlin timezone.
+  organising_org: Organising organisation
+  organising_org_placeholder: Search for an organisation…
+  organising_org_no_results: No matching organisation found
+  organising_org_truncated: "Showing the first {0} matches only - keep typing to narrow it down."
+  image: Image
+  image_drop: Drop an image here or click to browse
+  image_hint: JPG, PNG, GIF or WebP, at least 256px, max 10MB
+  image_remove: Remove
+  image_invalid_type: Unsupported file format.
+  image_too_large: The file is larger than 10MB.
+  image_read_error: The image could not be read.
+  image_author: Image author
+  image_author_placeholder: e.g. Studentische Vertretung TUM
+  image_license: License
+  image_license_placeholder: e.g. CC BY 4.0
+  image_license_url: License URL (optional)
+  preview: Map preview
+  preview_help: This is how the event will appear as a photo marker.
+  error:
+    name_required: Please enter a name.
+    name_too_long: The name is too long (max 200 characters).
+    description_required: Please enter a description.
+    starts_at_required: Please enter a valid start time.
+    ends_at_required: Please enter a valid end time.
+    event_ends_before_start: The end must be after the start.
+    event_ended: The event is already in the past.
+    event_too_far_out: The start is more than a year in the future.
+    event_too_long: The event may last at most 30 days.
+    org_required: Please choose an organisation.
+    image_required: Please upload an image.
+    image_too_small: The image must be at least 256px on its shorter edge.
+    image_author_required: Please enter the image author.
+    image_license_required: Please enter the image license.
+</i18n>

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -10,6 +10,7 @@ import { mdiCheck, mdiClose, mdiImage, mdiUnfoldMoreHorizontal } from "@mdi/js";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { useEditProposal } from "~/composables/editProposal";
 import { type OrgOption, useKnownOrgs } from "~/composables/useKnownOrgs";
+import { cropToThumbBlobUrl } from "~/utils/imageCrop";
 
 const editProposal = useEditProposal();
 const { t } = useI18n({ useScope: "local" });
@@ -41,9 +42,12 @@ const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const fileInput = ref<HTMLInputElement>();
 const isDragOver = ref(false);
 const fileError = ref("");
-// `blob:` URL for the not-yet-uploaded image, used by the live preview marker. Kept local (not in
-// the persisted draft) and revoked on replace/unmount so it never outlives the session.
+// `blob:` URLs kept local (not in the persisted draft) and revoked on replace/unmount so they never
+// outlive the session: `previewUrl` is the full image (the cropper's source); `croppedThumbUrl` is
+// the offset 256² crop fed to the live marker so it matches what the pipeline will render.
 const previewUrl = ref<string | null>(null);
+const croppedThumbUrl = ref<string | null>(null);
+const sourceImage = shallowRef<HTMLImageElement | null>(null);
 
 function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
   const binary = atob(base64);
@@ -59,10 +63,10 @@ async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
     .join("");
 }
 
-function measureDimensions(url: string): Promise<{ width: number; height: number }> {
+function loadImage(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const probe = new Image();
-    probe.onload = () => resolve({ width: probe.naturalWidth, height: probe.naturalHeight });
+    probe.onload = () => resolve(probe);
     probe.onerror = () => reject(new Error("decode failed"));
     probe.src = url;
   });
@@ -71,6 +75,30 @@ function measureDimensions(url: string): Promise<{ width: number; height: number
 function setPreviewUrl(url: string | null): void {
   if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
   previewUrl.value = url;
+}
+function setCroppedThumbUrl(url: string | null): void {
+  if (croppedThumbUrl.value) URL.revokeObjectURL(croppedThumbUrl.value);
+  croppedThumbUrl.value = url;
+}
+
+// Dragging the offset fires this rapidly; a token guards against an earlier crop resolving after a
+// later one and leaving the marker on a stale thumb.
+let thumbToken = 0;
+async function regenerateThumb(): Promise<void> {
+  const img = sourceImage.value;
+  const w = draft.value.image_width;
+  const h = draft.value.image_height;
+  if (!img || !w || !h) {
+    setCroppedThumbUrl(null);
+    return;
+  }
+  const token = ++thumbToken;
+  const url = await cropToThumbBlobUrl(img, w, h, draft.value.image_thumb_offset);
+  if (token !== thumbToken) {
+    if (url) URL.revokeObjectURL(url);
+    return;
+  }
+  setCroppedThumbUrl(url);
 }
 
 async function processFile(file: File): Promise<void> {
@@ -96,9 +124,9 @@ async function processFile(file: File): Promise<void> {
   }
 
   const url = URL.createObjectURL(file);
-  let dimensions: { width: number; height: number };
+  let image: HTMLImageElement;
   try {
-    dimensions = await measureDimensions(url);
+    image = await loadImage(url);
   } catch {
     URL.revokeObjectURL(url);
     fileError.value = t("image_read_error");
@@ -106,11 +134,15 @@ async function processFile(file: File): Promise<void> {
   }
 
   setPreviewUrl(url);
+  sourceImage.value = image;
   draft.value.image = { base64, fileName: file.name || "event-image" };
-  draft.value.image_width = dimensions.width;
-  draft.value.image_height = dimensions.height;
+  draft.value.image_width = image.naturalWidth;
+  draft.value.image_height = image.naturalHeight;
+  // A new image recentres the crop; its offset bounds depend on the new dimensions.
+  draft.value.image_thumb_offset = 0;
   // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs).
   draft.value.id = `event_${await sha256Hex(bytesFromBase64(base64))}`;
+  await regenerateThumb();
 }
 
 function onFileChange(event: Event): void {
@@ -124,17 +156,26 @@ function onDrop(event: DragEvent): void {
 }
 function removeImage(): void {
   setPreviewUrl(null);
+  setCroppedThumbUrl(null);
+  sourceImage.value = null;
   draft.value.image = null;
   draft.value.image_width = null;
   draft.value.image_height = null;
+  draft.value.image_thumb_offset = 0;
   draft.value.id = "";
   fileError.value = "";
   if (fileInput.value) fileInput.value.value = "";
 }
 
-onBeforeUnmount(() => setPreviewUrl(null));
+// Re-crop as the user drags the offset, so the marker preview tracks the selection.
+watch(() => draft.value.image_thumb_offset, regenerateThumb);
 
-const showPreview = computed(() => Boolean(previewUrl.value) && draft.value.coords.picked);
+onBeforeUnmount(() => {
+  setPreviewUrl(null);
+  setCroppedThumbUrl(null);
+});
+
+const showPreview = computed(() => Boolean(croppedThumbUrl.value) && draft.value.coords.picked);
 </script>
 
 <template>
@@ -283,6 +324,16 @@ const showPreview = computed(() => Boolean(previewUrl.value) && draft.value.coor
       <p v-else-if="errorFor('image')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("image") }}</p>
     </div>
 
+    <div v-if="previewUrl && draft.image_width && draft.image_height">
+      <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("crop") }}</span>
+      <EventImageCropper
+        v-model="draft.image_thumb_offset"
+        :image-url="previewUrl"
+        :width="draft.image_width"
+        :height="draft.image_height"
+      />
+    </div>
+
     <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
       <div>
         <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-author">
@@ -325,7 +376,7 @@ const showPreview = computed(() => Boolean(previewUrl.value) && draft.value.coor
     <div v-if="showPreview">
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("preview") }}</span>
       <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("preview_help") }}</p>
-      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="previewUrl" />
+      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="croppedThumbUrl" />
     </div>
   </div>
 </template>
@@ -356,6 +407,7 @@ de:
   image_license: Lizenz
   image_license_placeholder: z.B. CC BY 4.0
   image_license_url: Lizenz-URL (optional)
+  crop: Kartenausschnitt
   preview: Vorschau auf der Karte
   preview_help: So erscheint die Veranstaltung als Foto-Marker.
   error:
@@ -398,6 +450,7 @@ en:
   image_license: License
   image_license_placeholder: e.g. CC BY 4.0
   image_license_url: License URL (optional)
+  crop: Map crop
   preview: Map preview
   preview_help: This is how the event will appear as a photo marker.
   error:

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -10,6 +10,8 @@ import { mdiCheck, mdiClose, mdiImage, mdiInformation, mdiUnfoldMoreHorizontal }
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { useEditProposal } from "~/composables/editProposal";
 import { type OrgOption, useKnownOrgs } from "~/composables/useKnownOrgs";
+import type { EventPreviewPopup } from "~/components/EventPreviewMap.vue";
+import { wallTimeToRfc3339 } from "~/utils/datetime";
 import { type CropTarget, cropToBlobUrl, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
 
 const editProposal = useEditProposal();
@@ -212,6 +214,27 @@ onBeforeUnmount(() => {
 });
 
 const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.value.coords.picked);
+
+// The full event popup card, shown in the preview once every field it renders is filled. The popup
+// formats RFC3339 instants, so convert the wall-clock inputs here; a null conversion (or any missing
+// field) collapses to marker-only. The image is the not-yet-uploaded source blob, cover-fit by the
+// card exactly as the CDN image will be.
+const previewEvent = computed<EventPreviewPopup | null>(() => {
+  const org = selectedOrg.value;
+  const startsAt = wallTimeToRfc3339(draft.value.starts_at);
+  const endsAt = wallTimeToRfc3339(draft.value.ends_at);
+  if (!org || !startsAt || !endsAt || !draft.value.name || !previewUrl.value) return null;
+  return {
+    name: draft.value.name,
+    description: draft.value.description,
+    startsAt,
+    endsAt,
+    orgCode: org.code,
+    orgNameDe: org.nameDe,
+    orgNameEn: org.nameEn,
+    imageSrc: previewUrl.value,
+  };
+});
 </script>
 
 <template>
@@ -442,7 +465,12 @@ const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.valu
     <div v-if="showPreview">
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("preview") }}</span>
       <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("preview_help") }}</p>
-      <EventPreviewMap :lat="draft.coords.lat" :lon="draft.coords.lon" :image-url="thumbUrl" />
+      <EventPreviewMap
+        :lat="draft.coords.lat"
+        :lon="draft.coords.lon"
+        :image-url="thumbUrl"
+        :popup="previewEvent"
+      />
     </div>
   </div>
 </template>
@@ -481,7 +509,7 @@ de:
   crop_header: Header-Ausschnitt
   crop_header_help: Breiter Ausschnitt (512×210) für die Kopfzeile.
   preview: Vorschau auf der Karte
-  preview_help: So erscheint die Veranstaltung als Foto-Marker.
+  preview_help: So erscheint die Veranstaltung auf der Karte – als Foto-Marker mit Popup.
   error:
     name_required: Bitte gib einen Namen an.
     name_too_long: Der Name ist zu lang (max. 200 Zeichen).
@@ -529,7 +557,7 @@ en:
   crop_header: Header crop
   crop_header_help: Wide crop (512×210) used for the page header.
   preview: Map preview
-  preview_help: This is how the event will appear as a photo marker.
+  preview_help: This is how the event will appear on the map - as a photo marker with its popup.
   error:
     name_required: Please enter a name.
     name_too_long: The name is too long (max 200 characters).

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -7,12 +7,13 @@ import {
   ComboboxOptions,
 } from "@headlessui/vue";
 import { mdiCheck, mdiClose, mdiImage, mdiInformation, mdiUnfoldMoreHorizontal } from "@mdi/js";
+import { useDropZone, useFileDialog, useObjectUrl } from "@vueuse/core";
+import type { EventPreviewPopup } from "~/components/EventPreviewMap.vue";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { useEditProposal } from "~/composables/editProposal";
 import { type OrgOption, useKnownOrgs } from "~/composables/useKnownOrgs";
-import type { EventPreviewPopup } from "~/components/EventPreviewMap.vue";
 import { wallTimeToRfc3339 } from "~/utils/datetime";
-import { type CropTarget, cropToBlobUrl, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
+import { cropToBlob, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
 
 const editProposal = useEditProposal();
 const { t } = useI18n({ useScope: "local" });
@@ -55,70 +56,47 @@ const mapLon = computed({
 
 const VALID_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
-const fileInput = ref<HTMLInputElement>();
-const isDragOver = ref(false);
 const fileError = ref("");
-const previewUrl = ref<string | null>(null);
-const sourceImage = shallowRef<HTMLImageElement | null>(null);
 
-function makeCropPreview(target: CropTarget) {
-  const url = ref<string | null>(null);
-  let token = 0;
-  function set(next: string | null): void {
-    if (url.value) URL.revokeObjectURL(url.value);
-    url.value = next;
+// `useObjectUrl` owns the URL lifetime: it issues one when the source File/Blob changes and revokes
+// the old one on the next change or on unmount, so the manual createObjectURL/revoke bookkeeping
+// drops away. The bitmap is decoded once via `createImageBitmap` so canvas crops don't have to wait
+// on a hidden <img> probe to fire `onload`.
+const sourceFile = shallowRef<File | null>(null);
+const sourceBitmap = shallowRef<ImageBitmap | null>(null);
+const previewUrl = useObjectUrl(sourceFile);
+
+// Thumb blob feeds the map-marker preview; useObjectUrl keeps its URL synced to the blob's lifetime.
+// The header crop is offset-only - its preview lives inside EventImageCropper, so no blob here.
+const thumbBlob = shallowRef<Blob | null>(null);
+const thumbUrl = useObjectUrl(thumbBlob);
+
+// `onCleanup` cancels the previous run so a slow encode never overwrites a newer offset - this is
+// what the old `makeCropPreview` race-token bookkeeping was emulating.
+watchEffect(async (onCleanup) => {
+  const img = sourceBitmap.value;
+  const w = draft.value.image_width;
+  const h = draft.value.image_height;
+  const offset = draft.value.image_thumb_offset;
+  if (!img || !w || !h) {
+    thumbBlob.value = null;
+    return;
   }
-  async function regenerate(offset: number): Promise<void> {
-    const img = sourceImage.value;
-    const w = draft.value.image_width;
-    const h = draft.value.image_height;
-    if (!img || !w || !h) {
-      set(null);
-      return;
-    }
-    const ticket = ++token;
-    const next = await cropToBlobUrl(img, w, h, target, offset);
-    if (ticket !== token) {
-      if (next) URL.revokeObjectURL(next);
-      return;
-    }
-    set(next);
-  }
-  return { url, set, regenerate };
-}
-const thumbPreview = makeCropPreview(THUMB_TARGET);
-const thumbUrl = thumbPreview.url;
-
-function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return bytes;
-}
-
-async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function loadImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const probe = new Image();
-    probe.onload = () => resolve(probe);
-    probe.onerror = () => reject(new Error("decode failed"));
-    probe.src = url;
+  let cancelled = false;
+  onCleanup(() => {
+    cancelled = true;
   });
-}
+  const blob = await cropToBlob(img, w, h, THUMB_TARGET, offset);
+  if (!cancelled) thumbBlob.value = blob;
+});
 
-function setPreviewUrl(url: string | null): void {
-  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
-  previewUrl.value = url;
-}
-
-function regenerateCrops(): void {
-  void thumbPreview.regenerate(draft.value.image_thumb_offset);
+function fileToBase64(file: File): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(((reader.result as string) ?? "").split(",")[1] ?? null);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(file);
+  });
 }
 
 async function processFile(file: File): Promise<void> {
@@ -131,53 +109,60 @@ async function processFile(file: File): Promise<void> {
     fileError.value = t("image_too_large");
     return;
   }
-
-  const base64 = await new Promise<string | null>((resolve) => {
-    const reader = new FileReader();
-    reader.onload = (e) => resolve(((e.target?.result as string) ?? "").split(",")[1] ?? null);
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(file);
-  });
-  if (!base64) {
-    fileError.value = t("image_read_error");
-    return;
-  }
-
-  const url = URL.createObjectURL(file);
-  let image: HTMLImageElement;
+  let bitmap: ImageBitmap;
   try {
-    image = await loadImage(url);
+    bitmap = await createImageBitmap(file);
   } catch {
-    URL.revokeObjectURL(url);
     fileError.value = t("image_read_error");
     return;
   }
+  const [base64, buffer] = await Promise.all([fileToBase64(file), file.arrayBuffer()]);
+  if (!base64) {
+    bitmap.close();
+    fileError.value = t("image_read_error");
+    return;
+  }
+  // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs). The full
+  // sha256 is overkill for a filename; 16 hex chars (64 bits) keep collisions negligible yet tidy.
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", buffer));
+  const hash = Array.from(digest, (b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
 
-  setPreviewUrl(url);
-  sourceImage.value = image;
+  sourceBitmap.value?.close();
+  sourceBitmap.value = bitmap;
+  sourceFile.value = file;
   draft.value.image = { base64, fileName: file.name || "event-image" };
-  draft.value.image_width = image.naturalWidth;
-  draft.value.image_height = image.naturalHeight;
+  draft.value.image_width = bitmap.width;
+  draft.value.image_height = bitmap.height;
+  // A new image recentres both crops; their offset bounds depend on the new dimensions.
   draft.value.image_thumb_offset = 0;
   draft.value.image_header_offset = 0;
-  const hash = await sha256Hex(bytesFromBase64(base64));
-  draft.value.id = `event_${hash.slice(0, 16)}`;
-  regenerateCrops();
+  draft.value.id = `event_${hash}`;
 }
 
-function onFileChange(event: Event): void {
-  const file = (event.target as HTMLInputElement).files?.[0];
-  if (file) void processFile(file);
-}
-function onDrop(event: DragEvent): void {
-  isDragOver.value = false;
-  const file = event.dataTransfer?.files?.[0];
-  if (file) void processFile(file);
-}
+const {
+  open: openFileDialog,
+  onChange: onFileDialogChange,
+  reset: resetFileDialog,
+} = useFileDialog({ accept: "image/*", multiple: false });
+onFileDialogChange((files) => {
+  const f = files?.[0];
+  if (f) void processFile(f);
+});
+
+const dropArea = ref<HTMLElement>();
+const { isOverDropZone } = useDropZone(dropArea, {
+  onDrop: (files) => {
+    const f = files?.[0];
+    if (f) void processFile(f);
+  },
+});
+
 function removeImage(): void {
-  setPreviewUrl(null);
-  thumbPreview.set(null);
-  sourceImage.value = null;
+  sourceBitmap.value?.close();
+  sourceBitmap.value = null;
+  sourceFile.value = null;
   draft.value.image = null;
   draft.value.image_width = null;
   draft.value.image_height = null;
@@ -185,20 +170,15 @@ function removeImage(): void {
   draft.value.image_header_offset = 0;
   draft.value.id = "";
   fileError.value = "";
-  if (fileInput.value) fileInput.value.value = "";
+  resetFileDialog();
 }
 
-watch(
-  () => draft.value.image_thumb_offset,
-  (o) => thumbPreview.regenerate(o)
-);
-
-onBeforeUnmount(() => {
-  setPreviewUrl(null);
-  thumbPreview.set(null);
+// Release the bitmap's GPU/CPU buffers promptly; useObjectUrl handles the URL revokes itself.
+onScopeDispose(() => {
+  sourceBitmap.value?.close();
 });
 
-const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.value.coords.picked);
+const showPreview = computed(() => Boolean(thumbUrl.value) && draft.value.coords.picked);
 
 const previewEvent = computed<EventPreviewPopup | null>(() => {
   const org = selectedOrg.value;
@@ -362,19 +342,16 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
     <div>
       <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("image") }} <span class="text-red-700 dark:text-red-200">*</span></span>
       <div
+        ref="dropArea"
         class="cursor-pointer rounded border-2 border-dashed p-4 text-center text-sm transition-colors"
         :class="[
-          isDragOver
+          isOverDropZone
             ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900'
             : 'border-zinc-300 dark:border-zinc-600 hover:border-blue-400 dark:hover:border-blue-500',
           errorFor('image') ? 'border-red-500 dark:border-red-400' : '',
         ]"
-        @click="fileInput?.click()"
-        @dragover.prevent="isDragOver = true"
-        @dragleave.prevent="isDragOver = false"
-        @drop.prevent="onDrop"
+        @click="openFileDialog()"
       >
-        <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileChange" />
         <template v-if="draft.image">
           <p class="text-blue-700 dark:text-blue-200 font-medium">{{ draft.image.fileName }}</p>
           <p v-if="draft.image_width && draft.image_height" class="text-zinc-500 dark:text-zinc-400 text-xs">

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -24,11 +24,7 @@ function errorFor(path: string): string | null {
   return key ? t(key) : null;
 }
 
-// --- Organising org combobox (client-filtered, like the room usage picker) ---
 const knownOrgs = useKnownOrgs();
-// Destructure the fetch state into top-level refs so the template auto-unwraps them (a nested
-// `knownOrgs.pending` would stay a truthy Ref). The list is a required field sourced from a lazy
-// CDN fetch, so the dropdown must tell loading / load-failed / genuinely-empty apart.
 const { pending: orgsLoading, error: orgsError, refresh: reloadOrgs } = knownOrgs;
 const orgQuery = ref("");
 const filteredOrgs = computed<OrgOption[]>(() => knownOrgs.filter(orgQuery.value));
@@ -40,7 +36,6 @@ const selectedOrg = computed<OrgOption | null>({
   },
 });
 
-// --- Coordinates. Events have no parent to centre on, so default to TUM main campus. ---
 const DEFAULT_LAT = 48.149;
 const DEFAULT_LON = 11.568;
 const mapLat = computed({
@@ -58,20 +53,14 @@ const mapLon = computed({
   },
 });
 
-// --- Image upload ---
 const VALID_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const fileInput = ref<HTMLInputElement>();
 const isDragOver = ref(false);
 const fileError = ref("");
-// `blob:` URLs kept local (not in the persisted draft) and revoked on replace/unmount so they never
-// outlive the session. `previewUrl` is the full image (the croppers' source); each crop preview
-// renders the offset thumb/header exactly as the pipeline will.
 const previewUrl = ref<string | null>(null);
 const sourceImage = shallowRef<HTMLImageElement | null>(null);
 
-// A rendered preview of one crop target, regenerated as its offset changes. A token guards against
-// an earlier crop resolving after a later one and leaving a stale image.
 function makeCropPreview(target: CropTarget) {
   const url = ref<string | null>(null);
   let token = 0;
@@ -97,10 +86,7 @@ function makeCropPreview(target: CropTarget) {
   }
   return { url, set, regenerate };
 }
-// Only the thumb crop is previewed (in the map marker below); the header crop is chosen via its
-// cropper frame alone, so it needs no rendered blob.
 const thumbPreview = makeCropPreview(THUMB_TARGET);
-// Top-level ref so the template auto-unwraps it.
 const thumbUrl = thumbPreview.url;
 
 function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
@@ -172,11 +158,8 @@ async function processFile(file: File): Promise<void> {
   draft.value.image = { base64, fileName: file.name || "event-image" };
   draft.value.image_width = image.naturalWidth;
   draft.value.image_height = image.naturalHeight;
-  // A new image recentres both crops; their offset bounds depend on the new dimensions.
   draft.value.image_thumb_offset = 0;
   draft.value.image_header_offset = 0;
-  // Content-addressed key, matching `event_{hash(img)}` consumed by the server (event.rs). The full
-  // sha256 is overkill for a filename; 16 hex chars (64 bits) keep collisions negligible yet tidy.
   const hash = await sha256Hex(bytesFromBase64(base64));
   draft.value.id = `event_${hash.slice(0, 16)}`;
   regenerateCrops();
@@ -217,10 +200,6 @@ onBeforeUnmount(() => {
 
 const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.value.coords.picked);
 
-// The full event popup card, shown in the preview once every field it renders is filled. The popup
-// formats RFC3339 instants, so convert the wall-clock inputs here; a null conversion (or any missing
-// field) collapses to marker-only. The image is the not-yet-uploaded source blob, cover-fit by the
-// card exactly as the CDN image will be.
 const previewEvent = computed<EventPreviewPopup | null>(() => {
   const org = selectedOrg.value;
   const startsAt = wallTimeToRfc3339(draft.value.starts_at);

--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -24,6 +24,10 @@ function errorFor(path: string): string | null {
 
 // --- Organising org combobox (client-filtered, like the room usage picker) ---
 const knownOrgs = useKnownOrgs();
+// Destructure the fetch state into top-level refs so the template auto-unwraps them (a nested
+// `knownOrgs.pending` would stay a truthy Ref). The list is a required field sourced from a lazy
+// CDN fetch, so the dropdown must tell loading / load-failed / genuinely-empty apart.
+const { pending: orgsLoading, error: orgsError, refresh: reloadOrgs } = knownOrgs;
 const orgQuery = ref("");
 const filteredOrgs = computed<OrgOption[]>(() => knownOrgs.filter(orgQuery.value));
 const orgTruncated = computed(() => filteredOrgs.value.length >= knownOrgs.maxResults);
@@ -91,11 +95,11 @@ function makeCropPreview(target: CropTarget) {
   }
   return { url, set, regenerate };
 }
+// Only the thumb crop is previewed (in the map marker below); the header crop is chosen via its
+// cropper frame alone, so it needs no rendered blob.
 const thumbPreview = makeCropPreview(THUMB_TARGET);
-const headerPreview = makeCropPreview(HEADER_TARGET);
-// Top-level refs so the template auto-unwraps them.
+// Top-level ref so the template auto-unwraps it.
 const thumbUrl = thumbPreview.url;
-const headerUrl = headerPreview.url;
 
 function bytesFromBase64(base64: string): Uint8Array<ArrayBuffer> {
   const binary = atob(base64);
@@ -127,7 +131,6 @@ function setPreviewUrl(url: string | null): void {
 
 function regenerateCrops(): void {
   void thumbPreview.regenerate(draft.value.image_thumb_offset);
-  void headerPreview.regenerate(draft.value.image_header_offset);
 }
 
 async function processFile(file: File): Promise<void> {
@@ -187,7 +190,6 @@ function onDrop(event: DragEvent): void {
 function removeImage(): void {
   setPreviewUrl(null);
   thumbPreview.set(null);
-  headerPreview.set(null);
   sourceImage.value = null;
   draft.value.image = null;
   draft.value.image_width = null;
@@ -203,15 +205,10 @@ watch(
   () => draft.value.image_thumb_offset,
   (o) => thumbPreview.regenerate(o)
 );
-watch(
-  () => draft.value.image_header_offset,
-  (o) => headerPreview.regenerate(o)
-);
 
 onBeforeUnmount(() => {
   setPreviewUrl(null);
   thumbPreview.set(null);
-  headerPreview.set(null);
 });
 
 const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.value.coords.picked);
@@ -297,7 +294,20 @@ const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.valu
             <ComboboxOptions
               class="ring-black/5 dark:ring-white/5 bg-zinc-50 dark:bg-zinc-900 absolute z-30 mt-1 max-h-72 w-full overflow-auto rounded-md py-1 shadow-lg ring-1 focus:outline-none"
             >
-              <p v-if="filteredOrgs.length === 0" class="text-zinc-500 dark:text-zinc-400 px-3 py-2 text-sm">
+              <p v-if="orgsLoading" class="text-zinc-500 dark:text-zinc-400 px-3 py-2 text-sm">
+                {{ t("organising_org_loading") }}
+              </p>
+              <div v-else-if="orgsError" class="px-3 py-2 text-sm">
+                <p class="text-red-700 dark:text-red-200">{{ t("organising_org_load_error") }}</p>
+                <button
+                  type="button"
+                  class="text-blue-600 dark:text-blue-300 mt-1 underline"
+                  @mousedown.prevent="reloadOrgs()"
+                >
+                  {{ t("organising_org_retry") }}
+                </button>
+              </div>
+              <p v-else-if="filteredOrgs.length === 0" class="text-zinc-500 dark:text-zinc-400 px-3 py-2 text-sm">
                 {{ t("organising_org_no_results") }}
               </p>
               <ComboboxOption
@@ -379,7 +389,10 @@ const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.valu
       <p v-else-if="errorFor('image')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("image") }}</p>
     </div>
 
-    <template v-if="previewUrl && draft.image_width && draft.image_height">
+    <div
+      v-if="previewUrl && draft.image_width && draft.image_height"
+      class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:items-start"
+    >
       <div>
         <span class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">{{ t("crop_thumb") }}</span>
         <p class="text-zinc-500 dark:text-zinc-400 mb-1 text-xs">{{ t("crop_thumb_help") }}</p>
@@ -402,9 +415,8 @@ const showPreview = computed(() => Boolean(thumbPreview.url.value) && draft.valu
           :height="draft.image_height"
           :target="HEADER_TARGET"
         />
-        <img v-if="headerUrl" :src="headerUrl" alt="" class="border-zinc-300 dark:border-zinc-600 mt-2 w-full rounded border" />
       </div>
-    </template>
+    </div>
 
     <div>
       <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-event-image-author">
@@ -448,6 +460,9 @@ de:
   organising_org: Veranstaltende Organisation
   organising_org_placeholder: Organisation suchen…
   organising_org_no_results: Keine passende Organisation gefunden
+  organising_org_loading: Organisationen werden geladen…
+  organising_org_load_error: Die Organisationen konnten nicht geladen werden.
+  organising_org_retry: Erneut versuchen
   organising_org_truncated: "Nur die ersten {0} Treffer werden angezeigt - bitte weiter eingrenzen."
   coords: Ort
   image: Bild
@@ -493,6 +508,9 @@ en:
   organising_org: Organising organisation
   organising_org_placeholder: Search for an organisation…
   organising_org_no_results: No matching organisation found
+  organising_org_loading: Loading organisations…
+  organising_org_load_error: The organisations couldn't be loaded.
+  organising_org_retry: Try again
   organising_org_truncated: "Showing the first {0} matches only - keep typing to narrow it down."
   coords: Location
   image: Image

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -541,6 +541,7 @@ watch(
             v-model:lon="mapLon"
             :initial-lat="mapInitialLat"
             :initial-lon="mapInitialLon"
+            :awaiting-selection="!editProposal.pendingAddition.coords.picked"
           />
           <p v-if="editProposal.pendingAddition.coords.picked" class="text-zinc-600 dark:text-zinc-300 mt-1 text-xs">
             {{ editProposal.pendingAddition.coords.lat.toFixed(5) }},

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -5,7 +5,7 @@ import { useDebounceFn } from "@vueuse/core";
 import type { components } from "~/api_types";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { type AdditionKind, emptyAdditionDraft, useEditProposal } from "~/composables/editProposal";
-import { berlinWallTimeToRfc3339 } from "~/utils/datetime";
+import { wallTimeToRfc3339 } from "~/utils/datetime";
 import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 type FacetFilter = components["schemas"]["FacetFilter"];
@@ -243,8 +243,8 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
       description: draft.description,
       // The form holds Europe/Berlin wall-clock; stamp the offset for the RFC3339 server contract.
       // `newEventSchema` already rejected unconvertible values, so the `?? ""` fallback is unreachable.
-      starts_at: berlinWallTimeToRfc3339(draft.starts_at) ?? "",
-      ends_at: berlinWallTimeToRfc3339(draft.ends_at) ?? "",
+      starts_at: wallTimeToRfc3339(draft.starts_at) ?? "",
+      ends_at: wallTimeToRfc3339(draft.ends_at) ?? "",
       coords,
       organising_org_id: draft.organising_org_id as number,
       image: {

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -252,6 +252,8 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
         metadata: {
           author: draft.image_author,
           license: { text: draft.image_license_text, url: draft.image_license_url || null },
+          // Only the thumb crop is rendered for events; omit when centred to keep img-sources.yaml clean.
+          offsets: draft.image_thumb_offset === 0 ? null : { thumb: draft.image_thumb_offset },
         },
       },
     } as components["schemas"]["LimitedHashMap_String_Addition"][string];

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Tab, TabGroup, TabList } from "@headlessui/vue";
 import { mdiCalendarStar, mdiDomain, mdiMapMarker, mdiSofa } from "@mdi/js";
-import { useDebounceFn } from "@vueuse/core";
+import { refDebounced } from "@vueuse/core";
 import type { components } from "~/api_types";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { type AdditionKind, emptyAdditionDraft, useEditProposal } from "~/composables/editProposal";
@@ -29,40 +29,45 @@ const kindIndex = computed(() => {
   const k = editProposal.value.pendingAddition.kind;
   return k ? kindOptions.findIndex((o) => o.value === k) : -1;
 });
-// Debounce + verify the id against /api/locations/{id}; 200 means collision, 404 means free.
-const idCheckPending = ref(false);
+// Verify the id against /api/locations/{id}; 200 means collision, 404 means free. Event ids are
+// content-hashed locally and cannot collide with existing entries, so the check is suppressed.
+const trimmedId = computed(() => editProposal.value.pendingAddition.id.trim());
+const debouncedId = refDebounced(trimmedId, 350);
+const fetchingId = ref(false);
 const idCollidesOnServer = ref(false);
-// Counter still needed to invalidate in-flight fetches when the input changes
-// after the debounce already fired; `useDebounceFn` only cancels pending calls.
-let idCheckCounter = 0;
-const runIdCheck = useDebounceFn(async (id: string, ticket: number) => {
-  try {
-    const res = await fetch(
-      `${runtimeConfig.public.apiURL}/api/locations/${encodeURIComponent(id)}`,
-      { credentials: "omit" }
-    );
-    if (ticket !== idCheckCounter) return;
-    idCollidesOnServer.value = res.ok;
-  } catch {
-    // Network failure: don't block. The server validates again on submit.
-  } finally {
-    if (ticket === idCheckCounter) idCheckPending.value = false;
-  }
-}, 350);
 watch(
-  () => editProposal.value.pendingAddition.id,
-  (value) => {
-    idCheckCounter++;
+  [debouncedId, () => editProposal.value.pendingAddition.kind],
+  async ([id, kind], _old, onCleanup) => {
     idCollidesOnServer.value = false;
-    const id = value.trim();
-    if (!id || editProposal.value.pendingAddition.kind === "event") {
-      idCheckPending.value = false;
+    if (!id || kind === "event") {
+      fetchingId.value = false;
       return;
     }
-    idCheckPending.value = true;
-    runIdCheck(id, idCheckCounter);
+    const controller = new AbortController();
+    // `onCleanup` aborts the prior fetch the instant the watched inputs change again, so a slow
+    // response can never settle stale state. Replaces the manual counter the old code used.
+    onCleanup(() => controller.abort());
+    fetchingId.value = true;
+    try {
+      const res = await fetch(
+        `${runtimeConfig.public.apiURL}/api/locations/${encodeURIComponent(id)}`,
+        { credentials: "omit", signal: controller.signal }
+      );
+      idCollidesOnServer.value = res.ok;
+    } catch {
+      // Network failure or abort: don't block. The server re-validates on submit.
+    } finally {
+      fetchingId.value = false;
+    }
   }
 );
+// Pending while either the debounce hasn't caught up to the latest keystroke or a fetch is in
+// flight - both transient states map to "checking…" in the UI.
+const idCheckPending = computed(() => {
+  const id = trimmedId.value;
+  if (!id || editProposal.value.pendingAddition.kind === "event") return false;
+  return debouncedId.value !== id || fetchingId.value;
+});
 
 const allowedParentTypes = computed<readonly FacetFilter[]>(() => {
   const kind = editProposal.value.pendingAddition.kind;

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -55,8 +55,6 @@ watch(
     idCheckCounter++;
     idCollidesOnServer.value = false;
     const id = value.trim();
-    // Events aren't locations, and their id is a content hash derived from the image rather than
-    // typed, so the `/api/locations/{id}` collision check doesn't apply.
     if (!id || editProposal.value.pendingAddition.kind === "event") {
       idCheckPending.value = false;
       return;
@@ -241,8 +239,6 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
       kind: "event",
       name: draft.name,
       description: draft.description,
-      // The form holds Europe/Berlin wall-clock; stamp the offset for the RFC3339 server contract.
-      // `newEventSchema` already rejected unconvertible values, so the `?? ""` fallback is unreachable.
       starts_at: wallTimeToRfc3339(draft.starts_at) ?? "",
       ends_at: wallTimeToRfc3339(draft.ends_at) ?? "",
       coords,
@@ -251,10 +247,7 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
         content: draft.image.base64,
         metadata: {
           author: draft.image_author,
-          // Uploads are published under CC BY 4.0; the uploader attests by submitting (matches the
-          // "Suggest a new Image" flow), so the license isn't a form field.
           license: { text: "CC BY 4.0", url: "https://creativecommons.org/licenses/by/4.0/" },
-          // Omit offsets entirely when both crops are centred, to keep img-sources.yaml clean.
           offsets:
             draft.image_thumb_offset === 0 && draft.image_header_offset === 0
               ? null
@@ -427,7 +420,6 @@ watch(
       </TabGroup>
 
       <template v-if="editProposal.pendingAddition.kind">
-        <!-- Events have no parent entry; their place on the map is the picked coordinate alone. -->
         <div v-if="editProposal.pendingAddition.kind !== 'event'">
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
             {{ t("parent_label") }} <span class="text-red-700 dark:text-red-200">*</span>
@@ -530,8 +522,6 @@ watch(
         <AddPoiFields v-if="editProposal.pendingAddition.kind === 'poi'" />
         <AddEventFields v-if="editProposal.pendingAddition.kind === 'event'" />
 
-        <!-- Events render their own coordinate picker inside AddEventFields, above the image, so the
-             picker and the marker preview aren't two maps stacked together. -->
         <div v-if="editProposal.pendingAddition.kind !== 'event'">
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
             {{ t("coords_label") }} <span class="text-red-700 dark:text-red-200">*</span>
@@ -553,7 +543,6 @@ watch(
 
     <div class="float-right mt-6 flex flex-row-reverse gap-2">
       <Btn variant="primary" size="md" :disabled="!draftIsReady" @click="commitAddition">{{ t("commit") }}</Btn>
-      <!-- Events carry their image inline in the addition, so the separate image-upload step doesn't apply. -->
       <Btn v-if="editProposal.pendingAddition.kind !== 'event'" variant="secondary" size="md" :disabled="!draftIsReady" @click="commitAndAddImage">{{ t("commit_with_image") }}</Btn>
       <Btn variant="linkButton" size="md" @click="cancelAddition">{{ t("cancel") }}</Btn>
     </div>

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -251,9 +251,14 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
         content: draft.image.base64,
         metadata: {
           author: draft.image_author,
-          license: { text: draft.image_license_text, url: draft.image_license_url || null },
-          // Only the thumb crop is rendered for events; omit when centred to keep img-sources.yaml clean.
-          offsets: draft.image_thumb_offset === 0 ? null : { thumb: draft.image_thumb_offset },
+          // Uploads are published under CC BY 4.0; the uploader attests by submitting (matches the
+          // "Suggest a new Image" flow), so the license isn't a form field.
+          license: { text: "CC BY 4.0", url: "https://creativecommons.org/licenses/by/4.0/" },
+          // Omit offsets entirely when both crops are centred, to keep img-sources.yaml clean.
+          offsets:
+            draft.image_thumb_offset === 0 && draft.image_header_offset === 0
+              ? null
+              : { thumb: draft.image_thumb_offset, header: draft.image_header_offset },
         },
       },
     } as components["schemas"]["LimitedHashMap_String_Addition"][string];
@@ -525,7 +530,9 @@ watch(
         <AddPoiFields v-if="editProposal.pendingAddition.kind === 'poi'" />
         <AddEventFields v-if="editProposal.pendingAddition.kind === 'event'" />
 
-        <div>
+        <!-- Events render their own coordinate picker inside AddEventFields, above the image, so the
+             picker and the marker preview aren't two maps stacked together. -->
+        <div v-if="editProposal.pendingAddition.kind !== 'event'">
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
             {{ t("coords_label") }} <span class="text-red-700 dark:text-red-200">*</span>
           </label>

--- a/webclient/app/components/AddProposalModal.vue
+++ b/webclient/app/components/AddProposalModal.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { Tab, TabGroup, TabList } from "@headlessui/vue";
-import { mdiDomain, mdiMapMarker, mdiSofa } from "@mdi/js";
+import { mdiCalendarStar, mdiDomain, mdiMapMarker, mdiSofa } from "@mdi/js";
 import { useDebounceFn } from "@vueuse/core";
 import type { components } from "~/api_types";
 import { type AdditionFieldErrors, validateAddition } from "~/composables/additionSchema";
 import { type AdditionKind, emptyAdditionDraft, useEditProposal } from "~/composables/editProposal";
+import { berlinWallTimeToRfc3339 } from "~/utils/datetime";
 import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 type FacetFilter = components["schemas"]["FacetFilter"];
@@ -22,6 +23,7 @@ const kindOptions: { value: AdditionKind; icon: string }[] = [
   { value: "room", icon: mdiSofa },
   { value: "building", icon: mdiDomain },
   { value: "poi", icon: mdiMapMarker },
+  { value: "event", icon: mdiCalendarStar },
 ];
 const kindIndex = computed(() => {
   const k = editProposal.value.pendingAddition.kind;
@@ -53,7 +55,9 @@ watch(
     idCheckCounter++;
     idCollidesOnServer.value = false;
     const id = value.trim();
-    if (!id) {
+    // Events aren't locations, and their id is a content hash derived from the image rather than
+    // typed, so the `/api/locations/{id}` collision check doesn't apply.
+    if (!id || editProposal.value.pendingAddition.kind === "event") {
       idCheckPending.value = false;
       return;
     }
@@ -231,6 +235,27 @@ function buildAddition(): components["schemas"]["LimitedHashMap_String_Addition"
       generic_props: generic_props.length > 0 ? generic_props : undefined,
     } as components["schemas"]["LimitedHashMap_String_Addition"][string];
   }
+  if (draft.kind === "event") {
+    if (!draft.image) return null;
+    return {
+      kind: "event",
+      name: draft.name,
+      description: draft.description,
+      // The form holds Europe/Berlin wall-clock; stamp the offset for the RFC3339 server contract.
+      // `newEventSchema` already rejected unconvertible values, so the `?? ""` fallback is unreachable.
+      starts_at: berlinWallTimeToRfc3339(draft.starts_at) ?? "",
+      ends_at: berlinWallTimeToRfc3339(draft.ends_at) ?? "",
+      coords,
+      organising_org_id: draft.organising_org_id as number,
+      image: {
+        content: draft.image.base64,
+        metadata: {
+          author: draft.image_author,
+          license: { text: draft.image_license_text, url: draft.image_license_url || null },
+        },
+      },
+    } as components["schemas"]["LimitedHashMap_String_Addition"][string];
+  }
   return null;
 }
 
@@ -395,7 +420,8 @@ watch(
       </TabGroup>
 
       <template v-if="editProposal.pendingAddition.kind">
-        <div>
+        <!-- Events have no parent entry; their place on the map is the picked coordinate alone. -->
+        <div v-if="editProposal.pendingAddition.kind !== 'event'">
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
             {{ t("parent_label") }} <span class="text-red-700 dark:text-red-200">*</span>
           </label>
@@ -425,8 +451,8 @@ watch(
           </I18nT>
         </div>
 
-        <!-- For buildings the id input lives inside the Identifiers fieldset of AddBuildingFields. -->
-        <div v-if="editProposal.pendingAddition.kind !== 'building'">
+        <!-- Buildings render the id input inside AddBuildingFields; events derive it from the image. -->
+        <div v-if="editProposal.pendingAddition.kind !== 'building' && editProposal.pendingAddition.kind !== 'event'">
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium" for="add-id">
             {{ t("id_label") }} <span class="text-red-700 dark:text-red-200">*</span>
           </label>
@@ -495,6 +521,7 @@ watch(
         <AddRoomFields v-if="editProposal.pendingAddition.kind === 'room'" />
         <AddBuildingFields v-if="editProposal.pendingAddition.kind === 'building'" />
         <AddPoiFields v-if="editProposal.pendingAddition.kind === 'poi'" />
+        <AddEventFields v-if="editProposal.pendingAddition.kind === 'event'" />
 
         <div>
           <label class="text-zinc-600 dark:text-zinc-300 mb-1 block text-xs font-medium">
@@ -516,7 +543,8 @@ watch(
 
     <div class="float-right mt-6 flex flex-row-reverse gap-2">
       <Btn variant="primary" size="md" :disabled="!draftIsReady" @click="commitAddition">{{ t("commit") }}</Btn>
-      <Btn variant="secondary" size="md" :disabled="!draftIsReady" @click="commitAndAddImage">{{ t("commit_with_image") }}</Btn>
+      <!-- Events carry their image inline in the addition, so the separate image-upload step doesn't apply. -->
+      <Btn v-if="editProposal.pendingAddition.kind !== 'event'" variant="secondary" size="md" :disabled="!draftIsReady" @click="commitAndAddImage">{{ t("commit_with_image") }}</Btn>
       <Btn variant="linkButton" size="md" @click="cancelAddition">{{ t("cancel") }}</Btn>
     </div>
   </Modal>
@@ -532,6 +560,7 @@ de:
     room: Raum
     building: Gebäude
     poi: POI
+    event: Veranstaltung
   id_label: ID
   id_hint:
     room_segments: "Setzt sich aus übergeordnetem Gebäude, Stockwerk und Raumnummer zusammen."
@@ -564,6 +593,7 @@ en:
     room: Room
     building: Building
     poi: POI
+    event: Event
   id_label: ID
   id_hint:
     room_segments: "Composed from the parent building, floor and room number."

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -250,7 +250,6 @@ const actions = computed<DetailAction[]>(() => [
       <DetailsBuildingOverviewSection :buildings="data.sections?.buildings_overview"/>
       <ClientOnly>
         <LazyDetailsNearbyTransportSection :id="data.id"/>
-        <!-- Gated on the build-time signal, so uncovered pages issue no Iris request. -->
         <LazyDetailsIrisCoverageCard
           v-if="data.props.iris_coverage_building_ids?.length"
           :building-ids="data.props.iris_coverage_building_ids"

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -14,8 +14,6 @@ import { useIrisAvailability } from "~/composables/irisAvailability";
 import { bookedUntilTime, IRIS_SITE_URL, type IrisRoomRow, occupancyPercent } from "~/utils/iris";
 
 const props = defineProps<{
-  // A joined building (e.g. MI) passes every covered finger id, not just its own.
-  // The parent renders this only when non-empty, so an uncovered page issues no Iris request.
   readonly buildingIds: readonly string[];
 }>();
 

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -504,6 +504,7 @@ de:
     room: Raum
     building: Gebäude
     poi: POI
+    event: Veranstaltung
   room_edits: Raum-Änderungen
   coordinate: Koordinaten
   image: Bild
@@ -543,6 +544,7 @@ en:
     room: Room
     building: Building
     poi: POI
+    event: Event
   room_edits: Room Edits
   coordinate: Coordinate
   image: Image

--- a/webclient/app/components/EventImageCropper.vue
+++ b/webclient/app/components/EventImageCropper.vue
@@ -7,9 +7,6 @@ import {
   cropRect,
 } from "~/utils/imageCrop";
 
-// Lets the user choose an `offsets.*` value (see `data/processors/images.py`): a crop of the
-// target's aspect ratio slides along the over-long axis. The draggable frame shows what's kept; a
-// source that already matches the target aspect has nothing to choose.
 const offset = defineModel<number>({ required: true });
 const props = defineProps<{
   imageUrl: string;
@@ -27,7 +24,6 @@ const isHorizontal = computed(() => axis.value === "horizontal");
 
 const imageEl = ref<HTMLImageElement>();
 
-// The crop rectangle expressed as percentages of the displayed image, for the overlay frame.
 const frame = computed(() => {
   const rect = cropRect(props.width, props.height, props.target, offset.value);
   return {
@@ -55,7 +51,6 @@ function onPointerDown(event: PointerEvent): void {
 function onPointerMove(event: PointerEvent): void {
   if (!dragStart) return;
   const moved = (isHorizontal.value ? event.clientX : event.clientY) - dragStart.pointer;
-  // Convert the on-screen drag into source pixels via the displayed-axis length.
   const sourceAxis = isHorizontal.value ? props.width : props.height;
   const delta = (moved / dragStart.axisPx) * sourceAxis;
   offset.value = clampCropOffset(props.width, props.height, props.target, dragStart.offset + delta);
@@ -80,7 +75,6 @@ onBeforeUnmount(onPointerUp);
         draggable="false"
         class="block w-full"
       />
-      <!-- The frame's outward box-shadow dims everything outside the kept region. -->
       <div
         v-if="!fixed"
         class="absolute touch-none rounded-sm ring-2 ring-white/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]"

--- a/webclient/app/components/EventImageCropper.vue
+++ b/webclient/app/components/EventImageCropper.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { clampThumbOffset, thumbCropRect, thumbOffsetBounds } from "~/utils/imageCrop";
+
+// Lets the user choose the `offsets.thumb` value (see `data/processors/images.py`): the 256² thumb
+// is a `min(w, h)` square that slides along the longer axis. The frame shows what's kept; drag it
+// or use the slider. A square source has nothing to choose, so the controls collapse to a note.
+const offset = defineModel<number>({ required: true });
+const props = defineProps<{
+  imageUrl: string;
+  width: number;
+  height: number;
+}>();
+
+const { t } = useI18n({ useScope: "local" });
+
+const maxOffset = computed(() => thumbOffsetBounds(props.width, props.height).max);
+const isSquare = computed(() => maxOffset.value === 0);
+const isLandscape = computed(() => props.width >= props.height);
+
+const imageEl = ref<HTMLImageElement>();
+
+// The crop square expressed as percentages of the displayed image, for the overlay frame.
+const frame = computed(() => {
+  const rect = thumbCropRect(props.width, props.height, offset.value);
+  return {
+    left: `${(rect.x / props.width) * 100}%`,
+    top: `${(rect.y / props.height) * 100}%`,
+    width: `${(rect.size / props.width) * 100}%`,
+    height: `${(rect.size / props.height) * 100}%`,
+  };
+});
+
+let dragStart: { pointer: number; offset: number; axisPx: number } | null = null;
+
+function onPointerDown(event: PointerEvent): void {
+  if (isSquare.value || !imageEl.value) return;
+  const box = imageEl.value.getBoundingClientRect();
+  dragStart = {
+    pointer: isLandscape.value ? event.clientX : event.clientY,
+    offset: offset.value,
+    axisPx: isLandscape.value ? box.width : box.height,
+  };
+  window.addEventListener("pointermove", onPointerMove);
+  window.addEventListener("pointerup", onPointerUp);
+}
+
+function onPointerMove(event: PointerEvent): void {
+  if (!dragStart) return;
+  const moved = (isLandscape.value ? event.clientX : event.clientY) - dragStart.pointer;
+  // Convert the on-screen drag into source pixels via the displayed-axis length.
+  const sourceAxis = isLandscape.value ? props.width : props.height;
+  const delta = (moved / dragStart.axisPx) * sourceAxis;
+  offset.value = clampThumbOffset(props.width, props.height, dragStart.offset + delta);
+}
+
+function onPointerUp(): void {
+  dragStart = null;
+  window.removeEventListener("pointermove", onPointerMove);
+  window.removeEventListener("pointerup", onPointerUp);
+}
+
+onBeforeUnmount(onPointerUp);
+</script>
+
+<template>
+  <div>
+    <div class="border-zinc-300 dark:border-zinc-600 relative select-none overflow-hidden rounded border">
+      <img
+        ref="imageEl"
+        :src="imageUrl"
+        alt=""
+        draggable="false"
+        class="block w-full"
+      />
+      <!-- The frame's outward box-shadow dims everything outside the kept square. -->
+      <div
+        v-if="!isSquare"
+        class="absolute touch-none rounded-sm ring-2 ring-white/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]"
+        :class="isLandscape ? 'cursor-ew-resize' : 'cursor-ns-resize'"
+        :style="frame"
+        @pointerdown="onPointerDown"
+      />
+    </div>
+
+    <template v-if="isSquare">
+      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("square") }}</p>
+    </template>
+    <template v-else>
+      <input
+        :value="offset"
+        type="range"
+        :min="-maxOffset"
+        :max="maxOffset"
+        step="1"
+        :aria-label="t('aria_slider')"
+        class="mt-2 w-full accent-blue-600 dark:accent-blue-400"
+        @input="offset = clampThumbOffset(width, height, Number(($event.target as HTMLInputElement).value))"
+      />
+      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("help") }}</p>
+    </template>
+  </div>
+</template>
+
+<i18n lang="yaml">
+de:
+  help: Ziehe den Ausschnitt oder nutze den Regler, um den quadratischen Karten-Marker zu wählen.
+  square: Quadratisches Bild - der gesamte Ausschnitt wird verwendet.
+  aria_slider: Bildausschnitt verschieben
+en:
+  help: Drag the frame or use the slider to choose the square shown on the map marker.
+  square: Square image - the whole image is used.
+  aria_slider: Move the image crop
+</i18n>

--- a/webclient/app/components/EventImageCropper.vue
+++ b/webclient/app/components/EventImageCropper.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useEventListener } from "@vueuse/core";
 import {
   type CropTarget,
   clampCropOffset,
@@ -9,7 +10,9 @@ import {
 
 const offset = defineModel<number>({ required: true });
 const props = defineProps<{
-  imageUrl: string;
+  // Undefined upstream is guarded by `v-if="previewUrl"` at the parent's call site; widening the
+  // type here just keeps that template strict-typeable.
+  imageUrl: string | undefined;
   width: number;
   height: number;
   target: CropTarget;
@@ -34,35 +37,38 @@ const frame = computed(() => {
   };
 });
 
-let dragStart: { pointer: number; offset: number; axisPx: number } | null = null;
+interface DragStart {
+  pointer: number;
+  offset: number;
+  axisPx: number;
+}
+// shallowRef rather than a `let`: an outside-component cancellation (e.g. parent unmount mid-drag)
+// only needs to null this for the global listeners below to short-circuit.
+const dragStart = shallowRef<DragStart | null>(null);
 
 function onPointerDown(event: PointerEvent): void {
   if (fixed.value || !imageEl.value) return;
   const box = imageEl.value.getBoundingClientRect();
-  dragStart = {
+  dragStart.value = {
     pointer: isHorizontal.value ? event.clientX : event.clientY,
     offset: offset.value,
     axisPx: isHorizontal.value ? box.width : box.height,
   };
-  window.addEventListener("pointermove", onPointerMove);
-  window.addEventListener("pointerup", onPointerUp);
 }
 
-function onPointerMove(event: PointerEvent): void {
-  if (!dragStart) return;
-  const moved = (isHorizontal.value ? event.clientX : event.clientY) - dragStart.pointer;
+// Window-scoped listeners ride the component's effect scope, so `onBeforeUnmount` cleanup is
+// implicit; gating on `dragStart.value` makes the always-bound move handler a no-op when idle.
+useEventListener(window, "pointermove", (event: PointerEvent) => {
+  const start = dragStart.value;
+  if (!start) return;
+  const moved = (isHorizontal.value ? event.clientX : event.clientY) - start.pointer;
   const sourceAxis = isHorizontal.value ? props.width : props.height;
-  const delta = (moved / dragStart.axisPx) * sourceAxis;
-  offset.value = clampCropOffset(props.width, props.height, props.target, dragStart.offset + delta);
-}
-
-function onPointerUp(): void {
-  dragStart = null;
-  window.removeEventListener("pointermove", onPointerMove);
-  window.removeEventListener("pointerup", onPointerUp);
-}
-
-onBeforeUnmount(onPointerUp);
+  const delta = (moved / start.axisPx) * sourceAxis;
+  offset.value = clampCropOffset(props.width, props.height, props.target, start.offset + delta);
+});
+useEventListener(window, "pointerup", () => {
+  dragStart.value = null;
+});
 </script>
 
 <template>

--- a/webclient/app/components/EventImageCropper.vue
+++ b/webclient/app/components/EventImageCropper.vue
@@ -1,44 +1,52 @@
 <script setup lang="ts">
-import { clampThumbOffset, thumbCropRect, thumbOffsetBounds } from "~/utils/imageCrop";
+import {
+  type CropTarget,
+  clampCropOffset,
+  cropAxis,
+  cropOffsetBounds,
+  cropRect,
+} from "~/utils/imageCrop";
 
-// Lets the user choose the `offsets.thumb` value (see `data/processors/images.py`): the 256² thumb
-// is a `min(w, h)` square that slides along the longer axis. The frame shows what's kept; drag it
-// or use the slider. A square source has nothing to choose, so the controls collapse to a note.
+// Lets the user choose an `offsets.*` value (see `data/processors/images.py`): a crop of the
+// target's aspect ratio slides along the over-long axis. The draggable frame shows what's kept; a
+// source that already matches the target aspect has nothing to choose.
 const offset = defineModel<number>({ required: true });
 const props = defineProps<{
   imageUrl: string;
   width: number;
   height: number;
+  target: CropTarget;
 }>();
 
 const { t } = useI18n({ useScope: "local" });
 
-const maxOffset = computed(() => thumbOffsetBounds(props.width, props.height).max);
-const isSquare = computed(() => maxOffset.value === 0);
-const isLandscape = computed(() => props.width >= props.height);
+const maxOffset = computed(() => cropOffsetBounds(props.width, props.height, props.target).max);
+const fixed = computed(() => maxOffset.value === 0);
+const axis = computed(() => cropAxis(props.width, props.height, props.target));
+const isHorizontal = computed(() => axis.value === "horizontal");
 
 const imageEl = ref<HTMLImageElement>();
 
-// The crop square expressed as percentages of the displayed image, for the overlay frame.
+// The crop rectangle expressed as percentages of the displayed image, for the overlay frame.
 const frame = computed(() => {
-  const rect = thumbCropRect(props.width, props.height, offset.value);
+  const rect = cropRect(props.width, props.height, props.target, offset.value);
   return {
     left: `${(rect.x / props.width) * 100}%`,
     top: `${(rect.y / props.height) * 100}%`,
-    width: `${(rect.size / props.width) * 100}%`,
-    height: `${(rect.size / props.height) * 100}%`,
+    width: `${(rect.width / props.width) * 100}%`,
+    height: `${(rect.height / props.height) * 100}%`,
   };
 });
 
 let dragStart: { pointer: number; offset: number; axisPx: number } | null = null;
 
 function onPointerDown(event: PointerEvent): void {
-  if (isSquare.value || !imageEl.value) return;
+  if (fixed.value || !imageEl.value) return;
   const box = imageEl.value.getBoundingClientRect();
   dragStart = {
-    pointer: isLandscape.value ? event.clientX : event.clientY,
+    pointer: isHorizontal.value ? event.clientX : event.clientY,
     offset: offset.value,
-    axisPx: isLandscape.value ? box.width : box.height,
+    axisPx: isHorizontal.value ? box.width : box.height,
   };
   window.addEventListener("pointermove", onPointerMove);
   window.addEventListener("pointerup", onPointerUp);
@@ -46,11 +54,11 @@ function onPointerDown(event: PointerEvent): void {
 
 function onPointerMove(event: PointerEvent): void {
   if (!dragStart) return;
-  const moved = (isLandscape.value ? event.clientX : event.clientY) - dragStart.pointer;
+  const moved = (isHorizontal.value ? event.clientX : event.clientY) - dragStart.pointer;
   // Convert the on-screen drag into source pixels via the displayed-axis length.
-  const sourceAxis = isLandscape.value ? props.width : props.height;
+  const sourceAxis = isHorizontal.value ? props.width : props.height;
   const delta = (moved / dragStart.axisPx) * sourceAxis;
-  offset.value = clampThumbOffset(props.width, props.height, dragStart.offset + delta);
+  offset.value = clampCropOffset(props.width, props.height, props.target, dragStart.offset + delta);
 }
 
 function onPointerUp(): void {
@@ -72,18 +80,18 @@ onBeforeUnmount(onPointerUp);
         draggable="false"
         class="block w-full"
       />
-      <!-- The frame's outward box-shadow dims everything outside the kept square. -->
+      <!-- The frame's outward box-shadow dims everything outside the kept region. -->
       <div
-        v-if="!isSquare"
+        v-if="!fixed"
         class="absolute touch-none rounded-sm ring-2 ring-white/90 shadow-[0_0_0_9999px_rgba(0,0,0,0.45)]"
-        :class="isLandscape ? 'cursor-ew-resize' : 'cursor-ns-resize'"
+        :class="isHorizontal ? 'cursor-ew-resize' : 'cursor-ns-resize'"
         :style="frame"
         @pointerdown="onPointerDown"
       />
     </div>
 
-    <template v-if="isSquare">
-      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("square") }}</p>
+    <template v-if="fixed">
+      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("fixed") }}</p>
     </template>
     <template v-else>
       <input
@@ -94,20 +102,17 @@ onBeforeUnmount(onPointerUp);
         step="1"
         :aria-label="t('aria_slider')"
         class="mt-2 w-full accent-blue-600 dark:accent-blue-400"
-        @input="offset = clampThumbOffset(width, height, Number(($event.target as HTMLInputElement).value))"
+        @input="offset = clampCropOffset(width, height, target, Number(($event.target as HTMLInputElement).value))"
       />
-      <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("help") }}</p>
     </template>
   </div>
 </template>
 
 <i18n lang="yaml">
 de:
-  help: Ziehe den Ausschnitt oder nutze den Regler, um den quadratischen Karten-Marker zu wählen.
-  square: Quadratisches Bild - der gesamte Ausschnitt wird verwendet.
+  fixed: Das Seitenverhältnis passt bereits - das ganze Bild wird verwendet.
   aria_slider: Bildausschnitt verschieben
 en:
-  help: Drag the frame or use the slider to choose the square shown on the map marker.
-  square: Square image - the whole image is used.
+  fixed: The aspect ratio already matches - the whole image is used.
   aria_slider: Move the image crop
 </i18n>

--- a/webclient/app/components/EventPopupCard.vue
+++ b/webclient/app/components/EventPopupCard.vue
@@ -4,7 +4,9 @@ import { mdiOpenInNew } from "@mdi/js";
 const props = defineProps<{
   readonly name: string;
   readonly description: string;
-  readonly imagePath: string;
+  readonly imagePath?: string;
+  /** Pre-resolved image URL (e.g. a local `blob:`) for previewing a not-yet-uploaded image; overrides `imagePath`. */
+  readonly imageSrcOverride?: string | null;
   readonly startsAt: string;
   readonly endsAt: string;
   readonly orgCode: string;
@@ -65,7 +67,9 @@ const badge = computed(() => {
 
 const orgName = computed(() => (locale.value === "de" ? props.orgNameDe : props.orgNameEn));
 
-const imageSrc = computed(() => `${runtimeConfig.public.cdnURL}${props.imagePath}`);
+const imageSrc = computed(
+  () => props.imageSrcOverride ?? `${runtimeConfig.public.cdnURL}${props.imagePath ?? ""}`
+);
 </script>
 
 <template>

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -128,7 +128,17 @@ watch(
   }
 );
 watch(() => props.imageUrl, syncMarker);
-watch(() => Boolean(props.popup), applyPadding);
+watch(
+  () => Boolean(props.popup),
+  async () => {
+    // The container height changes with the popup. Let the DOM apply it, force MapLibre to read the
+    // new size, then re-bias and reproject — otherwise the card anchors against the stale height and
+    // lands above the frame, where `overflow-hidden` clips it out of sight.
+    await nextTick();
+    map.value?.resize();
+    applyPadding();
+  }
+);
 
 onBeforeUnmount(() => {
   marker.value?.remove();

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -2,16 +2,34 @@
 import { Map as MapLibreMap, Marker } from "maplibre-gl";
 import { webglSupport } from "~/composables/webglSupport";
 
+// Everything the event popup card needs, pre-resolved (times as RFC3339, image as a local `blob:`),
+// so the preview renders the exact `EventPopupCard` the live map shows on a marker click.
+export interface EventPreviewPopup {
+  readonly name: string;
+  readonly description: string;
+  readonly startsAt: string;
+  readonly endsAt: string;
+  readonly orgCode: string;
+  readonly orgNameDe: string;
+  readonly orgNameEn: string;
+  readonly imageSrc: string;
+}
+
 // Live preview of the event's #3136 photo marker at the picked coordinate, from the not-yet-uploaded
 // image. A plain DOM marker re-creates the circular look of the `events_active` symbol layer, since
-// the uncommitted event isn't in the Martin vector source.
+// the uncommitted event isn't in the Martin vector source. When `popup` is set, the real card is
+// shown above the marker exactly as the live map renders it on click.
 const props = defineProps<{
   lat: number;
   lon: number;
   imageUrl: string | null;
+  popup?: EventPreviewPopup | null;
 }>();
 
 const PREVIEW_ZOOM = 17;
+// The card grows upward from the marker; biasing the map's focal point down by this many pixels keeps
+// the whole card inside the (taller) preview frame.
+const POPUP_TOP_PADDING = 260;
 
 const mapContainer = ref<HTMLElement>();
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
@@ -19,6 +37,8 @@ const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const markerImg = shallowRef<HTMLImageElement | undefined>(undefined);
 const loaded = ref(false);
+// Screen-space position of the marker, kept in sync so the card overlay tracks it as the map moves.
+const markerPos = shallowRef<{ x: number; y: number } | null>(null);
 
 function createMarkerElement(): HTMLElement {
   const el = document.createElement("div");
@@ -59,6 +79,23 @@ function syncMarker(): void {
   marker.value.setLngLat([props.lon, props.lat]).addTo(target);
 }
 
+function projectMarker(): void {
+  const target = map.value;
+  if (!target) return;
+  const { x, y } = target.project([props.lon, props.lat]);
+  markerPos.value = { x, y };
+}
+
+// Bias the focal point down when the card is shown so it fits above the marker; recentre to keep the
+// marker glued to its coordinate under the new padding.
+function applyPadding(): void {
+  const target = map.value;
+  if (!target) return;
+  target.setPadding({ top: props.popup ? POPUP_TOP_PADDING : 0, bottom: 0, left: 0, right: 0 });
+  target.setCenter([props.lon, props.lat]);
+  projectMarker();
+}
+
 onMounted(() => {
   if (!webglSupport || !mapContainer.value) return;
   const instance = new MapLibreMap({
@@ -72,8 +109,13 @@ onMounted(() => {
   map.value = instance;
   instance.on("load", () => {
     loaded.value = true;
+    applyPadding();
     syncMarker();
+    projectMarker();
   });
+  instance.on("move", projectMarker);
+  // Toggling the popup changes the container height; reproject once MapLibre's ResizeObserver settles.
+  instance.on("resize", projectMarker);
 });
 
 // Follow coordinate edits without animating, so the marker stays glued to the picked spot.
@@ -82,9 +124,11 @@ watch(
   ([lat, lon]) => {
     map.value?.setCenter([lon, lat]);
     marker.value?.setLngLat([lon, lat]);
+    projectMarker();
   }
 );
 watch(() => props.imageUrl, syncMarker);
+watch(() => Boolean(props.popup), applyPadding);
 
 onBeforeUnmount(() => {
   marker.value?.remove();
@@ -93,11 +137,33 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="h-40 border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border">
+  <div
+    class="border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border"
+    :class="popup ? 'h-[26rem]' : 'h-40'"
+  >
     <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
     <LazyMapGLNotSupported v-else />
     <div v-if="webglSupport && !loaded" class="absolute inset-0 flex items-center justify-center">
       <Spinner class="h-8 w-8 text-blue-500 dark:text-blue-400" />
+    </div>
+    <!-- Non-interactive: this is a visual preview, so the card's org link must not navigate away and discard the draft. -->
+    <div
+      v-if="popup && markerPos && loaded"
+      class="pointer-events-none absolute z-20"
+      :style="{ left: `${markerPos.x}px`, top: `${markerPos.y}px` }"
+    >
+      <div class="-mt-3 -translate-x-1/2 -translate-y-full">
+        <EventPopupCard
+          :name="popup.name"
+          :description="popup.description"
+          :image-src-override="popup.imageSrc"
+          :starts-at="popup.startsAt"
+          :ends-at="popup.endsAt"
+          :org-code="popup.orgCode"
+          :org-name-de="popup.orgNameDe"
+          :org-name-en="popup.orgNameEn"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -132,7 +132,7 @@ watch(
   () => Boolean(props.popup),
   async () => {
     // The container height changes with the popup. Let the DOM apply it, force MapLibre to read the
-    // new size, then re-bias and reproject — otherwise the card anchors against the stale height and
+    // new size, then re-bias and reproject - otherwise the card anchors against the stale height and
     // lands above the frame, where `overflow-hidden` clips it out of sight.
     await nextTick();
     map.value?.resize();

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -2,10 +2,9 @@
 import { Map as MapLibreMap, Marker } from "maplibre-gl";
 import { webglSupport } from "~/composables/webglSupport";
 
-// Live preview of how the proposed event will show up as a #3136 photo marker, rendered from the
-// not-yet-uploaded image (a local `blob:` URL) at the picked coordinate. Marker-only on purpose -
-// the popup card is a separate concern - so this re-creates the circular white-ringed look of the
-// `events_active` symbol layer with a plain DOM marker instead of the Martin vector source.
+// Live preview of the event's #3136 photo marker at the picked coordinate, from the not-yet-uploaded
+// image. A plain DOM marker re-creates the circular look of the `events_active` symbol layer, since
+// the uncommitted event isn't in the Martin vector source.
 const props = defineProps<{
   lat: number;
   lon: number;
@@ -77,8 +76,7 @@ onMounted(() => {
   });
 });
 
-// Track live coordinate edits (e.g. dragging the picker) without animating, so the marker stays
-// glued to the chosen spot.
+// Follow coordinate edits without animating, so the marker stays glued to the picked spot.
 watch(
   () => [props.lat, props.lon] as const,
   ([lat, lon]) => {
@@ -95,7 +93,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="aspect-4/3 border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border">
+  <div class="h-40 border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border">
     <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
     <LazyMapGLNotSupported v-else />
     <div v-if="webglSupport && !loaded" class="absolute inset-0 flex items-center justify-center">

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -2,8 +2,6 @@
 import { Map as MapLibreMap, Marker } from "maplibre-gl";
 import { webglSupport } from "~/composables/webglSupport";
 
-// Everything the event popup card needs, pre-resolved (times as RFC3339, image as a local `blob:`),
-// so the preview renders the exact `EventPopupCard` the live map shows on a marker click.
 export interface EventPreviewPopup {
   readonly name: string;
   readonly description: string;
@@ -15,29 +13,21 @@ export interface EventPreviewPopup {
   readonly imageSrc: string;
 }
 
-// Live preview of the event's #3136 photo marker at the picked coordinate, from the not-yet-uploaded
-// image. A plain DOM marker re-creates the circular look of the `events_active` symbol layer, since
-// the uncommitted event isn't in the Martin vector source. When `popup` is set, the real card is
-// shown above the marker exactly as the live map renders it on click.
 const props = defineProps<{
   lat: number;
   lon: number;
-  imageUrl: string | null;
+  imageUrl: string | null | undefined;
   popup?: EventPreviewPopup | null;
 }>();
 
 const PREVIEW_ZOOM = 17;
-// The card grows upward from the marker; biasing the map's focal point down by this many pixels keeps
-// the whole card inside the (taller) preview frame.
 const POPUP_TOP_PADDING = 260;
 
 const mapContainer = ref<HTMLElement>();
-// `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const markerImg = shallowRef<HTMLImageElement | undefined>(undefined);
 const loaded = ref(false);
-// Screen-space position of the marker, kept in sync so the card overlay tracks it as the map moves.
 const markerPos = shallowRef<{ x: number; y: number } | null>(null);
 
 function createMarkerElement(): HTMLElement {
@@ -86,8 +76,6 @@ function projectMarker(): void {
   markerPos.value = { x, y };
 }
 
-// Bias the focal point down when the card is shown so it fits above the marker; recentre to keep the
-// marker glued to its coordinate under the new padding.
 function applyPadding(): void {
   const target = map.value;
   if (!target) return;
@@ -114,11 +102,9 @@ onMounted(() => {
     projectMarker();
   });
   instance.on("move", projectMarker);
-  // Toggling the popup changes the container height; reproject once MapLibre's ResizeObserver settles.
   instance.on("resize", projectMarker);
 });
 
-// Follow coordinate edits without animating, so the marker stays glued to the picked spot.
 watch(
   () => [props.lat, props.lon] as const,
   ([lat, lon]) => {
@@ -131,9 +117,6 @@ watch(() => props.imageUrl, syncMarker);
 watch(
   () => Boolean(props.popup),
   async () => {
-    // The container height changes with the popup. Let the DOM apply it, force MapLibre to read the
-    // new size, then re-bias and reproject - otherwise the card anchors against the stale height and
-    // lands above the frame, where `overflow-hidden` clips it out of sight.
     await nextTick();
     map.value?.resize();
     applyPadding();
@@ -156,7 +139,6 @@ onBeforeUnmount(() => {
     <div v-if="webglSupport && !loaded" class="absolute inset-0 flex items-center justify-center">
       <Spinner class="h-8 w-8 text-blue-500 dark:text-blue-400" />
     </div>
-    <!-- Non-interactive: this is a visual preview, so the card's org link must not navigate away and discard the draft. -->
     <div
       v-if="popup && markerPos && loaded"
       class="pointer-events-none absolute z-20"

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { Map as MapLibreMap, Marker } from "maplibre-gl";
+import { webglSupport } from "~/composables/webglSupport";
+
+// Live preview of how the proposed event will show up as a #3136 photo marker, rendered from the
+// not-yet-uploaded image (a local `blob:` URL) at the picked coordinate. Marker-only on purpose -
+// the popup card is a separate concern - so this re-creates the circular white-ringed look of the
+// `events_active` symbol layer with a plain DOM marker instead of the Martin vector source.
+const props = defineProps<{
+  lat: number;
+  lon: number;
+  imageUrl: string | null;
+}>();
+
+const PREVIEW_ZOOM = 17;
+
+const mapContainer = ref<HTMLElement>();
+// `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
+const map = shallowRef<MapLibreMap | undefined>(undefined);
+const marker = shallowRef<Marker | undefined>(undefined);
+const markerImg = shallowRef<HTMLImageElement | undefined>(undefined);
+const loaded = ref(false);
+
+function createMarkerElement(): HTMLElement {
+  const el = document.createElement("div");
+  Object.assign(el.style, {
+    width: "56px",
+    height: "56px",
+    borderRadius: "9999px",
+    overflow: "hidden",
+    border: "3px solid #ffffff",
+    boxShadow: "0 1px 4px rgba(0, 0, 0, 0.4)",
+    background: "#e4e4e7",
+  });
+  const img = document.createElement("img");
+  Object.assign(img.style, {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    display: "block",
+  });
+  el.appendChild(img);
+  markerImg.value = img;
+  return el;
+}
+
+function syncMarker(): void {
+  const target = map.value;
+  if (!target) return;
+  if (!props.imageUrl) {
+    marker.value?.remove();
+    marker.value = undefined;
+    return;
+  }
+  if (markerImg.value) markerImg.value.src = props.imageUrl;
+  if (!marker.value) {
+    marker.value = new Marker({ element: createMarkerElement(), anchor: "center" });
+    if (markerImg.value) markerImg.value.src = props.imageUrl;
+  }
+  marker.value.setLngLat([props.lon, props.lat]).addTo(target);
+}
+
+onMounted(() => {
+  if (!webglSupport || !mapContainer.value) return;
+  const instance = new MapLibreMap({
+    container: mapContainer.value,
+    style: "https://nav.tum.de/martin/style/navigatum-basemap.json",
+    center: [props.lon, props.lat],
+    zoom: PREVIEW_ZOOM,
+    attributionControl: false,
+    validateStyle: import.meta.env.DEV,
+  });
+  map.value = instance;
+  instance.on("load", () => {
+    loaded.value = true;
+    syncMarker();
+  });
+});
+
+// Track live coordinate edits (e.g. dragging the picker) without animating, so the marker stays
+// glued to the chosen spot.
+watch(
+  () => [props.lat, props.lon] as const,
+  ([lat, lon]) => {
+    map.value?.setCenter([lon, lat]);
+    marker.value?.setLngLat([lon, lat]);
+  }
+);
+watch(() => props.imageUrl, syncMarker);
+
+onBeforeUnmount(() => {
+  marker.value?.remove();
+  map.value?.remove();
+});
+</script>
+
+<template>
+  <div class="aspect-4/3 border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border">
+    <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
+    <LazyMapGLNotSupported v-else />
+    <div v-if="webglSupport && !loaded" class="absolute inset-0 flex items-center justify-center">
+      <Spinner class="h-8 w-8 text-blue-500 dark:text-blue-400" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+@import "maplibre-gl/dist/maplibre-gl.css";
+</style>

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -137,7 +137,7 @@ onUnmounted(() => {
 <template>
   <div class="location-picker">
     <div
-      class="border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded-lg border"
+      class="border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded border"
       :class="[containerClass, { 'dark:bg-black bg-white': webglSupport }]"
     >
       <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
@@ -147,7 +147,7 @@ onUnmounted(() => {
         class="pointer-events-none absolute inset-0 flex items-center justify-center p-3"
       >
         <span
-          class="bg-zinc-900/75 text-white flex items-center gap-2 rounded-full px-4 py-2 text-center text-sm font-medium shadow-lg backdrop-blur-sm"
+          class="bg-zinc-900/75 text-white flex items-center gap-2 rounded px-3 py-1.5 text-center text-sm font-medium shadow backdrop-blur-sm"
         >
           <MdiIcon :path="mdiMapMarkerPlus" :size="18" class="flex-shrink-0" />
           {{ t("clickMap") }}

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { until } from "@vueuse/core";
+import { mdiMapMarkerPlus } from "@mdi/js";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -16,16 +17,27 @@ interface Props {
   zoom?: number;
   /** Sizing class for the map container; override to make the map shorter than the default 4:3. */
   containerClass?: string;
+  /**
+   * No location has been chosen yet, so the initial coordinate is only a default. Withholds the pin
+   * (an already-shown pin reads as "already set") and overlays a call-to-action until the first pick.
+   */
+  awaitingSelection?: boolean;
 }
 const lat = defineModel<number>("lat", { required: true });
 
 const lon = defineModel<number>("lon", { required: true });
 
-const props = withDefaults(defineProps<Props>(), { zoom: 17, containerClass: "aspect-4/3" });
+const props = withDefaults(defineProps<Props>(), {
+  zoom: 17,
+  containerClass: "aspect-4/3",
+  awaitingSelection: false,
+});
 const { t } = useI18n({ useScope: "local" });
 
-const map = ref<MapLibreMap | undefined>(undefined);
-const marker = ref<Marker | undefined>(undefined);
+// `shallowRef`: MapLibre owns its own deep state; Vue must not deeply unwrap/track it (the unwrapped
+// type also stops being assignable where the raw `Map`/`Marker` is expected, e.g. `Marker.addTo`).
+const map = shallowRef<MapLibreMap | undefined>(undefined);
+const marker = shallowRef<Marker | undefined>(undefined);
 const mapContainer = ref<HTMLElement>();
 const isMobile = useIsMobile();
 
@@ -68,14 +80,16 @@ function initMap() {
     );
 
     const draggableMarker = new Marker({ element: createMarker(120), draggable: true });
-    draggableMarker.setLngLat([lon.value, lat.value]).addTo(mapInstance);
+    draggableMarker.setLngLat([lon.value, lat.value]);
+    // Withhold the pin until the first pick so an unset default doesn't read as a chosen location.
+    if (!props.awaitingSelection) draggableMarker.addTo(mapInstance);
     draggableMarker.on("dragend", () => {
       const lngLat = draggableMarker.getLngLat();
       lat.value = lngLat.lat;
       lon.value = lngLat.lng;
     });
     mapInstance.on("click", (e) => {
-      draggableMarker.setLngLat([e.lngLat.lng, e.lngLat.lat]);
+      draggableMarker.setLngLat([e.lngLat.lng, e.lngLat.lat]).addTo(mapInstance);
       lat.value = e.lngLat.lat;
       lon.value = e.lngLat.lng;
     });
@@ -101,6 +115,15 @@ watch(
   { immediate: false }
 );
 
+// A pick made elsewhere (e.g. prefilled from a parent entry) also resolves the awaiting state, so
+// surface the pin then too.
+watch(
+  () => props.awaitingSelection,
+  (awaiting) => {
+    if (!awaiting && marker.value && map.value) marker.value.addTo(map.value);
+  }
+);
+
 onMounted(async () => {
   await until(mapContainer).toBeTruthy();
   initMap();
@@ -119,8 +142,21 @@ onUnmounted(() => {
     >
       <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
       <LazyMapGLNotSupported v-else />
+      <div
+        v-if="awaitingSelection && webglSupport"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center p-3"
+      >
+        <span
+          class="bg-zinc-900/75 text-white flex items-center gap-2 rounded-full px-4 py-2 text-center text-sm font-medium shadow-lg backdrop-blur-sm"
+        >
+          <MdiIcon :path="mdiMapMarkerPlus" :size="18" class="flex-shrink-0" />
+          {{ t("clickMap") }}
+        </span>
+      </div>
     </div>
-    <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-center text-xs">{{ t("clickMap") }}</p>
+    <p v-if="!awaitingSelection" class="text-zinc-500 dark:text-zinc-400 mt-1 text-center text-xs">
+      {{ t("clickMap") }}
+    </p>
   </div>
 </template>
 

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -14,12 +14,14 @@ interface Props {
   initialLat: number;
   initialLon: number;
   zoom?: number;
+  /** Sizing class for the map container; override to make the map shorter than the default 4:3. */
+  containerClass?: string;
 }
 const lat = defineModel<number>("lat", { required: true });
 
 const lon = defineModel<number>("lon", { required: true });
 
-const props = withDefaults(defineProps<Props>(), { zoom: 17 });
+const props = withDefaults(defineProps<Props>(), { zoom: 17, containerClass: "aspect-4/3" });
 const { t } = useI18n({ useScope: "local" });
 
 const map = ref<MapLibreMap | undefined>(undefined);
@@ -112,8 +114,8 @@ onUnmounted(() => {
 <template>
   <div class="location-picker">
     <div
-      class="aspect-4/3 border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded-lg border"
-      :class="{ 'dark:bg-black bg-white': webglSupport }"
+      class="border-zinc-300 dark:border-zinc-600 relative overflow-hidden rounded-lg border"
+      :class="[containerClass, { 'dark:bg-black bg-white': webglSupport }]"
     >
       <div v-if="webglSupport" ref="mapContainer" class="absolute inset-0 h-full w-full" />
       <LazyMapGLNotSupported v-else />

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -15,12 +15,7 @@ interface Props {
   initialLat: number;
   initialLon: number;
   zoom?: number;
-  /** Sizing class for the map container; override to make the map shorter than the default 4:3. */
   containerClass?: string;
-  /**
-   * No location has been chosen yet, so the initial coordinate is only a default. Withholds the pin
-   * (an already-shown pin reads as "already set") and overlays a call-to-action until the first pick.
-   */
   awaitingSelection?: boolean;
 }
 const lat = defineModel<number>("lat", { required: true });
@@ -34,8 +29,6 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const { t } = useI18n({ useScope: "local" });
 
-// `shallowRef`: MapLibre owns its own deep state; Vue must not deeply unwrap/track it (the unwrapped
-// type also stops being assignable where the raw `Map`/`Marker` is expected, e.g. `Marker.addTo`).
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const mapContainer = ref<HTMLElement>();
@@ -81,7 +74,6 @@ function initMap() {
 
     const draggableMarker = new Marker({ element: createMarker(120), draggable: true });
     draggableMarker.setLngLat([lon.value, lat.value]);
-    // Withhold the pin until the first pick so an unset default doesn't read as a chosen location.
     if (!props.awaitingSelection) draggableMarker.addTo(mapInstance);
     draggableMarker.on("dragend", () => {
       const lngLat = draggableMarker.getLngLat();
@@ -115,8 +107,6 @@ watch(
   { immediate: false }
 );
 
-// A pick made elsewhere (e.g. prefilled from a parent entry) also resolves the awaiting state, so
-// surface the pin then too.
 watch(
   () => props.awaitingSelection,
   (awaiting) => {

--- a/webclient/app/components/OrgOptionContent.vue
+++ b/webclient/app/components/OrgOptionContent.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import type { OrgOption } from "~/composables/useKnownOrgs";
+
+defineProps<{
+  org: OrgOption;
+  emphasised?: boolean;
+}>();
+</script>
+
+<template>
+  <span class="text-sm text-zinc-800 dark:text-zinc-100" :class="emphasised ? 'font-bold' : 'font-normal'">{{ org.label }}</span>
+  <span class="text-zinc-400 dark:text-zinc-500 ml-auto font-mono text-[10px]">{{ org.code }}</span>
+</template>

--- a/webclient/app/components/Toast.vue
+++ b/webclient/app/components/Toast.vue
@@ -10,9 +10,7 @@ const props = withDefaults(
   }>(),
   { level: "default", msg: "", dismissable: false }
 );
-// No `default: () => []`: that would make `useCookie` write the empty array back during SSR, which
-// on `swr`-cached routes bakes a per-user `Set-Cookie` into the shared response (see the rationale
-// in `userPreferences.ts`). The server only reads which toasts were dismissed; the client writes.
+// No `default` factory; see `userPreferences.ts` (avoids per-user `Set-Cookie` on `swr` responses).
 const dismissedToasts = useCookie<string[] | null>("shownToasts");
 const isDismissed = computed(() => dismissedToasts.value?.includes(props.id) ?? false);
 

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -1,14 +1,20 @@
 // Zod schemas for the "propose a new entry" forms. These intentionally mirror the Rust validators
-// in `server/src/routes/feedback/proposed_edits/addition/{room,building,poi}.rs`. Whenever the
+// in `server/src/routes/feedback/proposed_edits/addition/{room,building,poi,event}.rs`. Whenever the
 // backend rules change, update both - the matching `case` in each Rust validator's rstest table
 // is the source of truth.
 import { z } from "zod";
 import type { AdditionDraft } from "~/composables/editProposal";
+import { berlinWallTimeToRfc3339 } from "~/utils/datetime";
 
-// Shared with `MAX_NAME_LEN` in the backend (room.rs / building.rs / poi.rs).
+// Shared with `MAX_NAME_LEN` in the backend (room.rs / building.rs / poi.rs / event.rs).
 const MAX_NAME_LEN = 200;
 // Shared with `MAX_KEY_LEN` in poi.rs.
 const MAX_POI_KEY_LEN = 64;
+// Mirrors the constants in event.rs.
+const MIN_IMAGE_DIM = 256;
+const MAX_HORIZON_DAYS = 365;
+const MAX_DURATION_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 // `is_allowed_roomcode_char` in room.rs (mirrored from `ALLOWED_ROOMCODE_CHARS` in
 // `data/processors/tumonline.py`).
@@ -19,6 +25,10 @@ const ARCH_NAME_RE = /^[A-Za-z0-9._-]+@\d{4}$/;
 
 // `is_valid_poi_key` in poi.rs: first char ascii-lowercase or digit; rest [a-z0-9_-].
 const POI_KEY_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+// `is_valid_event_key` in event.rs: the `event_` prefix followed by 1-64 lowercase hex chars (a
+// truncated content hash). The webclient derives this key from the image, so it is never typed.
+const EVENT_KEY_RE = /^event_[0-9a-f]{1,64}$/;
 
 const BUILDING_PREFIX_RE = /^\d{4}$/;
 
@@ -99,17 +109,108 @@ const newPoiSchema = z.object({
   coords: coordsSchema,
 });
 
+export const eventKeySchema = z
+  .string()
+  .min(1, "error.id_required")
+  .refine((k) => EVENT_KEY_RE.test(k), "error.event_key_format");
+
+const newEventSchema = z
+  .object({
+    kind: z.literal("event"),
+    id: eventKeySchema,
+    name: z
+      .string()
+      .max(MAX_NAME_LEN, "error.name_too_long")
+      .refine((s) => s.trim().length > 0, "error.name_required"),
+    description: z.string().refine((s) => s.trim().length > 0, "error.description_required"),
+    coords: coordsSchema,
+    // Events have no parent entry; their place on the map is the picked coordinate alone.
+    organising_org_id: z.number({ message: "error.org_required" }).int().positive(),
+    image: z.object({ base64: z.string() }).nullable(),
+    // Validated in the superRefine below (temporal rules / min-dimension), but declared here so the
+    // refinement can read them off the parsed draft.
+    starts_at: z.string(),
+    ends_at: z.string(),
+    image_width: z.number().nullable(),
+    image_height: z.number().nullable(),
+    image_author: z.string(),
+    image_license_text: z.string(),
+  })
+  .superRefine((draft, ctx) => {
+    // Temporal rules mirror `NewEvent::validate_temporal` in event.rs. Both ends are entered as
+    // Europe/Berlin wall-clock and only become RFC3339 here, so we validate the converted instants.
+    const startRfc = berlinWallTimeToRfc3339(draft.starts_at);
+    const endRfc = berlinWallTimeToRfc3339(draft.ends_at);
+    if (startRfc === null) {
+      ctx.addIssue({ code: "custom", path: ["starts_at"], message: "error.starts_at_required" });
+    }
+    if (endRfc === null) {
+      ctx.addIssue({ code: "custom", path: ["ends_at"], message: "error.ends_at_required" });
+    }
+    if (startRfc !== null && endRfc !== null) {
+      const start = Date.parse(startRfc);
+      const end = Date.parse(endRfc);
+      const now = Date.now();
+      if (end < start) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["ends_at"],
+          message: "error.event_ends_before_start",
+        });
+      } else if (end <= now) {
+        ctx.addIssue({ code: "custom", path: ["ends_at"], message: "error.event_ended" });
+      }
+      if (start > now + MAX_HORIZON_DAYS * DAY_MS) {
+        ctx.addIssue({ code: "custom", path: ["starts_at"], message: "error.event_too_far_out" });
+      }
+      if (end - start > MAX_DURATION_DAYS * DAY_MS) {
+        ctx.addIssue({ code: "custom", path: ["ends_at"], message: "error.event_too_long" });
+      }
+    }
+    if (!draft.image?.base64) {
+      ctx.addIssue({ code: "custom", path: ["image"], message: "error.image_required" });
+    } else if (
+      // Minimum-dimension check for instant feedback; the server re-decodes and re-checks the bytes.
+      draft.image_width !== null &&
+      draft.image_height !== null &&
+      Math.min(draft.image_width, draft.image_height) < MIN_IMAGE_DIM
+    ) {
+      ctx.addIssue({ code: "custom", path: ["image"], message: "error.image_too_small" });
+    }
+    if (!draft.image_author.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["image_author"],
+        message: "error.image_author_required",
+      });
+    }
+    if (!draft.image_license_text.trim()) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["image_license_text"],
+        message: "error.image_license_required",
+      });
+    }
+  });
+
 export type AdditionFieldErrors = Partial<Record<string, string>>;
+
+function schemaForKind(kind: NonNullable<AdditionDraft["kind"]>) {
+  switch (kind) {
+    case "room":
+      return newRoomSchema;
+    case "building":
+      return newBuildingSchema;
+    case "poi":
+      return newPoiSchema;
+    case "event":
+      return newEventSchema;
+  }
+}
 
 export function validateAddition(draft: AdditionDraft): AdditionFieldErrors {
   if (!draft.kind) return {};
-  const schema =
-    draft.kind === "room"
-      ? newRoomSchema
-      : draft.kind === "building"
-        ? newBuildingSchema
-        : newPoiSchema;
-  const result = schema.safeParse(draft);
+  const result = schemaForKind(draft.kind).safeParse(draft);
   if (result.success) return {};
   const errors: AdditionFieldErrors = {};
   for (const issue of result.error.issues) {
@@ -121,11 +222,5 @@ export function validateAddition(draft: AdditionDraft): AdditionFieldErrors {
 
 export function isAdditionValid(draft: AdditionDraft): boolean {
   if (!draft.kind) return false;
-  const schema =
-    draft.kind === "room"
-      ? newRoomSchema
-      : draft.kind === "building"
-        ? newBuildingSchema
-        : newPoiSchema;
-  return schema.safeParse(draft).success;
+  return schemaForKind(draft.kind).safeParse(draft).success;
 }

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -124,7 +124,6 @@ const newEventSchema = z
       .refine((s) => s.trim().length > 0, "error.name_required"),
     description: z.string().refine((s) => s.trim().length > 0, "error.description_required"),
     coords: coordsSchema,
-    // Events have no parent entry; their place on the map is the picked coordinate alone.
     organising_org_id: z.number({ message: "error.org_required" }).int().positive(),
     image: z.object({ base64: z.string() }).nullable(),
     // Validated in the superRefine below (temporal rules / min-dimension), but declared here so the
@@ -134,7 +133,6 @@ const newEventSchema = z
     image_width: z.number().nullable(),
     image_height: z.number().nullable(),
     image_author: z.string(),
-    image_license_text: z.string(),
   })
   .superRefine((draft, ctx) => {
     // Temporal rules mirror `NewEvent::validate_temporal` in event.rs. Both ends are entered as
@@ -182,13 +180,6 @@ const newEventSchema = z
         code: "custom",
         path: ["image_author"],
         message: "error.image_author_required",
-      });
-    }
-    if (!draft.image_license_text.trim()) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["image_license_text"],
-        message: "error.image_license_required",
       });
     }
   });

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -1,33 +1,18 @@
-// Zod schemas for the "propose a new entry" forms. These intentionally mirror the Rust validators
-// in `server/src/routes/feedback/proposed_edits/addition/{room,building,poi,event}.rs`. Whenever the
-// backend rules change, update both - the matching `case` in each Rust validator's rstest table
-// is the source of truth.
+// Mirrors the Rust validators in `server/src/routes/feedback/proposed_edits/addition/`.
 import { z } from "zod";
 import type { AdditionDraft } from "~/composables/editProposal";
 import { wallTimeToRfc3339 } from "~/utils/datetime";
 
-// Shared with `MAX_NAME_LEN` in the backend (room.rs / building.rs / poi.rs / event.rs).
 const MAX_NAME_LEN = 200;
-// Shared with `MAX_KEY_LEN` in poi.rs.
 const MAX_POI_KEY_LEN = 64;
-// Mirrors the constants in event.rs.
 const MIN_IMAGE_DIM = 256;
 const MAX_HORIZON_DAYS = 365;
 const MAX_DURATION_DAYS = 30;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// `is_allowed_roomcode_char` in room.rs (mirrored from `ALLOWED_ROOMCODE_CHARS` in
-// `data/processors/tumonline.py`).
 const ROOM_KEY_RE = /^[A-Za-z0-9.-]+$/;
-
-// `is_arch_name_valid` in room.rs.
 const ARCH_NAME_RE = /^[A-Za-z0-9._-]+@\d{4}$/;
-
-// `is_valid_poi_key` in poi.rs: first char ascii-lowercase or digit; rest [a-z0-9_-].
 const POI_KEY_RE = /^[a-z0-9][a-z0-9_-]*$/;
-
-// `is_valid_event_key` in event.rs: the `event_` prefix followed by 1-64 lowercase hex chars (a
-// truncated content hash). The webclient derives this key from the image, so it is never typed.
 const EVENT_KEY_RE = /^event_[0-9a-f]{1,64}$/;
 
 const BUILDING_PREFIX_RE = /^\d{4}$/;
@@ -126,8 +111,6 @@ const newEventSchema = z
     coords: coordsSchema,
     organising_org_id: z.number({ message: "error.org_required" }).int().positive(),
     image: z.object({ base64: z.string() }).nullable(),
-    // Validated in the superRefine below (temporal rules / min-dimension), but declared here so the
-    // refinement can read them off the parsed draft.
     starts_at: z.string(),
     ends_at: z.string(),
     image_width: z.number().nullable(),
@@ -135,8 +118,6 @@ const newEventSchema = z
     image_author: z.string(),
   })
   .superRefine((draft, ctx) => {
-    // Temporal rules mirror `NewEvent::validate_temporal` in event.rs. Both ends are picked as
-    // zoneless wall-clock and only become RFC3339 here, so we validate the converted instants.
     const startRfc = wallTimeToRfc3339(draft.starts_at);
     const endRfc = wallTimeToRfc3339(draft.ends_at);
     if (startRfc === null) {
@@ -168,7 +149,6 @@ const newEventSchema = z
     if (!draft.image?.base64) {
       ctx.addIssue({ code: "custom", path: ["image"], message: "error.image_required" });
     } else if (
-      // Minimum-dimension check for instant feedback; the server re-decodes and re-checks the bytes.
       draft.image_width !== null &&
       draft.image_height !== null &&
       Math.min(draft.image_width, draft.image_height) < MIN_IMAGE_DIM

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -4,7 +4,7 @@
 // is the source of truth.
 import { z } from "zod";
 import type { AdditionDraft } from "~/composables/editProposal";
-import { berlinWallTimeToRfc3339 } from "~/utils/datetime";
+import { wallTimeToRfc3339 } from "~/utils/datetime";
 
 // Shared with `MAX_NAME_LEN` in the backend (room.rs / building.rs / poi.rs / event.rs).
 const MAX_NAME_LEN = 200;
@@ -135,10 +135,10 @@ const newEventSchema = z
     image_author: z.string(),
   })
   .superRefine((draft, ctx) => {
-    // Temporal rules mirror `NewEvent::validate_temporal` in event.rs. Both ends are entered as
-    // Europe/Berlin wall-clock and only become RFC3339 here, so we validate the converted instants.
-    const startRfc = berlinWallTimeToRfc3339(draft.starts_at);
-    const endRfc = berlinWallTimeToRfc3339(draft.ends_at);
+    // Temporal rules mirror `NewEvent::validate_temporal` in event.rs. Both ends are picked as
+    // zoneless wall-clock and only become RFC3339 here, so we validate the converted instants.
+    const startRfc = wallTimeToRfc3339(draft.starts_at);
+    const endRfc = wallTimeToRfc3339(draft.ends_at);
     if (startRfc === null) {
       ctx.addIssue({ code: "custom", path: ["starts_at"], message: "error.starts_at_required" });
     }

--- a/webclient/app/composables/editProposal.ts
+++ b/webclient/app/composables/editProposal.ts
@@ -7,7 +7,7 @@ type EditRequestData = Omit<EditRequest, "privacy_checked" | "token" | "edits" |
   additions: NonNullable<EditRequest["additions"]>;
 };
 type BuildingKind = components["schemas"]["BuildingKind"];
-type AdditionKind = "room" | "building" | "poi";
+type AdditionKind = "room" | "building" | "poi" | "event";
 
 interface LinkDraft {
   text_de: string;
@@ -47,6 +47,21 @@ interface AdditionDraft {
   comment_en: string;
   poi_links: LinkDraft[];
   generic_props: GenericPropDraft[];
+  // event-only. `name` (shared) carries the event title; `description` is single-language and
+  // rendered verbatim. `starts_at`/`ends_at` hold the `datetime-local` wall value (Europe/Berlin),
+  // converted to RFC3339 only at submit time. The image rides inline in the addition (unlike the
+  // separate image edit used for room/building/poi), so its bytes + author/license live here, and
+  // `image_width`/`image_height` back the client-side minimum-dimension check.
+  description: string;
+  starts_at: string;
+  ends_at: string;
+  organising_org_id: number | null;
+  image: { base64: string; fileName: string } | null;
+  image_width: number | null;
+  image_height: number | null;
+  image_author: string;
+  image_license_text: string;
+  image_license_url: string;
 }
 
 interface PropertyFields {
@@ -127,6 +142,16 @@ function emptyAdditionDraft(): AdditionDraft {
     comment_en: "",
     poi_links: [],
     generic_props: [],
+    description: "",
+    starts_at: "",
+    ends_at: "",
+    organising_org_id: null,
+    image: null,
+    image_width: null,
+    image_height: null,
+    image_author: "",
+    image_license_text: "CC BY 4.0",
+    image_license_url: "https://creativecommons.org/licenses/by/4.0/",
   };
 }
 

--- a/webclient/app/composables/editProposal.ts
+++ b/webclient/app/composables/editProposal.ts
@@ -47,12 +47,10 @@ interface AdditionDraft {
   comment_en: string;
   poi_links: LinkDraft[];
   generic_props: GenericPropDraft[];
-  // event-only. `name` (shared) carries the event title; `description` is single-language and
-  // rendered verbatim. `starts_at`/`ends_at` hold the `datetime-local` wall value (Europe/Berlin),
-  // converted to RFC3339 only at submit time. The image rides inline in the addition (unlike the
-  // separate image edit used for room/building/poi), so its bytes + author/license live here, and
-  // `image_width`/`image_height` back the client-side minimum-dimension check, and
-  // `image_thumb_offset` is the chosen `offsets.thumb` (source-pixel slide of the square thumb crop).
+  // event-only (`name` is shared). The image rides inline in the addition rather than as a separate
+  // edit, so its bytes, author, and chosen crop offsets live here. The license is fixed to CC BY 4.0
+  // (set at submit time). `starts_at`/`ends_at` hold the `datetime-local` wall value, converted to
+  // RFC3339 at submit time.
   description: string;
   starts_at: string;
   ends_at: string;
@@ -61,9 +59,8 @@ interface AdditionDraft {
   image_width: number | null;
   image_height: number | null;
   image_thumb_offset: number;
+  image_header_offset: number;
   image_author: string;
-  image_license_text: string;
-  image_license_url: string;
 }
 
 interface PropertyFields {
@@ -152,9 +149,8 @@ function emptyAdditionDraft(): AdditionDraft {
     image_width: null,
     image_height: null,
     image_thumb_offset: 0,
+    image_header_offset: 0,
     image_author: "",
-    image_license_text: "CC BY 4.0",
-    image_license_url: "https://creativecommons.org/licenses/by/4.0/",
   };
 }
 

--- a/webclient/app/composables/editProposal.ts
+++ b/webclient/app/composables/editProposal.ts
@@ -47,10 +47,7 @@ interface AdditionDraft {
   comment_en: string;
   poi_links: LinkDraft[];
   generic_props: GenericPropDraft[];
-  // event-only (`name` is shared). The image rides inline in the addition rather than as a separate
-  // edit, so its bytes, author, and chosen crop offsets live here. The license is fixed to CC BY 4.0
-  // (set at submit time). `starts_at`/`ends_at` hold the `datetime-local` wall value, converted to
-  // RFC3339 at submit time.
+  // event-only
   description: string;
   starts_at: string;
   ends_at: string;

--- a/webclient/app/composables/editProposal.ts
+++ b/webclient/app/composables/editProposal.ts
@@ -51,7 +51,8 @@ interface AdditionDraft {
   // rendered verbatim. `starts_at`/`ends_at` hold the `datetime-local` wall value (Europe/Berlin),
   // converted to RFC3339 only at submit time. The image rides inline in the addition (unlike the
   // separate image edit used for room/building/poi), so its bytes + author/license live here, and
-  // `image_width`/`image_height` back the client-side minimum-dimension check.
+  // `image_width`/`image_height` back the client-side minimum-dimension check, and
+  // `image_thumb_offset` is the chosen `offsets.thumb` (source-pixel slide of the square thumb crop).
   description: string;
   starts_at: string;
   ends_at: string;
@@ -59,6 +60,7 @@ interface AdditionDraft {
   image: { base64: string; fileName: string } | null;
   image_width: number | null;
   image_height: number | null;
+  image_thumb_offset: number;
   image_author: string;
   image_license_text: string;
   image_license_url: string;
@@ -149,6 +151,7 @@ function emptyAdditionDraft(): AdditionDraft {
     image: null,
     image_width: null,
     image_height: null,
+    image_thumb_offset: 0,
     image_author: "",
     image_license_text: "CC BY 4.0",
     image_license_url: "https://creativecommons.org/licenses/by/4.0/",

--- a/webclient/app/composables/useKnownOrgs.ts
+++ b/webclient/app/composables/useKnownOrgs.ts
@@ -6,22 +6,14 @@ interface KnownOrg {
 }
 
 export interface OrgOption {
-  /** numeric primary key submitted as `events.organising_org_id`; required for an event addition. */
   org_id: number;
-  /** TUMonline org code, the disambiguator for the ~100 orgs that share a localized name. */
   code: string;
-  /** localized display name */
   label: string;
-  /** the other-language name, used for searching */
   altLabel: string;
-  /** raw German name, kept so the event popup can switch language independently of the picker's locale. */
   nameDe: string;
-  /** raw English name, kept so the event popup can switch language independently of the picker's locale. */
   nameEn: string;
 }
 
-// The org tree has ~2.3k entries; rendering them all into the combobox on an empty query is
-// needless. Cap the visible matches and let the user narrow by typing.
 const MAX_RESULTS = 50;
 
 export function useKnownOrgs() {

--- a/webclient/app/composables/useKnownOrgs.ts
+++ b/webclient/app/composables/useKnownOrgs.ts
@@ -14,6 +14,10 @@ export interface OrgOption {
   label: string;
   /** the other-language name, used for searching */
   altLabel: string;
+  /** raw German name, kept so the event popup can switch language independently of the picker's locale. */
+  nameDe: string;
+  /** raw English name, kept so the event popup can switch language independently of the picker's locale. */
+  nameEn: string;
 }
 
 // The org tree has ~2.3k entries; rendering them all into the combobox on an empty query is
@@ -42,6 +46,8 @@ export function useKnownOrgs() {
       code: o.code,
       label: isDe ? o.name_de : o.name_en,
       altLabel: isDe ? o.name_en : o.name_de,
+      nameDe: o.name_de,
+      nameEn: o.name_en,
     }));
   });
 

--- a/webclient/app/composables/useKnownOrgs.ts
+++ b/webclient/app/composables/useKnownOrgs.ts
@@ -1,0 +1,75 @@
+interface KnownOrg {
+  org_id: number;
+  code: string;
+  name_de: string;
+  name_en: string;
+}
+
+export interface OrgOption {
+  /** numeric primary key submitted as `events.organising_org_id`; required for an event addition. */
+  org_id: number;
+  /** TUMonline org code, the disambiguator for the ~100 orgs that share a localized name. */
+  code: string;
+  /** localized display name */
+  label: string;
+  /** the other-language name, used for searching */
+  altLabel: string;
+}
+
+// The org tree has ~2.3k entries; rendering them all into the combobox on an empty query is
+// needless. Cap the visible matches and let the user narrow by typing.
+const MAX_RESULTS = 50;
+
+export function useKnownOrgs() {
+  const { locale } = useI18n();
+  const runtimeConfig = useRuntimeConfig();
+
+  const { data, pending, error, refresh } = useFetch<KnownOrg[]>(
+    `${runtimeConfig.public.cdnURL}/cdn/known_orgs.json`,
+    {
+      key: "known-orgs",
+      server: true,
+      lazy: true,
+      default: () => [],
+    }
+  );
+
+  const options = computed<OrgOption[]>(() => {
+    const isDe = locale.value === "de";
+
+    return (data.value ?? []).map((o) => ({
+      org_id: o.org_id,
+      code: o.code,
+      label: isDe ? o.name_de : o.name_en,
+      altLabel: isDe ? o.name_en : o.name_de,
+    }));
+  });
+
+  function byId(id: number | null): OrgOption | null {
+    if (id === null) return null;
+    return options.value.find((o) => o.org_id === id) ?? null;
+  }
+
+  function filter(query: string): OrgOption[] {
+    const q = query.trim().toLowerCase();
+    const matches = q
+      ? options.value.filter(
+          (o) =>
+            o.label.toLowerCase().includes(q) ||
+            o.altLabel.toLowerCase().includes(q) ||
+            o.code.toLowerCase().includes(q)
+        )
+      : options.value;
+    return matches.slice(0, MAX_RESULTS);
+  }
+
+  return {
+    options,
+    pending,
+    error,
+    refresh,
+    byId,
+    filter,
+    maxResults: MAX_RESULTS,
+  };
+}

--- a/webclient/app/composables/userPreferences.ts
+++ b/webclient/app/composables/userPreferences.ts
@@ -16,11 +16,8 @@ const defaultPreferences: UserRoutingPreferences = {
 };
 
 export const useUserPreferences = () => {
-  // No `default` factory: that would make `useCookie` write the default back during SSR, and on
-  // `swr`-cached routes (see `routeRules` in `nuxt.config.ts`) that bakes a per-user `Set-Cookie`
-  // into the shared response - leaking values across visitors and crashing Nitro with "Cannot
-  // append headers after they are sent to the client". The defaults are merged in app code instead,
-  // so the server only ever reads this cookie and the client is the sole writer.
+  // A `default` factory would write the default back during SSR, baking a per-user `Set-Cookie`
+  // into `swr`-cached shared responses (see PR #3147). Merge defaults client-side instead.
   const stored = useCookie<Partial<UserRoutingPreferences> | null>("user-routing-preferences", {
     sameSite: "lax",
     secure: import.meta.env.PROD,

--- a/webclient/app/utils/datetime.ts
+++ b/webclient/app/utils/datetime.ts
@@ -48,7 +48,7 @@ export function berlinWallTimeToRfc3339(wall: string): string | null {
   const hour = wall.slice(11, 13);
   const minute = wall.slice(14, 16);
   // Treat the wall components as if they were UTC to get a first instant, read Berlin's offset
-  // there, then re-read it at the corrected instant (wall − offset) to settle around DST cutovers.
+  // there, then re-read it at the corrected instant (wall - offset) to settle around DST cutovers.
   const wallAsUtcMs = Date.UTC(
     Number(year),
     Number(month) - 1,

--- a/webclient/app/utils/datetime.ts
+++ b/webclient/app/utils/datetime.ts
@@ -1,10 +1,3 @@
-// Turns a browser `datetime-local` value (a zoneless `YYYY-MM-DDTHH:MM` wall-clock string) into the
-// RFC3339 contract the server's event validator parses
-// (`server/src/routes/feedback/proposed_edits/addition/event.rs`). `datetime-local` represents the
-// time the user picked in their own browser timezone, so `new Date` parses it in that zone and we
-// hand the server the equivalent UTC instant (which it stores as UTC anyway). Returns `null` for
-// malformed input so callers can surface a validation error.
-
 export function wallTimeToRfc3339(wall: string): string | null {
   const instant = new Date(wall);
   return Number.isNaN(instant.getTime()) ? null : instant.toISOString();

--- a/webclient/app/utils/datetime.ts
+++ b/webclient/app/utils/datetime.ts
@@ -1,62 +1,11 @@
-// Helpers for turning a browser `datetime-local` value into the RFC3339 contract the server's
-// event validator parses (`server/src/routes/feedback/proposed_edits/addition/event.rs`). A
-// `datetime-local` input yields a wall-clock string with no zone (`YYYY-MM-DDTHH:MM`); event
-// times are entered as Munich wall-clock, so we stamp them with Europe/Berlin's actual UTC offset
-// at that instant (DST-aware).
+// Turns a browser `datetime-local` value (a zoneless `YYYY-MM-DDTHH:MM` wall-clock string) into the
+// RFC3339 contract the server's event validator parses
+// (`server/src/routes/feedback/proposed_edits/addition/event.rs`). `datetime-local` represents the
+// time the user picked in their own browser timezone, so `new Date` parses it in that zone and we
+// hand the server the equivalent UTC instant (which it stores as UTC anyway). Returns `null` for
+// malformed input so callers can surface a validation error.
 
-const WALL_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/;
-// `longOffset` renders "GMT+02:00"; a zero offset can render as a bare "GMT".
-const GMT_OFFSET_RE = /GMT([+-])(\d{2}):(\d{2})/;
-
-// Europe/Berlin's offset (in minutes east of UTC) in effect at the given instant, read from the
-// IANA database via Intl rather than hard-coded so the DST cutover dates stay correct over time.
-function berlinOffsetMinutesAt(date: Date): number {
-  const tzName = new Intl.DateTimeFormat("en-US", {
-    timeZone: "Europe/Berlin",
-    timeZoneName: "longOffset",
-  })
-    .formatToParts(date)
-    .find((p) => p.type === "timeZoneName")?.value;
-  const match = GMT_OFFSET_RE.exec(tzName ?? "");
-  if (!match) return 0;
-  const sign = match[1] === "+" ? 1 : -1;
-  return sign * (Number(match[2]) * 60 + Number(match[3]));
-}
-
-function formatOffset(minutes: number): string {
-  const sign = minutes >= 0 ? "+" : "-";
-  const abs = Math.abs(minutes);
-  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
-  const mm = String(abs % 60).padStart(2, "0");
-  return `${sign}${hh}:${mm}`;
-}
-
-/**
- * Interpret a `datetime-local` wall-clock value as Europe/Berlin local time and render it as
- * RFC3339 with the matching offset, e.g. `2026-06-10T16:00` → `2026-06-10T16:00:00+02:00`.
- * Returns `null` for malformed input so callers can surface a validation error.
- *
- * Wall times that fall in a DST gap/overlap are inherently ambiguous; the two-pass settle below
- * resolves the common case, and such inputs only occur in the one missing/duplicated hour a year.
- */
-export function berlinWallTimeToRfc3339(wall: string): string | null {
-  if (!WALL_TIME_RE.test(wall)) return null;
-  // Fixed-width `YYYY-MM-DDTHH:MM` slices; the regex above guarantees the layout.
-  const year = wall.slice(0, 4);
-  const month = wall.slice(5, 7);
-  const day = wall.slice(8, 10);
-  const hour = wall.slice(11, 13);
-  const minute = wall.slice(14, 16);
-  // Treat the wall components as if they were UTC to get a first instant, read Berlin's offset
-  // there, then re-read it at the corrected instant (wall - offset) to settle around DST cutovers.
-  const wallAsUtcMs = Date.UTC(
-    Number(year),
-    Number(month) - 1,
-    Number(day),
-    Number(hour),
-    Number(minute)
-  );
-  const firstGuess = berlinOffsetMinutesAt(new Date(wallAsUtcMs));
-  const offset = berlinOffsetMinutesAt(new Date(wallAsUtcMs - firstGuess * 60_000));
-  return `${year}-${month}-${day}T${hour}:${minute}:00${formatOffset(offset)}`;
+export function wallTimeToRfc3339(wall: string): string | null {
+  const instant = new Date(wall);
+  return Number.isNaN(instant.getTime()) ? null : instant.toISOString();
 }

--- a/webclient/app/utils/datetime.ts
+++ b/webclient/app/utils/datetime.ts
@@ -1,0 +1,62 @@
+// Helpers for turning a browser `datetime-local` value into the RFC3339 contract the server's
+// event validator parses (`server/src/routes/feedback/proposed_edits/addition/event.rs`). A
+// `datetime-local` input yields a wall-clock string with no zone (`YYYY-MM-DDTHH:MM`); event
+// times are entered as Munich wall-clock, so we stamp them with Europe/Berlin's actual UTC offset
+// at that instant (DST-aware).
+
+const WALL_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/;
+// `longOffset` renders "GMT+02:00"; a zero offset can render as a bare "GMT".
+const GMT_OFFSET_RE = /GMT([+-])(\d{2}):(\d{2})/;
+
+// Europe/Berlin's offset (in minutes east of UTC) in effect at the given instant, read from the
+// IANA database via Intl rather than hard-coded so the DST cutover dates stay correct over time.
+function berlinOffsetMinutesAt(date: Date): number {
+  const tzName = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Berlin",
+    timeZoneName: "longOffset",
+  })
+    .formatToParts(date)
+    .find((p) => p.type === "timeZoneName")?.value;
+  const match = GMT_OFFSET_RE.exec(tzName ?? "");
+  if (!match) return 0;
+  const sign = match[1] === "+" ? 1 : -1;
+  return sign * (Number(match[2]) * 60 + Number(match[3]));
+}
+
+function formatOffset(minutes: number): string {
+  const sign = minutes >= 0 ? "+" : "-";
+  const abs = Math.abs(minutes);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
+  return `${sign}${hh}:${mm}`;
+}
+
+/**
+ * Interpret a `datetime-local` wall-clock value as Europe/Berlin local time and render it as
+ * RFC3339 with the matching offset, e.g. `2026-06-10T16:00` → `2026-06-10T16:00:00+02:00`.
+ * Returns `null` for malformed input so callers can surface a validation error.
+ *
+ * Wall times that fall in a DST gap/overlap are inherently ambiguous; the two-pass settle below
+ * resolves the common case, and such inputs only occur in the one missing/duplicated hour a year.
+ */
+export function berlinWallTimeToRfc3339(wall: string): string | null {
+  if (!WALL_TIME_RE.test(wall)) return null;
+  // Fixed-width `YYYY-MM-DDTHH:MM` slices; the regex above guarantees the layout.
+  const year = wall.slice(0, 4);
+  const month = wall.slice(5, 7);
+  const day = wall.slice(8, 10);
+  const hour = wall.slice(11, 13);
+  const minute = wall.slice(14, 16);
+  // Treat the wall components as if they were UTC to get a first instant, read Berlin's offset
+  // there, then re-read it at the corrected instant (wall − offset) to settle around DST cutovers.
+  const wallAsUtcMs = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute)
+  );
+  const firstGuess = berlinOffsetMinutesAt(new Date(wallAsUtcMs));
+  const offset = berlinOffsetMinutesAt(new Date(wallAsUtcMs - firstGuess * 60_000));
+  return `${year}-${month}-${day}T${hour}:${minute}:00${formatOffset(offset)}`;
+}

--- a/webclient/app/utils/imageCrop.ts
+++ b/webclient/app/utils/imageCrop.ts
@@ -92,17 +92,17 @@ export function cropRect(
 }
 
 /**
- * Renders the offset crop at the target's pixel dimensions as an `image/webp` blob URL - the same
- * output the pipeline produces - so the form can preview exactly what will be generated. The caller
- * owns revoking the returned URL.
+ * Renders the offset crop at the target's pixel dimensions as an `image/webp` blob - the same
+ * output the pipeline produces - so the form can preview exactly what will be generated. Pair with
+ * `useObjectUrl` so the URL's lifetime tracks the blob without manual revoke bookkeeping.
  */
-export function cropToBlobUrl(
-  image: HTMLImageElement,
+export function cropToBlob(
+  image: CanvasImageSource,
   width: number,
   height: number,
   target: CropTarget,
   offset: number
-): Promise<string | null> {
+): Promise<Blob | null> {
   const rect = cropRect(width, height, target, offset);
   const canvas = document.createElement("canvas");
   canvas.width = target.width;
@@ -110,7 +110,5 @@ export function cropToBlobUrl(
   const ctx = canvas.getContext("2d");
   if (!ctx) return Promise.resolve(null);
   ctx.drawImage(image, rect.x, rect.y, rect.width, rect.height, 0, 0, target.width, target.height);
-  return new Promise((resolve) => {
-    canvas.toBlob((blob) => resolve(blob ? URL.createObjectURL(blob) : null), "image/webp", 0.9);
-  });
+  return new Promise((resolve) => canvas.toBlob(resolve, "image/webp", 0.9));
 }

--- a/webclient/app/utils/imageCrop.ts
+++ b/webclient/app/utils/imageCrop.ts
@@ -1,60 +1,123 @@
-// Mirrors `Resizer.resize_to_fixed_size` in `data/processors/images.py`: the square thumb the event
-// marker renders is `min(width, height)` per side and slides along the longer axis by an integer
-// `offset` of source pixels (`offsets.thumb` in `img-sources.yaml`). `offset = 0` centres it. These
-// helpers reproduce that crop so the submission form can pick the offset with a faithful preview.
+// Mirrors `Resizer.resize_to_fixed_size` in `data/processors/images.py`: a crop of the target's
+// aspect ratio is taken from the source and slid along the over-long axis by an integer `offset` of
+// source pixels (`offsets.thumb` / `offsets.header` in `img-sources.yaml`). `offset = 0` centres it.
+// The pipeline emits a 256² thumb and a 512×210 header; these helpers reproduce that crop so the
+// submission form can pick each offset with a faithful preview.
 
-export interface ThumbCropRect {
-  /** left edge of the crop square, in source pixels */
+export interface CropTarget {
+  width: number;
+  height: number;
+}
+
+export const THUMB_TARGET: CropTarget = { width: 256, height: 256 };
+export const HEADER_TARGET: CropTarget = { width: 512, height: 210 };
+
+export type CropAxis = "horizontal" | "vertical" | "none";
+
+export interface CropRect {
   x: number;
-  /** top edge of the crop square, in source pixels */
   y: number;
-  /** side length of the (square) crop, in source pixels */
-  size: number;
+  width: number;
+  height: number;
+}
+
+interface CropGeometry {
+  axis: CropAxis;
+  width: number;
+  height: number;
+}
+
+// The crop rectangle's size and the axis it travels along, before the offset is applied. Matches the
+// `int(new_width / 2)` truncation the pipeline uses, so the dimensions are even.
+function cropGeometry(width: number, height: number, target: CropTarget): CropGeometry {
+  const targetAspect = target.width / target.height;
+  const sourceAspect = width / height;
+  if (targetAspect < sourceAspect) {
+    // Source is wider than the target: crop the width, keep full height, slide horizontally.
+    return { axis: "horizontal", width: 2 * Math.floor((targetAspect * height) / 2), height };
+  }
+  if (targetAspect > sourceAspect) {
+    // Source is taller than the target: crop the height, keep full width, slide vertically.
+    return { axis: "vertical", width, height: 2 * Math.floor(width / targetAspect / 2) };
+  }
+  return { axis: "none", width, height };
+}
+
+export function cropAxis(width: number, height: number, target: CropTarget): CropAxis {
+  return cropGeometry(width, height, target).axis;
 }
 
 /**
- * The inclusive `[-max, max]` range an offset may take before the crop square would leave the
- * image. A square source has `max = 0` (nothing to choose).
+ * The inclusive `[-max, max]` range an offset may take before the crop would leave the image. A
+ * source already matching the target aspect ratio has `max = 0` (nothing to choose).
  */
-export function thumbOffsetBounds(width: number, height: number): { max: number } {
-  return { max: Math.floor(Math.abs(width - height) / 2) };
+export function cropOffsetBounds(
+  width: number,
+  height: number,
+  target: CropTarget
+): { max: number } {
+  const geo = cropGeometry(width, height, target);
+  if (geo.axis === "horizontal") return { max: Math.floor((width - geo.width) / 2) };
+  if (geo.axis === "vertical") return { max: Math.floor((height - geo.height) / 2) };
+  return { max: 0 };
 }
 
-export function clampThumbOffset(width: number, height: number, offset: number): number {
-  const { max } = thumbOffsetBounds(width, height);
+export function clampCropOffset(
+  width: number,
+  height: number,
+  target: CropTarget,
+  offset: number
+): number {
+  const { max } = cropOffsetBounds(width, height, target);
   return Math.max(-max, Math.min(max, Math.round(offset)));
 }
 
-export function thumbCropRect(width: number, height: number, offset: number): ThumbCropRect {
-  const size = Math.min(width, height);
-  const clamped = clampThumbOffset(width, height, offset);
-  if (width >= height) {
-    // Landscape (or square): the square slides horizontally; full height is kept.
-    return { x: Math.floor(width / 2) - Math.floor(size / 2) + clamped, y: 0, size };
+export function cropRect(
+  width: number,
+  height: number,
+  target: CropTarget,
+  offset: number
+): CropRect {
+  const geo = cropGeometry(width, height, target);
+  const clamped = clampCropOffset(width, height, target, offset);
+  if (geo.axis === "horizontal") {
+    return {
+      x: Math.floor(width / 2) - Math.floor(geo.width / 2) + clamped,
+      y: 0,
+      width: geo.width,
+      height,
+    };
   }
-  // Portrait: the square slides vertically; full width is kept.
-  return { x: 0, y: Math.floor(height / 2) - Math.floor(size / 2) + clamped, size };
+  if (geo.axis === "vertical") {
+    return {
+      x: 0,
+      y: Math.floor(height / 2) - Math.floor(geo.height / 2) + clamped,
+      width,
+      height: geo.height,
+    };
+  }
+  return { x: 0, y: 0, width, height };
 }
 
 /**
- * Renders the offset crop to a 256×256 `image/webp` blob URL - the same dimensions the pipeline
- * emits - so the live map marker shows exactly what will be generated. The caller owns revoking the
- * returned URL.
+ * Renders the offset crop at the target's pixel dimensions as an `image/webp` blob URL - the same
+ * output the pipeline produces - so the form can preview exactly what will be generated. The caller
+ * owns revoking the returned URL.
  */
-export function cropToThumbBlobUrl(
+export function cropToBlobUrl(
   image: HTMLImageElement,
   width: number,
   height: number,
-  offset: number,
-  outSize = 256
+  target: CropTarget,
+  offset: number
 ): Promise<string | null> {
-  const { x, y, size } = thumbCropRect(width, height, offset);
+  const rect = cropRect(width, height, target, offset);
   const canvas = document.createElement("canvas");
-  canvas.width = outSize;
-  canvas.height = outSize;
+  canvas.width = target.width;
+  canvas.height = target.height;
   const ctx = canvas.getContext("2d");
   if (!ctx) return Promise.resolve(null);
-  ctx.drawImage(image, x, y, size, size, 0, 0, outSize, outSize);
+  ctx.drawImage(image, rect.x, rect.y, rect.width, rect.height, 0, 0, target.width, target.height);
   return new Promise((resolve) => {
     canvas.toBlob((blob) => resolve(blob ? URL.createObjectURL(blob) : null), "image/webp", 0.9);
   });

--- a/webclient/app/utils/imageCrop.ts
+++ b/webclient/app/utils/imageCrop.ts
@@ -1,8 +1,4 @@
-// Mirrors `Resizer.resize_to_fixed_size` in `data/processors/images.py`: a crop of the target's
-// aspect ratio is taken from the source and slid along the over-long axis by an integer `offset` of
-// source pixels (`offsets.thumb` / `offsets.header` in `img-sources.yaml`). `offset = 0` centres it.
-// The pipeline emits a 256² thumb and a 512×210 header; these helpers reproduce that crop so the
-// submission form can pick each offset with a faithful preview.
+// Mirrors `Resizer.resize_to_fixed_size` in `data/processors/images.py`.
 
 export interface CropTarget {
   width: number;
@@ -27,17 +23,13 @@ interface CropGeometry {
   height: number;
 }
 
-// The crop rectangle's size and the axis it travels along, before the offset is applied. Matches the
-// `int(new_width / 2)` truncation the pipeline uses, so the dimensions are even.
 function cropGeometry(width: number, height: number, target: CropTarget): CropGeometry {
   const targetAspect = target.width / target.height;
   const sourceAspect = width / height;
   if (targetAspect < sourceAspect) {
-    // Source is wider than the target: crop the width, keep full height, slide horizontally.
     return { axis: "horizontal", width: 2 * Math.floor((targetAspect * height) / 2), height };
   }
   if (targetAspect > sourceAspect) {
-    // Source is taller than the target: crop the height, keep full width, slide vertically.
     return { axis: "vertical", width, height: 2 * Math.floor(width / targetAspect / 2) };
   }
   return { axis: "none", width, height };

--- a/webclient/app/utils/imageCrop.ts
+++ b/webclient/app/utils/imageCrop.ts
@@ -1,0 +1,61 @@
+// Mirrors `Resizer.resize_to_fixed_size` in `data/processors/images.py`: the square thumb the event
+// marker renders is `min(width, height)` per side and slides along the longer axis by an integer
+// `offset` of source pixels (`offsets.thumb` in `img-sources.yaml`). `offset = 0` centres it. These
+// helpers reproduce that crop so the submission form can pick the offset with a faithful preview.
+
+export interface ThumbCropRect {
+  /** left edge of the crop square, in source pixels */
+  x: number;
+  /** top edge of the crop square, in source pixels */
+  y: number;
+  /** side length of the (square) crop, in source pixels */
+  size: number;
+}
+
+/**
+ * The inclusive `[-max, max]` range an offset may take before the crop square would leave the
+ * image. A square source has `max = 0` (nothing to choose).
+ */
+export function thumbOffsetBounds(width: number, height: number): { max: number } {
+  return { max: Math.floor(Math.abs(width - height) / 2) };
+}
+
+export function clampThumbOffset(width: number, height: number, offset: number): number {
+  const { max } = thumbOffsetBounds(width, height);
+  return Math.max(-max, Math.min(max, Math.round(offset)));
+}
+
+export function thumbCropRect(width: number, height: number, offset: number): ThumbCropRect {
+  const size = Math.min(width, height);
+  const clamped = clampThumbOffset(width, height, offset);
+  if (width >= height) {
+    // Landscape (or square): the square slides horizontally; full height is kept.
+    return { x: Math.floor(width / 2) - Math.floor(size / 2) + clamped, y: 0, size };
+  }
+  // Portrait: the square slides vertically; full width is kept.
+  return { x: 0, y: Math.floor(height / 2) - Math.floor(size / 2) + clamped, size };
+}
+
+/**
+ * Renders the offset crop to a 256×256 `image/webp` blob URL — the same dimensions the pipeline
+ * emits — so the live map marker shows exactly what will be generated. The caller owns revoking the
+ * returned URL.
+ */
+export function cropToThumbBlobUrl(
+  image: HTMLImageElement,
+  width: number,
+  height: number,
+  offset: number,
+  outSize = 256
+): Promise<string | null> {
+  const { x, y, size } = thumbCropRect(width, height, offset);
+  const canvas = document.createElement("canvas");
+  canvas.width = outSize;
+  canvas.height = outSize;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return Promise.resolve(null);
+  ctx.drawImage(image, x, y, size, size, 0, 0, outSize, outSize);
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob ? URL.createObjectURL(blob) : null), "image/webp", 0.9);
+  });
+}

--- a/webclient/app/utils/imageCrop.ts
+++ b/webclient/app/utils/imageCrop.ts
@@ -37,8 +37,8 @@ export function thumbCropRect(width: number, height: number, offset: number): Th
 }
 
 /**
- * Renders the offset crop to a 256×256 `image/webp` blob URL — the same dimensions the pipeline
- * emits — so the live map marker shows exactly what will be generated. The caller owns revoking the
+ * Renders the offset crop to a 256×256 `image/webp` blob URL - the same dimensions the pipeline
+ * emits - so the live map marker shows exactly what will be generated. The caller owns revoking the
  * returned URL.
  */
 export function cropToThumbBlobUrl(

--- a/webclient/app/utils/iris.ts
+++ b/webclient/app/utils/iris.ts
@@ -104,7 +104,7 @@ export function parseIrisRooms(json: unknown): IrisRoom[] {
   return rooms;
 }
 
-/** A joined building (e.g. MI) passes every covered finger id, so its page unions them. */
+/** Keep only the rooms Iris attributes to one of `buildingIds`. */
 export function roomsForBuildings(
   rooms: readonly IrisRoom[],
   buildingIds: readonly string[]

--- a/webclient/test/additionSchema.event.test.ts
+++ b/webclient/test/additionSchema.event.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { validateAddition } from "../app/composables/additionSchema";
+import { type AdditionDraft, emptyAdditionDraft } from "../app/composables/editProposal";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// A `datetime-local` wall string `now + offsetDays`. Built from the machine's local clock; the
+// schema reads it as Europe/Berlin, but every threshold here is days wide, so the <=2h tz skew is
+// irrelevant.
+function wall(offsetDays: number): string {
+  const d = new Date(Date.now() + offsetDays * DAY_MS);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function validEvent(overrides: Partial<AdditionDraft> = {}): AdditionDraft {
+  return {
+    ...emptyAdditionDraft(),
+    kind: "event",
+    id: "event_9d02ddd940c43f87",
+    name: "GARNIX Festival",
+    description: "Live music, food trucks, and stands.",
+    starts_at: wall(2),
+    ends_at: wall(3),
+    coords: { lat: 48.262908, lon: 11.669102, picked: true },
+    organising_org_id: 51897,
+    image: { base64: "Zm9v", fileName: "event.png" },
+    image_width: 300,
+    image_height: 300,
+    image_author: "Studi",
+    image_license_text: "CC BY 4.0",
+    image_license_url: "",
+    ...overrides,
+  };
+}
+
+describe("validateAddition (event)", () => {
+  it("accepts a well-formed event", () => {
+    expect(validateAddition(validEvent())).toEqual({});
+  });
+
+  // Mirrors the `validate_failure_cases` rstest table in
+  // `server/src/routes/feedback/proposed_edits/addition/event.rs`.
+  it.each([
+    ["bad key", { id: "event_NOTHEX" }, "id", "error.event_key_format"],
+    ["missing prefix", { id: "9d02ddd940c43f87" }, "id", "error.event_key_format"],
+    ["empty name", { name: "  " }, "name", "error.name_required"],
+    ["empty description", { description: "" }, "description", "error.description_required"],
+    ["unpicked coords", { coords: { lat: 0, lon: 0, picked: false } }, "coords.picked", "error.coords_required"],
+    ["no org", { organising_org_id: null }, "organising_org_id", "error.org_required"],
+    ["no image", { image: null }, "image", "error.image_required"],
+    ["image too small", { image_width: 100, image_height: 100 }, "image", "error.image_too_small"],
+    ["ends before start", { starts_at: wall(3), ends_at: wall(2) }, "ends_at", "error.event_ends_before_start"],
+    ["already ended", { starts_at: wall(-3), ends_at: wall(-2) }, "ends_at", "error.event_ended"],
+    ["too far out", { starts_at: wall(400), ends_at: wall(401) }, "starts_at", "error.event_too_far_out"],
+    ["too long", { starts_at: wall(2), ends_at: wall(40) }, "ends_at", "error.event_too_long"],
+    ["missing author", { image_author: "" }, "image_author", "error.image_author_required"],
+    ["missing license", { image_license_text: "" }, "image_license_text", "error.image_license_required"],
+  ] as const)("rejects %s", (_label, overrides, path, message) => {
+    expect(validateAddition(validEvent(overrides))[path]).toBe(message);
+  });
+});

--- a/webclient/test/additionSchema.event.test.ts
+++ b/webclient/test/additionSchema.event.test.ts
@@ -46,16 +46,36 @@ describe("validateAddition (event)", () => {
     ["missing prefix", { id: "9d02ddd940c43f87" }, "id", "error.event_key_format"],
     ["empty name", { name: "  " }, "name", "error.name_required"],
     ["empty description", { description: "" }, "description", "error.description_required"],
-    ["unpicked coords", { coords: { lat: 0, lon: 0, picked: false } }, "coords.picked", "error.coords_required"],
+    [
+      "unpicked coords",
+      { coords: { lat: 0, lon: 0, picked: false } },
+      "coords.picked",
+      "error.coords_required",
+    ],
     ["no org", { organising_org_id: null }, "organising_org_id", "error.org_required"],
     ["no image", { image: null }, "image", "error.image_required"],
     ["image too small", { image_width: 100, image_height: 100 }, "image", "error.image_too_small"],
-    ["ends before start", { starts_at: wall(3), ends_at: wall(2) }, "ends_at", "error.event_ends_before_start"],
+    [
+      "ends before start",
+      { starts_at: wall(3), ends_at: wall(2) },
+      "ends_at",
+      "error.event_ends_before_start",
+    ],
     ["already ended", { starts_at: wall(-3), ends_at: wall(-2) }, "ends_at", "error.event_ended"],
-    ["too far out", { starts_at: wall(400), ends_at: wall(401) }, "starts_at", "error.event_too_far_out"],
+    [
+      "too far out",
+      { starts_at: wall(400), ends_at: wall(401) },
+      "starts_at",
+      "error.event_too_far_out",
+    ],
     ["too long", { starts_at: wall(2), ends_at: wall(40) }, "ends_at", "error.event_too_long"],
     ["missing author", { image_author: "" }, "image_author", "error.image_author_required"],
-    ["missing license", { image_license_text: "" }, "image_license_text", "error.image_license_required"],
+    [
+      "missing license",
+      { image_license_text: "" },
+      "image_license_text",
+      "error.image_license_required",
+    ],
   ] as const)("rejects %s", (_label, overrides, path, message) => {
     expect(validateAddition(validEvent(overrides))[path]).toBe(message);
   });

--- a/webclient/test/additionSchema.event.test.ts
+++ b/webclient/test/additionSchema.event.test.ts
@@ -28,8 +28,6 @@ function validEvent(overrides: Partial<AdditionDraft> = {}): AdditionDraft {
     image_width: 300,
     image_height: 300,
     image_author: "Studi",
-    image_license_text: "CC BY 4.0",
-    image_license_url: "",
     ...overrides,
   };
 }
@@ -70,12 +68,6 @@ describe("validateAddition (event)", () => {
     ],
     ["too long", { starts_at: wall(2), ends_at: wall(40) }, "ends_at", "error.event_too_long"],
     ["missing author", { image_author: "" }, "image_author", "error.image_author_required"],
-    [
-      "missing license",
-      { image_license_text: "" },
-      "image_license_text",
-      "error.image_license_required",
-    ],
   ] as const)("rejects %s", (_label, overrides, path, message) => {
     expect(validateAddition(validEvent(overrides))[path]).toBe(message);
   });

--- a/webclient/test/additionSchema.event.test.ts
+++ b/webclient/test/additionSchema.event.test.ts
@@ -4,9 +4,6 @@ import { type AdditionDraft, emptyAdditionDraft } from "../app/composables/editP
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-// A `datetime-local` wall string `now + offsetDays`. Built from the machine's local clock; the
-// schema reads it as Europe/Berlin, but every threshold here is days wide, so the <=2h tz skew is
-// irrelevant.
 function wall(offsetDays: number): string {
   const d = new Date(Date.now() + offsetDays * DAY_MS);
   const pad = (n: number) => String(n).padStart(2, "0");
@@ -37,8 +34,6 @@ describe("validateAddition (event)", () => {
     expect(validateAddition(validEvent())).toEqual({});
   });
 
-  // Mirrors the `validate_failure_cases` rstest table in
-  // `server/src/routes/feedback/proposed_edits/addition/event.rs`.
   it.each([
     ["bad key", { id: "event_NOTHEX" }, "id", "error.event_key_format"],
     ["missing prefix", { id: "9d02ddd940c43f87" }, "id", "error.event_key_format"],

--- a/webclient/test/datetime.test.ts
+++ b/webclient/test/datetime.test.ts
@@ -1,28 +1,26 @@
-import { describe, expect, it } from "vitest";
-import { berlinWallTimeToRfc3339 } from "../app/utils/datetime";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wallTimeToRfc3339 } from "../app/utils/datetime";
 
-describe("berlinWallTimeToRfc3339", () => {
-  it("stamps the summer (CEST) offset", () => {
-    expect(berlinWallTimeToRfc3339("2026-06-10T16:00")).toBe("2026-06-10T16:00:00+02:00");
+describe("wallTimeToRfc3339", () => {
+  // Pin the zone so the UTC output is deterministic regardless of where the suite runs.
+  const original = process.env.TZ;
+  beforeAll(() => {
+    process.env.TZ = "Europe/Berlin";
+  });
+  afterAll(() => {
+    process.env.TZ = original;
   });
 
-  it("stamps the winter (CET) offset", () => {
-    expect(berlinWallTimeToRfc3339("2026-01-10T16:00")).toBe("2026-01-10T16:00:00+01:00");
+  it("converts a summer (CEST, +02:00) wall time to UTC", () => {
+    expect(wallTimeToRfc3339("2026-06-10T16:00")).toBe("2026-06-10T14:00:00.000Z");
   });
 
-  it("uses the offset in effect just after the spring-forward cutover", () => {
-    // 2026 DST starts 2026-03-29 02:00 CET → 03:00 CEST.
-    expect(berlinWallTimeToRfc3339("2026-03-29T04:00")).toBe("2026-03-29T04:00:00+02:00");
+  it("converts a winter (CET, +01:00) wall time to UTC", () => {
+    expect(wallTimeToRfc3339("2026-01-10T16:00")).toBe("2026-01-10T15:00:00.000Z");
   });
 
-  it("uses the offset in effect just before the autumn cutover", () => {
-    // 2026 DST ends 2026-10-25 03:00 CEST → 02:00 CET.
-    expect(berlinWallTimeToRfc3339("2026-10-25T00:30")).toBe("2026-10-25T00:30:00+02:00");
-  });
-
-  it("rejects malformed input", () => {
-    expect(berlinWallTimeToRfc3339("")).toBeNull();
-    expect(berlinWallTimeToRfc3339("2026-06-10")).toBeNull();
-    expect(berlinWallTimeToRfc3339("not-a-date")).toBeNull();
+  it("returns null for malformed input", () => {
+    expect(wallTimeToRfc3339("")).toBeNull();
+    expect(wallTimeToRfc3339("not-a-date")).toBeNull();
   });
 });

--- a/webclient/test/datetime.test.ts
+++ b/webclient/test/datetime.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { berlinWallTimeToRfc3339 } from "../app/utils/datetime";
+
+describe("berlinWallTimeToRfc3339", () => {
+  it("stamps the summer (CEST) offset", () => {
+    expect(berlinWallTimeToRfc3339("2026-06-10T16:00")).toBe("2026-06-10T16:00:00+02:00");
+  });
+
+  it("stamps the winter (CET) offset", () => {
+    expect(berlinWallTimeToRfc3339("2026-01-10T16:00")).toBe("2026-01-10T16:00:00+01:00");
+  });
+
+  it("uses the offset in effect just after the spring-forward cutover", () => {
+    // 2026 DST starts 2026-03-29 02:00 CET → 03:00 CEST.
+    expect(berlinWallTimeToRfc3339("2026-03-29T04:00")).toBe("2026-03-29T04:00:00+02:00");
+  });
+
+  it("uses the offset in effect just before the autumn cutover", () => {
+    // 2026 DST ends 2026-10-25 03:00 CEST → 02:00 CET.
+    expect(berlinWallTimeToRfc3339("2026-10-25T00:30")).toBe("2026-10-25T00:30:00+02:00");
+  });
+
+  it("rejects malformed input", () => {
+    expect(berlinWallTimeToRfc3339("")).toBeNull();
+    expect(berlinWallTimeToRfc3339("2026-06-10")).toBeNull();
+    expect(berlinWallTimeToRfc3339("not-a-date")).toBeNull();
+  });
+});

--- a/webclient/test/imageCrop.test.ts
+++ b/webclient/test/imageCrop.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { clampThumbOffset, thumbCropRect, thumbOffsetBounds } from "../app/utils/imageCrop";
+
+describe("thumbOffsetBounds", () => {
+  it("is half the difference of the axes", () => {
+    expect(thumbOffsetBounds(800, 600).max).toBe(100);
+    expect(thumbOffsetBounds(600, 800).max).toBe(100);
+  });
+  it("is zero for a square image", () => {
+    expect(thumbOffsetBounds(500, 500).max).toBe(0);
+  });
+});
+
+describe("clampThumbOffset", () => {
+  it("clamps to the valid range and rounds", () => {
+    expect(clampThumbOffset(800, 600, 999)).toBe(100);
+    expect(clampThumbOffset(800, 600, -999)).toBe(-100);
+    expect(clampThumbOffset(800, 600, 12.6)).toBe(13);
+  });
+});
+
+describe("thumbCropRect", () => {
+  it("centres a landscape crop at offset 0", () => {
+    // 800×600 → 600² square centred horizontally: x = 400 - 300 = 100.
+    expect(thumbCropRect(800, 600, 0)).toEqual({ x: 100, y: 0, size: 600 });
+  });
+  it("slides a landscape crop horizontally with the offset", () => {
+    expect(thumbCropRect(800, 600, 50)).toEqual({ x: 150, y: 0, size: 600 });
+    expect(thumbCropRect(800, 600, -50)).toEqual({ x: 50, y: 0, size: 600 });
+  });
+  it("centres a portrait crop and slides it vertically", () => {
+    expect(thumbCropRect(600, 800, 0)).toEqual({ x: 0, y: 100, size: 600 });
+    expect(thumbCropRect(600, 800, 40)).toEqual({ x: 0, y: 140, size: 600 });
+  });
+  it("clamps an out-of-range offset to keep the crop inside the image", () => {
+    expect(thumbCropRect(800, 600, 9999)).toEqual({ x: 200, y: 0, size: 600 });
+  });
+  it("uses the whole square image regardless of offset", () => {
+    expect(thumbCropRect(500, 500, 30)).toEqual({ x: 0, y: 0, size: 500 });
+  });
+});

--- a/webclient/test/imageCrop.test.ts
+++ b/webclient/test/imageCrop.test.ts
@@ -1,41 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { clampThumbOffset, thumbCropRect, thumbOffsetBounds } from "../app/utils/imageCrop";
+import {
+  clampCropOffset,
+  cropAxis,
+  cropOffsetBounds,
+  cropRect,
+  HEADER_TARGET,
+  THUMB_TARGET,
+} from "../app/utils/imageCrop";
 
-describe("thumbOffsetBounds", () => {
-  it("is half the difference of the axes", () => {
-    expect(thumbOffsetBounds(800, 600).max).toBe(100);
-    expect(thumbOffsetBounds(600, 800).max).toBe(100);
+describe("thumb crop (256×256 square target)", () => {
+  it("bounds are half the difference of the axes", () => {
+    expect(cropOffsetBounds(800, 600, THUMB_TARGET).max).toBe(100);
+    expect(cropOffsetBounds(600, 800, THUMB_TARGET).max).toBe(100);
+    expect(cropOffsetBounds(500, 500, THUMB_TARGET).max).toBe(0);
   });
-  it("is zero for a square image", () => {
-    expect(thumbOffsetBounds(500, 500).max).toBe(0);
-  });
-});
 
-describe("clampThumbOffset", () => {
-  it("clamps to the valid range and rounds", () => {
-    expect(clampThumbOffset(800, 600, 999)).toBe(100);
-    expect(clampThumbOffset(800, 600, -999)).toBe(-100);
-    expect(clampThumbOffset(800, 600, 12.6)).toBe(13);
+  it("slides a landscape crop horizontally", () => {
+    expect(cropAxis(800, 600, THUMB_TARGET)).toBe("horizontal");
+    expect(cropRect(800, 600, THUMB_TARGET, 0)).toEqual({ x: 100, y: 0, width: 600, height: 600 });
+    expect(cropRect(800, 600, THUMB_TARGET, 50)).toEqual({ x: 150, y: 0, width: 600, height: 600 });
   });
-});
 
-describe("thumbCropRect", () => {
-  it("centres a landscape crop at offset 0", () => {
-    // 800×600 → 600² square centred horizontally: x = 400 - 300 = 100.
-    expect(thumbCropRect(800, 600, 0)).toEqual({ x: 100, y: 0, size: 600 });
+  it("slides a portrait crop vertically", () => {
+    expect(cropAxis(600, 800, THUMB_TARGET)).toBe("vertical");
+    expect(cropRect(600, 800, THUMB_TARGET, 40)).toEqual({ x: 0, y: 140, width: 600, height: 600 });
   });
-  it("slides a landscape crop horizontally with the offset", () => {
-    expect(thumbCropRect(800, 600, 50)).toEqual({ x: 150, y: 0, size: 600 });
-    expect(thumbCropRect(800, 600, -50)).toEqual({ x: 50, y: 0, size: 600 });
-  });
-  it("centres a portrait crop and slides it vertically", () => {
-    expect(thumbCropRect(600, 800, 0)).toEqual({ x: 0, y: 100, size: 600 });
-    expect(thumbCropRect(600, 800, 40)).toEqual({ x: 0, y: 140, size: 600 });
-  });
+
   it("clamps an out-of-range offset to keep the crop inside the image", () => {
-    expect(thumbCropRect(800, 600, 9999)).toEqual({ x: 200, y: 0, size: 600 });
+    expect(clampCropOffset(800, 600, THUMB_TARGET, 9999)).toBe(100);
+    expect(cropRect(800, 600, THUMB_TARGET, 9999)).toEqual({
+      x: 200,
+      y: 0,
+      width: 600,
+      height: 600,
+    });
   });
+
   it("uses the whole square image regardless of offset", () => {
-    expect(thumbCropRect(500, 500, 30)).toEqual({ x: 0, y: 0, size: 500 });
+    expect(cropAxis(500, 500, THUMB_TARGET)).toBe("none");
+    expect(cropRect(500, 500, THUMB_TARGET, 30)).toEqual({ x: 0, y: 0, width: 500, height: 500 });
+  });
+});
+
+describe("header crop (512×210 banner target)", () => {
+  // A 1000×1000 source is taller than the 512:210 banner, so the crop keeps full width and slides
+  // vertically. Banner height = round(1000 * 210/512) = 410 (even via the floor-of-half).
+  it("crops the height of a square source and slides vertically", () => {
+    expect(cropAxis(1000, 1000, HEADER_TARGET)).toBe("vertical");
+    const rect = cropRect(1000, 1000, HEADER_TARGET, 0);
+    expect(rect.width).toBe(1000);
+    expect(rect.height).toBe(410);
+    expect(rect.x).toBe(0);
+    expect(rect.y).toBe(295);
+  });
+
+  it("crops the width of an ultra-wide source and slides horizontally", () => {
+    // 4000×500 is wider than 512:210; banner width = 500 * 512/210 ≈ 1218 → even 1218.
+    expect(cropAxis(4000, 500, HEADER_TARGET)).toBe("horizontal");
+    const rect = cropRect(4000, 500, HEADER_TARGET, 0);
+    expect(rect.height).toBe(500);
+    expect(rect.width).toBe(1218);
+    expect(rect.y).toBe(0);
   });
 });

--- a/webclient/test/imageCrop.test.ts
+++ b/webclient/test/imageCrop.test.ts
@@ -43,8 +43,6 @@ describe("thumb crop (256×256 square target)", () => {
 });
 
 describe("header crop (512×210 banner target)", () => {
-  // A 1000×1000 source is taller than the 512:210 banner, so the crop keeps full width and slides
-  // vertically. Banner height = round(1000 * 210/512) = 410 (even via the floor-of-half).
   it("crops the height of a square source and slides vertically", () => {
     expect(cropAxis(1000, 1000, HEADER_TARGET)).toBe("vertical");
     const rect = cropRect(1000, 1000, HEADER_TARGET, 0);
@@ -55,7 +53,6 @@ describe("header crop (512×210 banner target)", () => {
   });
 
   it("crops the width of an ultra-wide source and slides horizontally", () => {
-    // 4000×500 is wider than 512:210; banner width = 500 * 512/210 ≈ 1218 → even 1218.
     expect(cropAxis(4000, 500, HEADER_TARGET)).toBe("horizontal");
     const rect = cropRect(4000, 500, HEADER_TARGET, 0);
     expect(rect.height).toBe(500);

--- a/webclient/test/iris.test.ts
+++ b/webclient/test/iris.test.ts
@@ -131,7 +131,6 @@ describe("roomsForBuildings", () => {
 
   it("unions rooms across several buildings (a joined building's fingers)", () => {
     const rooms = parseIrisRooms(IRIS_FIXTURE);
-    // A joined building passes every covered child id; the union spans all of them.
     expect(roomsForBuildings(rooms, ["5504", "8102"]).map((r) => r.buildingId)).toEqual([
       "5504",
       "8102",

--- a/webclient/vitest.config.ts
+++ b/webclient/vitest.config.ts
@@ -1,8 +1,13 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-// Unit tests cover the pure logic in `app/utils` (no Nuxt runtime needed), so they live outside
-// `app/` to stay clear of Nuxt's auto-import scanning.
+// Unit tests cover the pure logic in `app/utils` and the framework-free composables (zod schemas),
+// so they live outside `app/` to stay clear of Nuxt's auto-import scanning. The `~` alias mirrors
+// Nuxt's so those modules' `~/...` imports resolve under plain Vitest.
 export default defineConfig({
+  resolve: {
+    alias: { "~": fileURLToPath(new URL("./app", import.meta.url)) },
+  },
   test: {
     include: ["test/**/*.test.ts"],
     environment: "node",

--- a/webclient/vitest.config.ts
+++ b/webclient/vitest.config.ts
@@ -1,9 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
-// Unit tests cover the pure logic in `app/utils` and the framework-free composables (zod schemas),
-// so they live outside `app/` to stay clear of Nuxt's auto-import scanning. The `~` alias mirrors
-// Nuxt's so those modules' `~/...` imports resolve under plain Vitest.
+// Tests live outside `app/` to stay clear of Nuxt's auto-import scanning.
 export default defineConfig({
   resolve: {
     alias: { "~": fileURLToPath(new URL("./app", import.meta.url)) },


### PR DESCRIPTION
Closes #3143.

Adds a 4th **event** kind to `AddProposalModal` that posts an `Addition::Event` (#3141) through the existing token/privacy submit plumbing, with a **live preview** of how the event will look as a #3136 photo marker on the map.