### PR TITLE
refactor(feedback): drop unused deletion-request field and simplify privacy consent copy

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2612,7 +2612,6 @@ components:
         - subject
         - body
         - privacy_checked
-        - deletion_requested
       properties:
         body:
           type: string
@@ -2626,14 +2625,6 @@ components:
         category:
           $ref: '#/components/schemas/FeedbackCategory'
           description: The category of the feedback.
-        deletion_requested:
-          type: boolean
-          description: |-
-            Whether the user has requested to delete the issue.
-
-            This flag means:
-            - If the user has requested to delete the issue, we will delete it from GitHub after processing it
-            - If the user has not requested to delete the issue, we will not delete it from GitHub and it will remain as a closed issue.
         privacy_checked:
           type: boolean
           description: |-

--- a/server/src/routes/feedback/post_feedback.rs
+++ b/server/src/routes/feedback/post_feedback.rs
@@ -70,12 +70,6 @@ pub struct PostFeedbackRequest {
     /// We are posting the feedback publicly on GitHub (not a EU-Company).
     /// **You MUST also include such a checkmark.**
     privacy_checked: bool,
-    /// Whether the user has requested to delete the issue.
-    ///
-    /// This flag means:
-    /// - If the user has requested to delete the issue, we will delete it from GitHub after processing it
-    /// - If the user has not requested to delete the issue, we will not delete it from GitHub and it will remain as a closed issue.
-    deletion_requested: bool,
 }
 
 /// Post feedback
@@ -126,16 +120,8 @@ pub async fn send_feedback(
             .body("Using this endpoint without accepting the privacy policy is not allowed");
     }
 
+    let labels = vec!["webform".to_string(), req_data.category.to_string()];
     GitHub::default()
-        .open_issue(&req_data.subject, &req_data.body, parse_labels(&req_data.0))
+        .open_issue(&req_data.subject, &req_data.body, labels)
         .await
