### PR TITLE
feat(data,server,webclient): route overview entries to canonical /{type}/{id} paths

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -942,9 +942,6 @@ components:
         id:
           type: string
           description: The id of the entry
-        type:
-          $ref: '#/components/schemas/BuildingsOverviewItemTypeResponse'
-          description: The type of the entry, used to build its canonical `/{type}/{id}` route.
         name:
           type: string
           description: Human display name
@@ -956,12 +953,15 @@ components:
             - string
             - "null"
           description: The thumbnail for the building
+        type:
+          $ref: '#/components/schemas/BuildingsOverviewItemTypeResponse'
+          description: The type of the entry, used to build its canonical `/{type}/{id}` route.
     BuildingsOverviewItemTypeResponse:
       type: string
       description: |-
         The type of a building-overview child.
 
-        A strict subset of `LocationTypeResponse`: the overview only ever lists the
+        A strict subset of [`LocationTypeResponse`]: the overview only ever lists the
         container types whose `subtext` the data pipeline knows how to render
         (`generate_buildings_overview` in `data/processors/sections.py`). Modelling it
         separately lets clients build the canonical `/{type}/{id}` route without a

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -935,12 +935,16 @@ components:
       type: object
       required:
         - id
+        - type
         - name
         - subtext
       properties:
         id:
           type: string
           description: The id of the entry
+        type:
+          $ref: '#/components/schemas/BuildingsOverviewItemTypeResponse'
+          description: The type of the entry, used to build its canonical `/{type}/{id}` route.
         name:
           type: string
           description: Human display name
@@ -952,6 +956,21 @@ components:
             - string
             - "null"
           description: The thumbnail for the building
+    BuildingsOverviewItemTypeResponse:
+      type: string
+      description: |-
+        The type of a building-overview child.
+
+        A strict subset of `LocationTypeResponse`: the overview only ever lists the
+        container types whose `subtext` the data pipeline knows how to render
+        (`generate_buildings_overview` in `data/processors/sections.py`). Modelling it
+        separately lets clients build the canonical `/{type}/{id}` route without a
+        non-routable fallback.
+      enum:
+        - building
+        - joined_building
+        - area
+        - site
     BuildingsOverviewResponse:
       type: object
       required:

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -534,6 +534,7 @@ def generate_buildings_overview(df: pl.DataFrame) -> pl.DataFrame:
             b_overview["entries"].append(
                 {
                     "id": child_id,
+                    "type": child["type"],
                     "name": child.get("short_name") or child["name"],
                     "subtext": subtext,
                     "thumb": imgs[0]["name"] if imgs else None,

--- a/data/processors/test_sections.py
+++ b/data/processors/test_sections.py
@@ -1,0 +1,90 @@
+from typing import TypedDict
+
+import orjson
+import polars as pl
+
+from processors.sections import generate_buildings_overview
+
+
+class LookupRow(TypedDict):
+    """One node as `generate_buildings_overview` reads it from the export frame."""
+
+    id: str
+    type: str
+    name: str
+    short_name: str | None
+    props_stats_n_rooms: int
+    props_stats_n_buildings: int
+    imgs_json: str | None
+    children_flat: list[str] | None
+    children: list[str] | None
+    generators_json: str | None
+    sections_buildings_overview_json: str | None
+
+
+class OverviewEntry(TypedDict):
+    """One decoded entry of a parent's `buildings_overview` section."""
+
+    id: str
+    type: str
+    name: str
+    subtext: str
+    thumb: str | None
+
+
+def _lookup_row(
+    _id: str,
+    _type: str,
+    name: str,
+    *,
+    n_rooms: int = 0,
+    n_buildings: int = 0,
+    children: list[str] | None = None,
+    children_flat: list[str] | None = None,
+) -> LookupRow:
+    """One node as `generate_buildings_overview` expects it in the global lookup."""
+    return {
+        "id": _id,
+        "type": _type,
+        "name": name,
+        "short_name": None,
+        "props_stats_n_rooms": n_rooms,
+        "props_stats_n_buildings": n_buildings,
+        "imgs_json": None,
+        "children_flat": children_flat,
+        "children": children,
+        "generators_json": None,
+        "sections_buildings_overview_json": None,
+    }
+
+
+def _overview_entries(df: pl.DataFrame, parent_id: str) -> list[OverviewEntry]:
+    """Run the generator and decode the parent's resulting overview entries."""
+    result = generate_buildings_overview(df)
+    raw = result.filter(pl.col("id") == parent_id)["sections_buildings_overview_json"].item()
+    entries: list[OverviewEntry] = orjson.loads(raw)["entries"]
+    return entries
+
+
+def test_buildings_overview_entries_carry_child_type() -> None:
+    """
+    Each overview entry exposes the child's entity `type`.
+
+    A campus lists children of mixed types (building, area, site). The frontend routes
+    them to type-specific canonical paths (area/site -> /site, building -> /building), so
+    the type must travel with each entry rather than being inferred client-side.
+    """
+    children = ["b1", "a1", "s1"]
+    df = pl.DataFrame(
+        [
+            _lookup_row("root", "campus", "Root", children=children, children_flat=children),
+            _lookup_row("b1", "building", "Bravo", n_rooms=5),
+            _lookup_row("a1", "area", "Alpha", n_rooms=100, n_buildings=3),
+            _lookup_row("s1", "site", "Sierra", n_rooms=50, n_buildings=2),
+        ],
+    )
+
+    entries = _overview_entries(df, "root")
+
+    types_by_id = {e["id"]: e["type"] for e in entries}
+    assert types_by_id == {"b1": "building", "a1": "area", "s1": "site"}

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -751,7 +751,10 @@ mod tests {
         }))
         .unwrap();
 
