### PR TITLE
feat(server,webclient): render opening hours on location pages

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1576,6 +1576,14 @@ components:
           description: The name of the entry in a human-readable form
           examples:
             - 5606.EG.036 (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)
+        opening_hours:
+          oneOf:
+            - type: "null"
+            - $ref: '#/components/schemas/OpeningHoursResponse'
+              description: |-
+                Opening hours of this location, when we have a schedule for it.
+
+                Omitted for entries without a known schedule (most rooms).
         parent_names:
           type: array
           items:
@@ -2315,6 +2323,57 @@ components:
             - integer
             - "null"
           format: int32
+    OpeningHoursResponse:
+      type: object
+      description: |-
+        Opening hours of a location.
+
+        The schedule is a plain OSM [`opening_hours`](https://wiki.openstreetmap.org/wiki/Key:opening_hours)
+        string. Any `lecture:`/`break:` semester macros are already expanded into absolute
+        date ranges at data-build time, so consumers only ever see standard OSM syntax.
+      required:
+        - osm
+        - source_url
+        - last_update
+      properties:
+        last_update:
+          type: string
+          description: '`YYYY-MM-DD` date on which this schedule was last confirmed.'
+          examples:
+            - 2026-05-01
+        osm:
+          type: string
+          description: Plain OSM `opening_hours` string describing the schedule.
+          examples:
+            - Mo-Fr 08:00-22:00; Sa 09:00-17:00
+        service:
+          type:
+            - string
+            - "null"
+          description: |-
+            The service variant this schedule describes, when a location distinguishes
+            several (e.g. a separate lending desk).
+          examples:
+            - Ausleihe
+        source_url:
+          type: string
+          description: Where this schedule was sourced from, shown as the "source" link.
+          examples:
+            - https://www.ub.tum.de/en/branch-libraries
+        valid_from:
+          type:
+            - string
+            - "null"
+          description: '`YYYY-MM-DD` date from which this schedule is valid, when bounded.'
+          examples:
+            - 2026-04-28
+        valid_until:
+          type:
+            - string
+            - "null"
+          description: '`YYYY-MM-DD` date until which this schedule is valid, when bounded.'
+          examples:
+            - 2026-09-30
     OperatorResponse:
       type: object
       description: Operator of a location

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2340,7 +2340,7 @@ components:
           type: string
           description: '`YYYY-MM-DD` date on which this schedule was last confirmed.'
           examples:
-            - 2026-05-01
+            - "2026-05-01"
         osm:
           type: string
           description: Plain OSM `opening_hours` string describing the schedule.
@@ -2366,14 +2366,14 @@ components:
             - "null"
           description: '`YYYY-MM-DD` date from which this schedule is valid, when bounded.'
           examples:
-            - 2026-04-28
+            - "2026-04-28"
         valid_until:
           type:
             - string
             - "null"
           description: '`YYYY-MM-DD` date until which this schedule is valid, when bounded.'
           examples:
-            - 2026-09-30
+            - "2026-09-30"
     OperatorResponse:
       type: object
       description: Operator of a location

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -166,6 +166,39 @@ struct LocationDetailsResponse {
     /// - featured view
     #[serde(default)]
     sections: SectionsResponse,
+    /// Opening hours of this location, when we have a schedule for it.
+    ///
+    /// Omitted for entries without a known schedule (most rooms).
+    opening_hours: Option<OpeningHoursResponse>,
+}
+
+/// Opening hours of a location.
+///
+/// The schedule is a plain OSM [`opening_hours`](https://wiki.openstreetmap.org/wiki/Key:opening_hours)
+/// string. Any `lecture:`/`break:` semester macros are already expanded into absolute
+/// date ranges at data-build time, so consumers only ever see standard OSM syntax.
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct OpeningHoursResponse {
+    /// Plain OSM `opening_hours` string describing the schedule.
+    #[schema(examples("Mo-Fr 08:00-22:00; Sa 09:00-17:00"))]
+    osm: String,
+    /// Where this schedule was sourced from, shown as the "source" link.
+    #[schema(examples("https://www.ub.tum.de/en/branch-libraries"))]
+    source_url: String,
+    /// `YYYY-MM-DD` date on which this schedule was last confirmed.
+    #[schema(examples("2026-05-01"))]
+    last_update: String,
+    /// `YYYY-MM-DD` date from which this schedule is valid, when bounded.
+    #[schema(examples("2026-04-28"))]
+    valid_from: Option<String>,
+    /// `YYYY-MM-DD` date until which this schedule is valid, when bounded.
+    #[schema(examples("2026-09-30"))]
+    valid_until: Option<String>,
+    /// The service variant this schedule describes, when a location distinguishes
+    /// several (e.g. a separate lending desk).
+    #[schema(examples("Ausleihe"))]
+    service: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, utoipa::ToSchema)]

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -819,6 +819,12 @@ export type components = {
        */
       readonly name: string;
       /**
+       * @description Opening hours of this location, when we have a schedule for it.
+       *
+       *     Omitted for entries without a known schedule (most rooms).
+       */
+      readonly opening_hours?: null | components["schemas"]["OpeningHoursResponse"];
+      /**
        * @description The human names of the parents.
        *
        *     They are ordered as they would appear in a Breadcrumb menu.
@@ -1287,6 +1293,46 @@ export type components = {
       readonly thumb?: number | null;
     };
     /** @description Operator of a location */
+    /**
+     * @description Opening hours of a location.
+     *
+     *     The schedule is a plain OSM [`opening_hours`](https://wiki.openstreetmap.org/wiki/Key:opening_hours)
+     *     string. Any `lecture:`/`break:` semester macros are already expanded into absolute
+     *     date ranges at data-build time, so consumers only ever see standard OSM syntax.
+     */
+    readonly OpeningHoursResponse: {
+      /**
+       * @description `YYYY-MM-DD` date on which this schedule was last confirmed.
+       * @example 2026-05-01
+       */
+      readonly last_update: string;
+      /**
+       * @description Plain OSM `opening_hours` string describing the schedule.
+       * @example Mo-Fr 08:00-22:00; Sa 09:00-17:00
+       */
+      readonly osm: string;
+      /**
+       * @description The service variant this schedule describes, when a location distinguishes
+       *     several (e.g. a separate lending desk).
+       * @example Ausleihe
+       */
+      readonly service?: string | null;
+      /**
+       * @description Where this schedule was sourced from, shown as the "source" link.
+       * @example https://www.ub.tum.de/en/branch-libraries
+       */
+      readonly source_url: string;
+      /**
+       * @description `YYYY-MM-DD` date from which this schedule is valid, when bounded.
+       * @example 2026-04-28
+       */
+      readonly valid_from?: string | null;
+      /**
+       * @description `YYYY-MM-DD` date until which this schedule is valid, when bounded.
+       * @example 2026-09-30
+       */
+      readonly valid_until?: string | null;
+    };
     readonly OperatorResponse: {
       /**
        * @description designation code of the operator

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -818,11 +818,6 @@ export type components = {
        * @example 5606.EG.036 (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)
        */
       readonly name: string;
-      /**
-       * @description Opening hours of this location, when we have a schedule for it.
-       *
-       *     Omitted for entries without a known schedule (most rooms).
-       */
       readonly opening_hours?: null | components["schemas"]["OpeningHoursResponse"];
       /**
        * @description The human names of the parents.
@@ -1292,7 +1287,6 @@ export type components = {
       /** Format: int32 */
       readonly thumb?: number | null;
     };
-    /** @description Operator of a location */
     /**
      * @description Opening hours of a location.
      *
@@ -1333,6 +1327,7 @@ export type components = {
        */
       readonly valid_until?: string | null;
     };