-}
-
-fn parse_labels(req_data: &PostFeedbackRequest) -> Vec<String> {
-    let mut labels = vec!["webform".to_string()];
-    if req_data.deletion_requested {
-        labels.push("delete-after-processing".to_string());
-    }
-    labels.push(req_data.category.to_string());
-    labels
 }

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1507,14 +1507,6 @@ export type components = {
       /** @description The category of the feedback. */
       readonly category?: components["schemas"]["FeedbackCategory"];
       /**
-       * @description Whether the user has requested to delete the issue.
-       *
-       *     This flag means:
-       *     - If the user has requested to delete the issue, we will delete it from GitHub after processing it
-       *     - If the user has not requested to delete the issue, we will not delete it from GitHub and it will remain as a closed issue.
-       */
-      readonly deletion_requested: boolean;
-      /**
        * @description Whether the user has checked the privacy-checkbox.
        *
        *     We are posting the feedback publicly on GitHub (not a EU-Company).

--- a/webclient/app/components/AppFooter.vue
+++ b/webclient/app/components/AppFooter.vue
@@ -49,7 +49,6 @@ const navigation = computed(() => [
                   category: 'general',
                   subject: '',
                   body: '',
-                  deletion_requested: false,
                 };
               }
             "

--- a/webclient/app/components/CalendarModal.vue
+++ b/webclient/app/components/CalendarModal.vue
@@ -55,7 +55,6 @@ ${error}
 
 In case you have trouble replicating this bug, my environment is PLEASE_INSERT_YOUR_BROWSER_HERE.
 I also did PLEASE_INSERT_IF_YOU_DID_SOMETHING_SPECIAL_BEFOREHAND`,
-                      deletion_requested: false,
                     };
                   }
                 "

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -18,7 +18,6 @@ function switchToFeedback() {
     category: "entry",
     subject: `[${id}]: `,
     body: "",
-    deletion_requested: false,
   };
 }
 

--- a/webclient/app/components/FeedbackModal.vue
+++ b/webclient/app/components/FeedbackModal.vue
@@ -3,7 +3,6 @@ import { useEditProposal } from "~/composables/editProposal";
 import { useFeedback } from "~/composables/feedback";
 
 const { t } = useI18n({ useScope: "local" });
-const deleteIssueRequested = ref(false);
 const feedback = useFeedback();
 const editProposal = useEditProposal();
 const route = useRoute();
@@ -66,8 +65,6 @@ function switchToEditProposal() {
         />
         <p class="text-zinc-500 dark:text-zinc-400 text-xs">{{ t("helptext." + feedback.data.category) }}</p>
       </div>
-
-      <Checkbox id="delete-issue" v-model="deleteIssueRequested">{{ t("delete") }}</Checkbox>
     </template>
     <template #success="{ successUrl }">
       <p>{{ t("success.thank_you") }}</p>
@@ -83,7 +80,6 @@ function switchToEditProposal() {
 <i18n lang="yaml">
 de:
   category: Feedback-Kategorie
-  delete: Das zugehörige GitHub Issue löschen, sobald es gelöst wurde.
   helptext:
     bug: Welchen Fehler hast du gefunden? Wo hast du ihn gefunden? Bitte gib eine genaue Beschreibung an.
     entry: Feedback zu einem Eintrag. Wir können Räume/Gebäude/Standorte hinzufügen und alle Daten, die du siehst (Namen, Koordinaten, Adressen, ...) anpassen. Was können wir verbessern?
@@ -111,7 +107,6 @@ de:
     navigation: Navigation
 en:
   category: Feedback category
-  delete: Delete this GitHub issue when resolved.
   helptext:
     bug: Which bug did you find? Where did you find it? Please provide a detailed description.
     entry: Feedback about an entry. We can add rooms/buildings/locations and adjust all data you see (names, coordinates, addresses, ...). What can we improve?

--- a/webclient/app/components/NavigationDisclaimerToast.vue
+++ b/webclient/app/components/NavigationDisclaimerToast.vue
@@ -25,7 +25,6 @@ const { t } = useI18n({ useScope: "local" });
             category: 'navigation',
             subject: `navigation from \`${selectedFrom}\` to \`${selectedTo}\``,
             body: !!comingFrom ? t('got_here_and_found_issues', [comingFrom]) : t('found_issues'),
-            deletion_requested: false,
           };
         }
       "

--- a/webclient/app/components/TokenBasedEditProposalModal.vue
+++ b/webclient/app/components/TokenBasedEditProposalModal.vue
@@ -184,60 +184,28 @@ function sendForm() {
       <slot name="modal" />
       <div class="mt-6">
         <Checkbox id="privacy-checked" v-model="privacyChecked">
-          <template #default>
-            <I18nT tag="p" keypath="public.agreement" class="font-bold">
-              <template #github_project_issues>
-                <NuxtLink
-                  tabindex="1"
-                  class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
-                  to="https://github.com/TUM-Dev/navigatum/issues"
-                  target="_blank"
-                  external
-                >
-                  {{ t("public.github_project_issues") }}
-                </NuxtLink>
-              </template>
-            </I18nT>
-          </template>
-          <template #helptext>
-            <p>
-              <I18nT tag="span" keypath="public.disclaimer">
-                <template #github_site_policy>
-                  <NuxtLink
-                    tabindex="1"
-                    class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
-                    to="https://docs.github.com/en/github/site-policy"
-                    target="_blank"
-                    external
-                  >
-                    {{ t("public.github_site_policy") }}
-                  </NuxtLink>
-                </template>
-              </I18nT>
-              {{ t("public.processing_based_on_gdpr") }}
-            </p>
-            <p>
-              {{ t("public.right_to_information") }}
-              {{ t("public.right_of_appeal") }}
-            </p>
-            <p>
-              <I18nT keypath="public.objection_instruction" tag="span">
-                <template #imprint>
-                  <NuxtLinkLocale tabindex="1" to="/about/impressum" class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline">
-                    {{ t("public.imprint") }}
-                  </NuxtLinkLocale>
-                </template>
-              </I18nT>
-              <br />
-              <I18nT keypath="public.question_contact">
-                <template #datenschutz>
-                  <NuxtLink tabindex="1" class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline" to="https://datenschutz.tum.de" target="_blank" external
-                    >datenschutz.tum.de
-                  </NuxtLink>
-                </template>
-              </I18nT>
-            </p>
-          </template>
+          <I18nT tag="span" keypath="public.consent">
+            <template #github>
+              <NuxtLink
+                tabindex="1"
+                class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
+                to="https://github.com/TUM-Dev/NavigaTUM"
+                target="_blank"
+                external
+              >
+                GitHub
+              </NuxtLink>
+            </template>
+            <template #privacy_policy>
+              <NuxtLink
+                tabindex="1"
+                :to="t('public.privacy_policy_url')"
+                class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
+              >
+                {{ t("public.privacy_policy") }}
+              </NuxtLink>
+            </template>
+          </I18nT>
         </Checkbox>
       </div>
     </div>
@@ -295,16 +263,9 @@ de:
   validation_failures:
     title: "Folgende Einträge konnten nicht angelegt werden:"
   public:
-    agreement: Meine Änderungsvorschläge dürfen anonym, aber öffentlich zugänglich auf der {github_project_issues} gespeichert werden.
-    disclaimer: Mit der Nutzung dieses Formulars stimmst du explizit den {github_site_policy} sowie einer möglichen Übertragung der Daten außerhalb der Europäischen Union zu.
-    github_project_issues: GitHub Projektseite
-    github_site_policy: Nutzungsbedingungen und Datenschutzbestimmungen von GitHub
-    imprint: Impressum gelisteten Kontaktmöglichkeiten
-    objection_instruction: Falls du dies ablehnst, schreibe uns bitte über navigatum (at-symbol) tum.de, oder eine der anderen Optionen aus unserem {imprint}.
-    processing_based_on_gdpr: Die Verarbeitung basiert auf Grundlage des Art. 6 Abs.1 lit. a DSGVO.
-    question_contact: Bei Fragen kannst du dich gerne an uns (navigatum (at-symbol) tum.de) oder an unseren Datenschutzbeauftragten ({datenschutz}) wenden.
-    right_of_appeal: Es besteht zudem ein Beschwerderecht beim Bayerischen Landesbeauftragten für den Datenschutz.
-    right_to_information: Unter den gesetzlichen Voraussetzungen und einem vorhandenen Personenbezug der Daten besteht ein Recht auf Auskunft, sowie auf Berichtigung oder Löschung oder auf Einschränkung der Verarbeitung oder eines Widerspruchsrechts gegen die Verarbeitung sowie des Rechts auf Datenübertragbarkeit.
+    consent: Ich verstehe, dass mein Änderungsvorschlag auf {github} veröffentlicht und gemäß der {privacy_policy} verarbeitet wird. Mit dem Absenden dieses Formulars willige ich in diese Verarbeitung ein.
+    privacy_policy: Datenschutzerklärung
+    privacy_policy_url: /about/datenschutz
   sending: Wird gesendet
   try_again_later: Bitte versuche es später noch einmal
   send: Senden
@@ -331,16 +292,9 @@ en:
   validation_failures:
     title: "These entries could not be created:"
   public:
-    agreement: My edit proposal data may be stored anonymously but publicly accessible on the {github_project_issues}.
-    disclaimer: By using this edit proposal form, you explicitly agree to the {github_site_policy} as well as a possible transfer of the data outside the European Union.
-    github_project_issues: GitHub project page
-    github_site_policy: terms of use and privacy policy of GitHub
-    imprint: contact options listed in our imprint
-    objection_instruction: If you object to this, please write to us via navigatum (at-symbol) tum.de, or one of the other other options from the {imprint}.
-    processing_based_on_gdpr: The processing is based on Art. 6 para. 1 lit. a DSGVO.
-    question_contact: If you have any questions, please feel free to contact us (navigatum (at-symbol) tum.de) or our data protection officer ({datenschutz}).
-    right_of_appeal: There is also a right of appeal to the Bavarian State Commissioner for Data Protection.
-    right_to_information: Under the legal conditions and an existing personal reference of the data, there is a right to information, as well as to correction or deletion or to restriction of processing or a right to object to processing as well as the right to data portability.
+    consent: I understand that my edit proposal will be published on {github} and processed in accordance with the {privacy_policy}. By submitting this form, I consent to this processing.
+    privacy_policy: Privacy Policy
+    privacy_policy_url: /en/about/privacy
   sending: Sending
   try_again_later: Please try again later
   send: Send

--- a/webclient/app/components/TokenBasedFeedbackModal.vue
+++ b/webclient/app/components/TokenBasedFeedbackModal.vue
@@ -114,69 +114,28 @@ function sendForm() {
       <slot name="modal" />
       <div>
         <Checkbox id="privacy-checked" v-model="privacyChecked">
-          <template #default>
-            <I18nT tag="p" keypath="public.agreement" class="font-bold">
-              <template #github_project_issues>
-                <NuxtLink
-                  tabindex="1"
-                  class="text-blue-600 visited:text-blue-600 hover:underline"
-                  to="https://github.com/TUM-Dev/navigatum/issues"
-                  target="_blank"
-                  external
-                >
-                  {{ t("public.github_project_issues") }}
-                </NuxtLink>
-              </template>
-            </I18nT>
-          </template>
-          <template #helptext>
-            <p>
-              <I18nT tag="span" keypath="public.disclaimer">
-                <template #github_site_policy>
-                  <NuxtLink
-                    tabindex="1"
-                    class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
-                    to="https://docs.github.com/en/github/site-policy"
-                    target="_blank"
-                    external
-                  >
-                    {{ t("public.github_site_policy") }}
-                  </NuxtLink>
-                </template>
-              </I18nT>
-              {{ t("public.processing_based_on_gdpr") }}
-            </p>
-            <p>
-              {{ t("public.right_to_information") }}
-              {{ t("public.right_of_appeal") }}
-            </p>
-            <p>
-              <I18nT keypath="public.objection_instruction" tag="span">
-                <template #imprint>
-                  <NuxtLinkLocale
-                    tabindex="1"
-                    to="/about/impressum"
-                    class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
-                  >
-                    {{ t("public.imprint") }}
-                  </NuxtLinkLocale>
-                </template>
-              </I18nT>
-              <br />
-              <I18nT keypath="public.question_contact">
-                <template #datenschutz>
-                  <NuxtLink
-                    tabindex="1"
-                    class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
-                    to="https://datenschutz.tum.de"
-                    target="_blank"
-                    external
-                    >datenschutz.tum.de
-                  </NuxtLink>
-                </template>
-              </I18nT>
-            </p>
-          </template>
+          <I18nT tag="span" keypath="public.consent">
+            <template #github>
+              <NuxtLink
+                tabindex="1"
+                class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
+                to="https://github.com/TUM-Dev/NavigaTUM"
+                target="_blank"
+                external
+              >
+                GitHub
+              </NuxtLink>
+            </template>
+            <template #privacy_policy>
+              <NuxtLink
+                tabindex="1"
+                :to="t('public.privacy_policy_url')"
+                class="text-blue-600 dark:text-blue-300 visited:text-blue-600 dark:visited:text-blue-300 hover:underline"
+              >
+                {{ t("public.privacy_policy") }}
+              </NuxtLink>
+            </template>
+          </I18nT>
         </Checkbox>
       </div>
     </div>
@@ -232,16 +191,9 @@ de:
     send_unexpected_status: Unerwarteter Status Code
     server_error: Server Fehler
   public:
-    agreement: Meine Feedback Daten (Betreff und Nachricht) dürfen anonym, aber öffentlich zugänglich auf der {github_project_issues} gespeichert werden.
-    disclaimer: Mit der Nutzung dieses Feedbackformulars stimmst du explizit den {github_site_policy} sowie einer möglichen Übertragung der Daten außerhalb der Europäischen Union zu.
-    github_project_issues: GitHub Projektseite
-    github_site_policy: Nutzungsbedingungen und Datenschutzbestimmungen von GitHub
-    imprint: Impressum gelisteten Kontaktmöglichkeiten
-    objection_instruction: Falls du dies ablehnst, schreibe uns bitte über navigatum (at-symbol) tum.de, oder eine der anderen Optionen aus unserem {imprint}.
-    processing_based_on_gdpr: Die Verarbeitung basiert auf Grundlage des Art. 6 Abs.1 lit. a DSGVO.
-    question_contact: Bei Fragen kannst du dich gerne an uns (navigatum (at-symbol) tum.de) oder an unseren Datenschutzbeauftragten ({datenschutz}) wenden.
-    right_of_appeal: Es besteht zudem ein Beschwerderecht beim Bayerischen Landesbeauftragten für den Datenschutz.
-    right_to_information: Unter den gesetzlichen Voraussetzungen und einem vorhandenen Personenbezug der Daten besteht ein Recht auf Auskunft, sowie auf Berichtigung oder Löschung oder auf Einschränkung der Verarbeitung oder eines Widerspruchsrechts gegen die Verarbeitung sowie des Rechts auf Datenübertragbarkeit.
+    consent: Ich verstehe, dass mein Feedback auf {github} veröffentlicht und gemäß der {privacy_policy} verarbeitet wird. Mit dem Absenden dieses Formulars willige ich in diese Verarbeitung ein.
+    privacy_policy: Datenschutzerklärung
+    privacy_policy_url: /about/datenschutz
   sending: Wird gesendet
   try_again_later: Bitte versuche es später noch einmal
   send: Senden
@@ -266,16 +218,9 @@ en:
     server_error: Server Error
     send_unexpected_status: Unexpected status code
   public:
-    agreement: My feedback data (subject and message) may be stored anonymously but publicly accessible on the {github_project_issues}.
-    disclaimer: By using this feedback form, you explicitly agree to the {github_site_policy} as well as a possible transfer of the data outside the European Union.
-    github_project_issues: GitHub project page
-    github_site_policy: terms of use and privacy policy of GitHub
-    imprint: contact options listed in our imprint
-    objection_instruction: If you object to this, please write to us via navigatum (at-symbol) tum.de, or one of the other other options from the {imprint}.
-    processing_based_on_gdpr: The processing is based on Art. 6 para. 1 lit. a DSGVO.
-    question_contact: If you have any questions, please feel free to contact us (navigatum (at-symbol) tum.de) or our data protection officer ({datenschutz}).
-    right_of_appeal: There is also a right of appeal to the Bavarian State Commissioner for Data Protection.
-    right_to_information: Under the legal conditions and an existing personal reference of the data, there is a right to information, as well as to correction or deletion or to restriction of processing or a right to object to processing as well as the right to data portability.
+    consent: I understand that my feedback will be published on {github} and processed in accordance with the {privacy_policy}. By submitting this form, I consent to this processing.
+    privacy_policy: Privacy Policy
+    privacy_policy_url: /en/about/privacy
   sending: Sending
   try_again_later: not possible
   send: Send

--- a/webclient/app/composables/feedback.ts
+++ b/webclient/app/composables/feedback.ts
@@ -12,6 +12,5 @@ export const useFeedback = () =>
       category: "general",
       subject: "",
       body: "",
-      deletion_requested: false,
     },
   }));

--- a/webclient/app/error.vue
+++ b/webclient/app/error.vue
@@ -49,7 +49,6 @@ useSeoMeta({
                   category: 'bug',
                   subject: `404 on \`${currentPath}\``,
                   body: t('got_here'),
-                  deletion_requested: false,
                 };
               }
             "

--- a/webclient/app/pages/search.vue
+++ b/webclient/app/pages/search.vue
@@ -100,7 +100,6 @@ useSeoMeta({
               category: 'search',
               subject: '',
               body: '',
-              deletion_requested: false,
             };
           }
         "


### PR DESCRIPTION
Removes the inert `deletion_requested` feedback field end-to-end and collapses the verbose GDPR consent block into a single consent sentence linking to the privacy policy (with the link wired per-locale to match `AppFooter`'s convention rather than relying on a redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)