-        assert!(matches!(entry.r#type, BuildingsOverviewItemTypeResponse::Area));
+        assert!(matches!(
+            entry.r#type,
+            BuildingsOverviewItemTypeResponse::Area
+        ));
         assert_eq!(serde_json::to_value(&entry).unwrap()["type"], "area");
     }
 

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -263,10 +263,29 @@ struct SectionsResponse {
     featured_overview: Option<FeaturedOverviewResponse>,
 }
 
+/// The type of a building-overview child.
+///
+/// A strict subset of [`LocationTypeResponse`]: the overview only ever lists the
+/// container types whose `subtext` the data pipeline knows how to render
+/// (`generate_buildings_overview` in `data/processors/sections.py`). Modelling it
+/// separately lets clients build the canonical `/{type}/{id}` route without a
+/// non-routable fallback.
+#[derive(Serialize, Deserialize, Debug, Default, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+enum BuildingsOverviewItemTypeResponse {
+    #[default]
+    Building,
+    JoinedBuilding,
+    Area,
+    Site,
+}
+
 #[derive(Deserialize, Serialize, Debug, Default, utoipa::ToSchema)]
 struct BuildingsOverviewItemResponse {
     /// The id of the entry
     id: String,
+    /// The type of the entry, used to build its canonical `/{type}/{id}` route.
+    r#type: BuildingsOverviewItemTypeResponse,
     /// Human display name
     name: String,
     /// What should be displayed below this Building
@@ -719,5 +738,36 @@ mod tests {
         settings.bind(|| {
             insta::assert_json_snapshot!(key.clone(), body_value, {".hash" => 0});
         });
+    }
+
+    #[test]
+    fn building_overview_entry_round_trips_type() {
+        let entry: BuildingsOverviewItemResponse = serde_json::from_value(serde_json::json!({
+            "id": "5510",
+            "type": "area",
+            "name": "Stammgelände",
+            "subtext": "12 Gebäude, 345 Räume",
+            "thumb": null,
+        }))
+        .unwrap();
+
+        assert!(matches!(entry.r#type, BuildingsOverviewItemTypeResponse::Area));
+        assert_eq!(serde_json::to_value(&entry).unwrap()["type"], "area");
+    }
+
+    #[test]
+    fn building_overview_entry_rejects_non_container_type() {
+        // The overview only lists container types; a leaf type like `room` is not a valid
+        // entry, so the strict enum rejects it rather than silently routing it wrong.
+        let parsed: Result<BuildingsOverviewItemResponse, _> =
+            serde_json::from_value(serde_json::json!({
+                "id": "5510.01.250",
+                "type": "room",
+                "name": "Seminarraum",
+                "subtext": "",
+                "thumb": null,
+            }));
+
+        assert!(parsed.is_err());
     }
 }

--- a/tests/specs/calendar-about.ui.spec.ts
+++ b/tests/specs/calendar-about.ui.spec.ts
@@ -92,7 +92,7 @@ test.describe("Calendar Page - Actions", () => {
     const heading = page.getByRole("heading", { name: "Kalender" }).first();
     await expect(heading).toBeVisible({ timeout: 10000 });
 
-    const backLink = page.locator('a[href*="/view/5602"]').first();
+    const backLink = page.locator('a[href*="/room/5602."]').first();
     await expect(backLink).toBeVisible();
   });
 });