+    /** @description Operator of a location */
     readonly OperatorResponse: {
       /**
        * @description designation code of the operator

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -249,6 +249,10 @@ const actions = computed<DetailAction[]>(() => [
     <div class="flex flex-col gap-6">
       <DetailsBuildingOverviewSection :buildings="data.sections?.buildings_overview"/>
       <ClientOnly>
+        <LazyDetailsOpeningHoursCard
+          v-if="data.opening_hours"
+          :opening-hours="data.opening_hours"
+        />
         <LazyDetailsNearbyTransportSection :id="data.id"/>
         <LazyDetailsIrisCoverageCard
           v-if="data.props.iris_coverage_building_ids?.length"

--- a/webclient/app/components/DetailsOpeningHoursCard.vue
+++ b/webclient/app/components/DetailsOpeningHoursCard.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { mdiChevronDown, mdiOpenInNew } from "@mdi/js";
+import { useToggle } from "@vueuse/core";
+import type { components } from "~/api_types";
+import {
+  type OpeningHoursDay,
+  type OpeningHoursRange,
+  parseOpeningHoursWeek,
+} from "~/utils/openingHours";
+
+type OpeningHoursResponse = components["schemas"]["OpeningHoursResponse"];
+
+const props = defineProps<{
+  readonly openingHours: OpeningHoursResponse;
+}>();
+
+const { t, locale } = useI18n({ useScope: "local" });
+
+// `undefined` while parsing, `null` once it has failed.
+const week = ref<readonly OpeningHoursDay[] | null | undefined>(undefined);
+const parseFailed = computed(() => week.value === null);
+
+async function refreshWeek(): Promise<void> {
+  week.value = await parseOpeningHoursWeek(props.openingHours.osm, new Date());
+}
+
+onMounted(refreshWeek);
+watch(() => props.openingHours.osm, refreshWeek);
+
+const today = computed<OpeningHoursDay | null>(
+  () => week.value?.find((day) => day.isToday) ?? null
+);
+
+const [expanded, toggleExpanded] = useToggle(false);
+
+function formatRanges(ranges: readonly OpeningHoursRange[]): string {
+  return ranges.map((range) => `${range.from}–${range.to}`).join(", ");
+}
+
+const lastUpdated = computed(() => formatIsoDate(props.openingHours.last_update));
+const validUntil = computed(() =>
+  props.openingHours.valid_until ? formatIsoDate(props.openingHours.valid_until) : null
+);
+
+// Parse the parts explicitly; `new Date("YYYY-MM-DD")` is UTC and shifts the day in negative
+// offsets.
+function formatIsoDate(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  if (!year || !month || !day) return iso;
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString(locale.value === "de" ? "de-DE" : "en-GB", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+</script>
+
+<template>
+  <section v-if="week || parseFailed" class="flex flex-col gap-3 print:!hidden">
+    <div class="flex flex-row items-baseline justify-between gap-2">
+      <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold">{{ t("title") }}</p>
+      <Btn :to="openingHours.source_url" variant="link" size="text-xs gap-1 rounded">
+        {{ t("source") }}
+        <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
+      </Btn>
+    </div>
+
+    <p
+      v-if="parseFailed"
+      class="bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 rounded-sm border p-3 font-mono text-sm break-words"
+    >
+      {{ openingHours.osm }}
+    </p>
+    <div
+      v-else
+      class="bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 rounded-sm border"
+    >
+      <button
+        type="button"
+        class="focusable flex w-full items-center gap-3 p-3 text-left"
+        :aria-expanded="expanded"
+        @click="toggleExpanded()"
+      >
+        <span class="text-zinc-800 dark:text-zinc-100 font-medium">{{ t("today") }}</span>
+        <span v-if="today?.ranges.length" class="text-zinc-600 dark:text-zinc-300 min-w-0 flex-1 truncate">
+          {{ formatRanges(today.ranges) }}
+        </span>
+        <span v-else class="text-zinc-500 dark:text-zinc-400 min-w-0 flex-1">{{ t("closed") }}</span>
+        <MdiIcon
+          :path="mdiChevronDown"
+          :size="18"
+          class="text-zinc-500 dark:text-zinc-400 shrink-0 transition-transform"
+          :class="{ 'rotate-180': expanded }"
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        v-if="expanded"
+        class="border-zinc-200 dark:border-zinc-700 grid grid-cols-[auto_minmax(0,1fr)] gap-x-6 gap-y-1.5 border-t p-3 text-sm"
+      >
+        <template v-for="day in week" :key="day.key">
+          <span
+            :class="
+              day.isToday
+                ? 'text-zinc-800 dark:text-zinc-100 font-medium'
+                : 'text-zinc-500 dark:text-zinc-400'
+            "
+          >
+            {{ t(`day.${day.key}`) }}
+          </span>
+          <span class="text-zinc-600 dark:text-zinc-300 text-end" :class="{ 'font-medium': day.isToday }">
+            <template v-if="day.ranges.length">
+              <span v-for="(range, index) in day.ranges" :key="index" class="block" :title="range.comment">
+                {{ range.from }}&#8211;{{ range.to }}
+              </span>
+            </template>
+            <span v-else class="text-zinc-500 dark:text-zinc-400">{{ t("closed") }}</span>
+          </span>
+        </template>
+      </div>
+    </div>
+
+    <small class="text-zinc-500 dark:text-zinc-400">
+      <span v-if="openingHours.service">{{ openingHours.service }} · </span>
+      <span v-if="validUntil">{{ t("valid_until", { date: validUntil }) }} · </span>
+      {{ t("last_updated", { date: lastUpdated }) }}
+    </small>
+  </section>
+</template>
+
+<i18n lang="yaml">
+de:
+  title: Öffnungszeiten
+  source: Quelle
+  today: Heute
+  closed: geschlossen
+  last_updated: "zuletzt aktualisiert am {date}"
+  valid_until: "gültig bis {date}"
+  day:
+    mo: Montag
+    tu: Dienstag
+    we: Mittwoch
+    th: Donnerstag
+    fr: Freitag
+    sa: Samstag
+    su: Sonntag
+en:
+  title: Opening hours
+  source: Source
+  today: Today
+  closed: closed
+  last_updated: "last updated on {date}"
+  valid_until: "valid until {date}"
+  day:
+    mo: Monday
+    tu: Tuesday
+    we: Wednesday
+    th: Thursday
+    fr: Friday
+    sa: Saturday
+    su: Sunday
+</i18n>

--- a/webclient/app/components/DetailsOpeningHoursCard.vue
+++ b/webclient/app/components/DetailsOpeningHoursCard.vue
@@ -34,7 +34,7 @@ const today = computed<OpeningHoursDay | null>(
 const [expanded, toggleExpanded] = useToggle(false);
 
 function formatRanges(ranges: readonly OpeningHoursRange[]): string {
-  return ranges.map((range) => `${range.from}–${range.to}`).join(", ");
+  return ranges.map((range) => `${range.from}-${range.to}`).join(", ");
 }
 
 const lastUpdated = computed(() => formatIsoDate(props.openingHours.last_update));

--- a/webclient/app/utils/openingHours.ts
+++ b/webclient/app/utils/openingHours.ts
@@ -52,7 +52,11 @@ export async function parseOpeningHoursWeek(
 
     return WEEKDAY_KEYS.map((key, index): OpeningHoursDay => {
       const dayStart = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + index);
-      const dayEnd = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + index + 1);
+      const dayEnd = new Date(
+        monday.getFullYear(),
+        monday.getMonth(),
+        monday.getDate() + index + 1
+      );
       const intervals: readonly OpenInterval[] = oh.getOpenIntervals(dayStart, dayEnd);
       const ranges = intervals.map(
         ([from, to, , comment]): OpeningHoursRange => ({

--- a/webclient/app/utils/openingHours.ts
+++ b/webclient/app/utils/openingHours.ts
@@ -1,0 +1,69 @@
+// Monday-first; the translated labels live in the rendering component, keyed by these.
+export type WeekdayKey = "mo" | "tu" | "we" | "th" | "fr" | "sa" | "su";
+export const WEEKDAY_KEYS: readonly WeekdayKey[] = ["mo", "tu", "we", "th", "fr", "sa", "su"];
+
+/** A wall-clock boundary formatted as `HH:MM`, where a midnight close reads as `24:00`. */
+export type TimeOfDay = `${number}:${number}`;
+
+export interface OpeningHoursRange {
+  readonly from: TimeOfDay;
+  readonly to: TimeOfDay;
+  readonly comment?: string;
+}
+export interface OpeningHoursDay {
+  readonly key: WeekdayKey;
+  readonly isToday: boolean;
+  readonly ranges: readonly OpeningHoursRange[];
+}
+
+// One open interval as the `opening_hours` library yields it: `[from, to, unknown, comment]`.
+type OpenInterval = readonly [Date, Date, boolean, string | undefined];
+
+function formatBoundary(date: Date, dayEnd: Date): TimeOfDay {
+  // opening_hours reports an interval ending at the following midnight as the next day's
+  // 00:00; within a single day's row that boundary should read as 24:00.
+  if (date.getTime() >= dayEnd.getTime()) return "24:00";
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}` as TimeOfDay;
+}
+
+/**
+ * Expand a plain OSM `opening_hours` string into the seven days of the week containing
+ * `reference`. Returns `null` when the string cannot be parsed, so callers can fall back to
+ * the raw schedule rather than dropping it.
+ */
+export async function parseOpeningHoursWeek(
+  osm: string,
+  reference: Date
+): Promise<readonly OpeningHoursDay[] | null> {
+  try {
+    const { default: OpeningHours } = await import("opening_hours");
+    // The mode argument is omitted because the ESM build does not export the `mode` enum its
+    // types advertise; the library defaults to time-range mode regardless.
+    const oh = new OpeningHours(osm, null);
+
+    const todayIndex = (reference.getDay() + 6) % 7; // 0 = Monday … 6 = Sunday.
+    const monday = new Date(
+      reference.getFullYear(),
+      reference.getMonth(),
+      reference.getDate() - todayIndex
+    );
+
+    return WEEKDAY_KEYS.map((key, index): OpeningHoursDay => {
+      const dayStart = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + index);
+      const dayEnd = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + index + 1);
+      const intervals: readonly OpenInterval[] = oh.getOpenIntervals(dayStart, dayEnd);
+      const ranges = intervals.map(
+        ([from, to, , comment]): OpeningHoursRange => ({
+          from: formatBoundary(from, dayEnd),
+          to: formatBoundary(to, dayEnd),
+          comment: comment || undefined,
+        })
+      );
+      return { key, isToday: index === todayIndex, ranges };
+    });
+  } catch {
+    return null;
+  }
+}

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -32,6 +32,7 @@
 		"maplibre-gl": "5.24.0",
 		"maplibre-gl-indoor": "0.0.22",
 		"nuxt": "4.4.7",
+		"opening_hours": "^3.13.0",
 		"prom-client": "^15.1.3",
 		"sharp": "0.34.5",
 		"ts-essentials": "^10.1.1",

--- a/webclient/pnpm-lock.yaml
+++ b/webclient/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       nuxt:
         specifier: 4.4.7
         version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@biomejs/biome@2.4.16)(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      opening_hours:
+        specifier: ^3.13.0
+        version: 3.13.0(typescript@6.0.3)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -3821,6 +3824,14 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  i18next@26.3.1:
+    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -4562,6 +4573,10 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: ^5.x
+
+  opening_hours@3.13.0:
+    resolution: {integrity: sha512-yQxRzM+ggFvmgML53tcnI3Ugy/OCt4HgyYeTryD2tgahfcjDNSgrU2wTs1ccNhA2ytatNUwKDJcLi2u54nT2Bg==}
+    engines: {node: '>=12'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5312,6 +5327,9 @@ packages:
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
       postcss: ^8.5.14
+
+  suncalc@1.9.0:
+    resolution: {integrity: sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -9646,6 +9664,10 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  i18next@26.3.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -10791,6 +10813,13 @@ snapshots:
       typescript: 6.0.3
       yargs-parser: 21.1.1
 
+  opening_hours@3.13.0(typescript@6.0.3):
+    dependencies:
+      i18next: 26.3.1(typescript@6.0.3)
+      suncalc: 1.9.0
+    transitivePeerDependencies:
+      - typescript
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -11784,6 +11813,8 @@ snapshots:
       browserslist: 4.28.2
       postcss: 8.5.15
       postcss-selector-parser: 7.1.1
+
+  suncalc@1.9.0: {}
 
   supports-color@10.2.2: {}
 

--- a/webclient/test/openingHours.test.ts
+++ b/webclient/test/openingHours.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { type OpeningHoursDay, parseOpeningHoursWeek, WEEKDAY_KEYS } from "../app/utils/openingHours";
+import {
+  type OpeningHoursDay,
+  parseOpeningHoursWeek,
+  WEEKDAY_KEYS,
+} from "../app/utils/openingHours";
 
 // A fixed Wednesday so the Monday-anchored week and the `isToday` flag are deterministic.
 const WEDNESDAY = new Date(2026, 5, 10); // 2026-06-10 is a Wednesday.
@@ -21,7 +25,9 @@ describe("parseOpeningHoursWeek", () => {
   it("parses a single range and leaves uncovered days closed", async () => {
     const week = await parseOpeningHoursWeek("Mo-Fr 08:00-22:00", WEDNESDAY);
     if (!week) throw new Error("expected a parsed week");
-    expect(dayByKey(week, "mo").ranges).toEqual([{ from: "08:00", to: "22:00", comment: undefined }]);
+    expect(dayByKey(week, "mo").ranges).toEqual([
+      { from: "08:00", to: "22:00", comment: undefined },
+    ]);
     // Weekends are not covered by the rule, so they read as closed (no ranges).
     expect(dayByKey(week, "sa").ranges).toEqual([]);
     expect(dayByKey(week, "su").ranges).toEqual([]);

--- a/webclient/test/openingHours.test.ts
+++ b/webclient/test/openingHours.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { type OpeningHoursDay, parseOpeningHoursWeek, WEEKDAY_KEYS } from "../app/utils/openingHours";
+
+// A fixed Wednesday so the Monday-anchored week and the `isToday` flag are deterministic.
+const WEDNESDAY = new Date(2026, 5, 10); // 2026-06-10 is a Wednesday.
+
+function dayByKey(week: readonly OpeningHoursDay[], key: string): OpeningHoursDay {
+  const day = week.find((d) => d.key === key);
+  if (!day) throw new Error(`missing day ${key}`);
+  return day;
+}
+
+describe("parseOpeningHoursWeek", () => {
+  it("returns the seven Monday-first weekdays with today flagged", async () => {
+    const week = await parseOpeningHoursWeek("Mo-Fr 08:00-22:00", WEDNESDAY);
+    expect(week).not.toBeNull();
+    expect(week?.map((d) => d.key)).toEqual([...WEEKDAY_KEYS]);
+    expect(week?.filter((d) => d.isToday).map((d) => d.key)).toEqual(["we"]);
+  });
+
+  it("parses a single range and leaves uncovered days closed", async () => {
+    const week = await parseOpeningHoursWeek("Mo-Fr 08:00-22:00", WEDNESDAY);
+    if (!week) throw new Error("expected a parsed week");
+    expect(dayByKey(week, "mo").ranges).toEqual([{ from: "08:00", to: "22:00", comment: undefined }]);
+    // Weekends are not covered by the rule, so they read as closed (no ranges).
+    expect(dayByKey(week, "sa").ranges).toEqual([]);
+    expect(dayByKey(week, "su").ranges).toEqual([]);
+  });
+
+  it("parses multiple ranges in a single day", async () => {
+    const week = await parseOpeningHoursWeek("Mo 08:00-12:00,13:00-17:00", WEDNESDAY);
+    if (!week) throw new Error("expected a parsed week");
+    expect(dayByKey(week, "mo").ranges.map((r) => `${r.from}-${r.to}`)).toEqual([
+      "08:00-12:00",
+      "13:00-17:00",
+    ]);
+  });
+
+  it("renders an all-day rule as 00:00-24:00 rather than 00:00-00:00", async () => {
+    const week = await parseOpeningHoursWeek("24/7", WEDNESDAY);
+    if (!week) throw new Error("expected a parsed week");
+    for (const day of week) {
+      expect(day.ranges).toEqual([{ from: "00:00", to: "24:00", comment: undefined }]);
+    }
+  });
+
+  it("expands a semester-style date range into the matching week only", async () => {
+    const osm = "2026 Jun 08-2026 Jun 12 Mo-Fr 09:00-18:00";
+    const inRange = await parseOpeningHoursWeek(osm, WEDNESDAY);
+    const outOfRange = await parseOpeningHoursWeek(osm, new Date(2026, 6, 1)); // a July week.
+    expect(dayByKey(inRange ?? [], "we").ranges).toEqual([
+      { from: "09:00", to: "18:00", comment: undefined },
+    ]);
+    expect((outOfRange ?? []).every((d) => d.ranges.length === 0)).toBe(true);
+  });
+
+  it("returns null for a malformed OSM string instead of throwing", async () => {
+    expect(await parseOpeningHoursWeek("Mo-Fr 08:00-99:99", WEDNESDAY)).toBeNull();
+  });
+});


### PR DESCRIPTION
Renders the opening-hours schedule the data pipeline already attaches: adds an `opening_hours` field to the location details API and an `DetailsOpeningHoursCard` (today's hours, expandable full-week table, last-updated note, source link, DE/EN labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)