### PR TITLE
ci: retry docker compose pull on registry timeouts

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -74,7 +74,17 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: {persist-credentials: false}
       - name: Setup | Pull Docker images
-        run: docker compose pull
+        run: |
+          attempt=1
+          until docker compose pull; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::docker compose pull failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::docker compose pull attempt $attempt failed, retrying in 15s"
+            sleep 15
+            attempt=$((attempt + 1))
+          done
       - name: Setup | Build Docker images
         run: docker compose -f compose.local.yml build
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,7 +34,19 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Setup | Pull Docker images
-        run: docker compose pull
+        # registry-1.docker.io occasionally times out mid-pull; retry to avoid a flake on transient
+        # connection drops. `until` keeps `set -e` happy because failures in the condition aren't fatal.
+        run: |
+          attempt=1
+          until docker compose pull; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::docker compose pull failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::docker compose pull attempt $attempt failed, retrying in 15s"
+            sleep 15
+            attempt=$((attempt + 1))
+          done
       - name: Setup | Build Docker images
         run: docker compose -f compose.local.yml build server webclient
 
@@ -142,7 +154,17 @@ jobs:
         with: { persist-credentials: false }
 
       - name: Setup | Pull Docker images
-        run: docker compose pull
+        run: |
+          attempt=1
+          until docker compose pull; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::docker compose pull failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::docker compose pull attempt $attempt failed, retrying in 15s"
+            sleep 15
+            attempt=$((attempt + 1))
+          done
       - name: Setup | Build Docker images
         run: docker compose -f compose.local.yml build
 


### PR DESCRIPTION
The e2e workflow's `Setup | Pull Docker images` step occasionally fails with a transient Docker Hub timeout, e.g. PR #3168 [run 27130012206 / ui-tests-desktop (chromium, main)](https://github.com/TUM-Dev/NavigaTUM/actions/runs/27130012206/job/80068283801?pr=3168)