--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -309,7 +309,7 @@ test.describe("Details Page - Building Overview", () => {
     // view -> building redirect
     await expect(page).toHaveURL("building/5602");
 
-    const roomLink = page.locator('a[href*="/view/5602."]').first();
+    const roomLink = page.locator('a[href*="/room/5602."]').first();
     await expect(roomLink).toBeVisible();
     // await expect(page).toHaveScreenshot();
     await roomLink.click();

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -419,6 +419,8 @@ export type components = {
     readonly BuildingsOverviewItemResponse: {
       /** @description The id of the entry */
       readonly id: string;
+      /** @description The type of the entry, used to build its canonical `/{type}/{id}` route. */
+      readonly type: components["schemas"]["BuildingsOverviewItemTypeResponse"];
       /** @description Human display name */
       readonly name: string;
       /** @description What should be displayed below this Building */
@@ -426,6 +428,16 @@ export type components = {
       /** @description The thumbnail for the building */
       readonly thumb?: string | null;
     };
+    /**
+     * @description The type of a building-overview child.
+     *
+     *     A strict subset of `LocationTypeResponse`: the overview only ever lists the
+     *     container types whose `subtext` the data pipeline knows how to render
+     *     (`generate_buildings_overview` in `data/processors/sections.py`). Modelling it
+     *     separately lets clients build the canonical `/{type}/{id}` route without a
+     *     non-routable fallback.
+     */
+    readonly BuildingsOverviewItemTypeResponse: "building" | "joined_building" | "area" | "site";
     readonly BuildingsOverviewResponse: {
       readonly entries: readonly components["schemas"]["BuildingsOverviewItemResponse"][];
       /** Format: int32 */

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -419,23 +419,24 @@ export type components = {
     readonly BuildingsOverviewItemResponse: {
       /** @description The id of the entry */
       readonly id: string;
-      /** @description The type of the entry, used to build its canonical `/{type}/{id}` route. */
-      readonly type: components["schemas"]["BuildingsOverviewItemTypeResponse"];
       /** @description Human display name */
       readonly name: string;
       /** @description What should be displayed below this Building */
       readonly subtext: string;
       /** @description The thumbnail for the building */
       readonly thumb?: string | null;
+      /** @description The type of the entry, used to build its canonical `/{type}/{id}` route. */
+      readonly type: components["schemas"]["BuildingsOverviewItemTypeResponse"];
     };
     /**
      * @description The type of a building-overview child.
      *
-     *     A strict subset of `LocationTypeResponse`: the overview only ever lists the
+     *     A strict subset of [`LocationTypeResponse`]: the overview only ever lists the
      *     container types whose `subtext` the data pipeline knows how to render
      *     (`generate_buildings_overview` in `data/processors/sections.py`). Modelling it
      *     separately lets clients build the canonical `/{type}/{id}` route without a
      *     non-routable fallback.
+     * @enum {string}
      */
     readonly BuildingsOverviewItemTypeResponse: "building" | "joined_building" | "area" | "site";
     readonly BuildingsOverviewResponse: {

--- a/webclient/app/components/CalendarRoomSelector.vue
+++ b/webclient/app/components/CalendarRoomSelector.vue
@@ -3,6 +3,7 @@ import { mdiCalendar, mdiPlusCircle } from "@mdi/js";
 import type { components } from "~/api_types";
 import PreviewIcon from "~/components/PreviewIcon.vue";
 import { useCalendar } from "~/composables/calendar";
+import { entityPath, isRoutableEntityType } from "~/utils/entityPath";
 
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 type CalendarLocationResponse = components["schemas"]["CalendarLocationResponse"];
@@ -70,7 +71,13 @@ async function addLocation() {
         }"
       />
       <div class="text-zinc-600 dark:text-zinc-300 flex flex-col gap-1">
-        <NuxtLinkLocale class="line-clamp-1 hover:underline" :to="'/view/' + key">{{ location.name }}</NuxtLinkLocale>
+        <NuxtLinkLocale
+          v-if="isRoutableEntityType(location.type)"
+          class="line-clamp-1 hover:underline"
+          :to="entityPath(key, location.type)"
+          >{{ location.name }}</NuxtLinkLocale
+        >
+        <span v-else class="line-clamp-1">{{ location.name }}</span>
         <small>
           {{ location.type_common_name }}
         </small>

--- a/webclient/app/components/DetailsBuildingOverviewSection.vue
+++ b/webclient/app/components/DetailsBuildingOverviewSection.vue
@@ -2,6 +2,7 @@
 import { mdiChevronDown, mdiChevronRight, mdiChevronUp, mdiOfficeBuilding } from "@mdi/js";
 import { useToggle } from "@vueuse/core";
 import type { components } from "~/api_types";
+import { entityPath } from "~/utils/entityPath";
 
 type BuildingsOverviewResponse = components["schemas"]["BuildingsOverviewResponse"];
 
@@ -22,7 +23,7 @@ const runtimeConfig = useRuntimeConfig();
       <template v-for="(b, i) in props.buildings.entries" :key="b.id">
         <NuxtLinkLocale
           v-if="i < props.buildings.n_visible || buildingsExpanded"
-          :to="'/view/' + b.id"
+          :to="entityPath(b.id, b.type)"
           class="focusable border-zinc-200 dark:border-zinc-700 flex flex-row items-center justify-between rounded-sm border border-solid p-3.5 !no-underline hover:bg-zinc-100 dark:hover:bg-zinc-800"
           :aria-label="t('show_details_for', [b.name])"
         >

--- a/webclient/app/components/DetailsRoomOverviewSection.vue
+++ b/webclient/app/components/DetailsRoomOverviewSection.vue
@@ -3,6 +3,7 @@ import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from "@headless
 import { mdiCheck, mdiFilter, mdiMagnify, mdiMapMarker, mdiUnfoldMoreHorizontal } from "@mdi/js";
 import { useVirtualList } from "@vueuse/core";
 import type { components } from "~/api_types";
+import { entityPath } from "~/utils/entityPath";
 
 type RoomsOverviewResponse = components["schemas"]["RoomsOverviewResponse"];
 type RoomsOverviewUsageChildResponse = components["schemas"]["RoomsOverviewUsageChildResponse"];
@@ -165,7 +166,7 @@ const { list, containerProps, wrapperProps } = useVirtualList<RoomsOverviewUsage
             <NuxtLinkLocale
               v-for="(room, index) in list"
               :key="index"
-              :to="`/view/${room.data.id}`"
+              :to="entityPath(room.data.id, 'room')"
               class="flex h-[36px] max-h-[36px] min-h-[36px] flex-row gap-2 p-1.5 px-3 hover:text-white dark:hover:text-black hover:bg-blue-500 dark:hover:bg-blue-400"
             >
               <MdiIcon :path="mdiMapMarker" :size="16" class="my-auto" aria-hidden="true" />


### PR DESCRIPTION
## What

Building-overview and calendar links previously pointed at the generic `/view/{id}` route. This carries each building-overview child's entity `type` from the data pipeline through the details API so the webclient can build the canonical `/{type}/{id}` path directly (via the existing `entityPath` helper from #3110).

## Changes

- **data**: emit `type` per entry in `generate_buildings_overview`, with a test asserting a mixed-type campus carries `building`/`area`/`site` through to its overview entries.
- **server**: model the field as a strict `BuildingsOverviewItemTypeResponse` enum — the container subset of `LocationTypeResponse` — so non-routable types like `room` are rejected at deserialization rather than silently mis-routed. Covered by round-trip and rejection unit tests.
- **webclient**: link via `entityPath()` in the building and room overview sections and the calendar room selector, gated by `isRoutableEntityType`.
- OpenAPI spec and generated `api_types` updated in lockstep.

## Verification

- `uv run pytest processors/test_sections.py` — passes.
- `pnpm --dir webclient type-check` — clean.
- `cargo check --manifest-path server/Cargo.toml --tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)