### PR TITLE
refactor(data): drop standalone Lernraumbelegung link in favor of IRIS

### DIFF
--- a/data/sources/links.yaml
+++ b/data/sources/links.yaml
@@ -187,11 +187,6 @@ heilbronn:
     de: Über den Campus Heilbronn
     en: About the Campus Heilbronn
   url: https://www.mgt.tum.de/campuses/heilbronn/explore-the-campus
-mi:
-- text:
-    de: Lernraumbelegung
-    en: Learning rooms usage
-  url: https://www.devapp.it.tum.de/iris/app/
 roggenstein:
 - text:
     de: Offizielle Webseite


### PR DESCRIPTION
## What

Removes the standalone "Lernraumbelegung" / "Learning rooms usage" link on the MI campus, which pointed at the external IRIS app (`https://www.devapp.it.tum.de/iris/app/`).

## Why

Learning-room availability is now integrated directly into NavigaTUM via IRIS, so the external link is redundant. Removed entirely — no empty key or comment left behind (`links.yaml` is an `id → links` map joined with a left join, so an absent key cleanly means "no link override").

## Scope

Only the `mi:` link entry was removed. Deliberately left untouched:
- The IRIS sections in `datenschutz.md` / `privacy.md` (incl. IRIS privacy-policy links) — these document the *new* integrated IRIS feature.
- The generic `Lernraum` search synonym and TUMonline room names containing "Lernraum" — unrelated data, not links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)