### PR TITLE
refactor(data): ban explicit `Any` via mypy disallow_any_explicit

### DIFF
--- a/data/compile.py
+++ b/data/compile.py
@@ -3,12 +3,12 @@ import logging
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
 from multiprocessing import Process
-from typing import Any
 
 import polars as pl
 import processors.areatree.process as areatree
 import yaml
 from external.loaders.opening_hours import load_opening_hours
+from pipeline_types import Entry
 from processors import (
     aliases,
     coords,
@@ -139,7 +139,7 @@ def main() -> None:
 def _run_pipeline(
     *,
     resizer: Process,
-    fut_old_data: Future[list[Any]],
+    fut_old_data: Future[list[Entry]],
     fut_old_sitemaps: Future[SimplifiedSitemaps],
     fut_web_sitemap: Future[dict[str, datetime]],
 ) -> None:

--- a/data/external/scrapers/public_transport.py
+++ b/data/external/scrapers/public_transport.py
@@ -5,11 +5,11 @@ import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import backoff
 import polars as pl
 import requests
+from pipeline_types import FlatRow, Json
 from utils import setup_logging
 
 from external.schemas.public_transport import TRANSPORT_MODES, StationsSchema
@@ -120,7 +120,7 @@ def cluster_bboxes(coords: pl.DataFrame) -> list[Bbox]:
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=3)
-def _fetch_stops(session: requests.Session, bbox: Bbox) -> list[dict[str, Any]]:
+def _fetch_stops(session: requests.Session, bbox: Bbox) -> list[dict[str, Json]]:
     response = session.get(STOPS_ENDPOINT, params=bbox.as_query(), timeout=30)
     response.raise_for_status()
     payload = response.json()
@@ -129,7 +129,7 @@ def _fetch_stops(session: requests.Session, bbox: Bbox) -> list[dict[str, Any]]:
     return payload
 
 
-def _normalise_modes(raw: list[Any] | None) -> list[str]:
+def _normalise_modes(raw: list[Json] | None) -> list[str]:
     """Lowercase + dedupe motis mode strings; unknown values fold to `other`."""
     if not raw:
         return []
@@ -147,7 +147,7 @@ def _normalise_modes(raw: list[Any] | None) -> list[str]:
     return out
 
 
-def _stops_to_rows(stops: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _stops_to_rows(stops: list[dict[str, Json]]) -> list[FlatRow]:
     """Flatten motis stops into row dicts; no station-level folding yet."""
     rows = []
     for stop in stops:
@@ -199,7 +199,7 @@ def scrape_stations() -> None:
     bboxes = cluster_bboxes(coords)
     _logger.info(f"Discovered {len(bboxes)} geographic clusters from {coords.height} TUM coordinates")
 
-    all_rows: list[dict[str, Any]] = []
+    all_rows: list[FlatRow] = []
     with requests.Session() as session:
         for i, bbox in enumerate(bboxes):
             if i > 0:

--- a/data/pipeline_types.py
+++ b/data/pipeline_types.py
@@ -1,0 +1,10 @@
+"""Named aliases for the pipeline's dynamic boundaries, so `disallow_any_explicit` bans bare `Any` everywhere else."""
+
+from typing import Any
+
+# Deserialized JSON/YAML value (source file, HTTP payload, (de)serialization helper).
+type Json = Any  # type: ignore[explicit-any]
+# A nested API location entry; recursive and field-optional across entry kinds, so no fixed TypedDict fits.
+type Entry = dict[str, Json]
+# A flat DataFrame row keyed by column name, as yielded by `iter_rows(named=True)` or built up by hand.
+type FlatRow = dict[str, Json]

--- a/data/processors/areatree/test_areatree.py
+++ b/data/processors/areatree/test_areatree.py
@@ -1,7 +1,8 @@
 import logging
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import IO
 
 import pytest
 from external.loaders.tumonline import load_buildings
@@ -32,7 +33,7 @@ def test_extract_names_without_short_name() -> None:
     assert _extract_names(names) == expected_output
 
 
-def test_extract_names_with_long_short_name(caplog: Any) -> None:
+def test_extract_names_with_long_short_name(caplog: pytest.LogCaptureFixture) -> None:
     """If the short name is longer than 20 chars, a warning is raised"""
     names = ["Mechanical Engineering", "ThisIsAVeryLongNameForAShortName"]
     expected_output = {"name": "Mechanical Engineering", "short_name": "ThisIsAVeryLongNameForAShortName"}
@@ -118,7 +119,7 @@ def test_id_not_inferable() -> None:
 
 
 @pytest.fixture
-def areatree_tempfile() -> Any:
+def areatree_tempfile() -> Iterator[IO[str]]:
     """Bind AREATREE_FILE to a writable temp file; restore the original on teardown."""
     original = areatree.process.AREATREE_FILE
     with tempfile.NamedTemporaryFile(mode="w+") as file:
@@ -127,12 +128,12 @@ def areatree_tempfile() -> Any:
     areatree.process.AREATREE_FILE = original
 
 
-def test_empty_file(areatree_tempfile: Any) -> None:
+def test_empty_file(areatree_tempfile: IO[str]) -> None:
     """Empty file returns empty list"""
     assert not list(_areatree_lines())
 
 
-def test_comment_lines(areatree_tempfile: Any) -> None:
+def test_comment_lines(areatree_tempfile: IO[str]) -> None:
     """Comment lines are removed"""
     areatree_tempfile.write("line1\n")
     areatree_tempfile.write("\n")  # Empty line
@@ -142,7 +143,7 @@ def test_comment_lines(areatree_tempfile: Any) -> None:
     assert list(_areatree_lines()) == ["line1", "line2"]
 
 
-def test_inline_comments(areatree_tempfile: Any) -> None:
+def test_inline_comments(areatree_tempfile: IO[str]) -> None:
     """Inline comments are removed"""
     areatree_tempfile.write("line1#comment1\n")
     areatree_tempfile.write("line2#comment2 # comment 3\n")
@@ -150,7 +151,7 @@ def test_inline_comments(areatree_tempfile: Any) -> None:
     assert list(_areatree_lines()) == ["line1", "line2"]
 
 
-def test_file_preserves_indentation(areatree_tempfile: Any) -> None:
+def test_file_preserves_indentation(areatree_tempfile: IO[str]) -> None:
     """Indentation is preserved"""
     areatree_tempfile.write("  line1  \n")
     areatree_tempfile.write(" line2\n")

--- a/data/processors/df_utils.py
+++ b/data/processors/df_utils.py
@@ -1,7 +1,6 @@
-from typing import Any
-
 import orjson
 import polars as pl
+from pipeline_types import Entry, FlatRow, Json
 from utils import TranslatableStr
 
 _DEFAULT_DTYPE: pl.DataType = pl.Utf8()
@@ -22,7 +21,7 @@ def ensure_columns(df: pl.DataFrame, columns: dict[str, pl.DataType]) -> pl.Data
     return df
 
 
-def translatable_to_columns(field: str, value: Any) -> dict[str, str | None]:
+def translatable_to_columns(field: str, value: Json) -> dict[str, str | None]:
     """Split a TranslatableStr or plain string into ``{field}_de`` / ``{field}_en`` columns."""
     if value is None:
         return {f"{field}_de": None, f"{field}_en": None}
@@ -35,16 +34,16 @@ def translatable_to_columns(field: str, value: Any) -> dict[str, str | None]:
     return {f"{field}_de": str(value), f"{field}_en": str(value)}
 
 
-def to_json_or_none(value: Any) -> str | None:
+def to_json_or_none(value: Json) -> str | None:
     """``orjson.dumps`` ``value`` to a string, passing ``None`` through unchanged."""
     if value is None:
         return None
     return orjson.dumps(value).decode()
 
 
-def flatten_entry(entry_id: str, entry: dict[str, Any]) -> dict[str, Any]:
+def flatten_entry(entry_id: str, entry: Entry) -> FlatRow:
     """Convert a legacy nested dict entry into a flat column dict for DataFrame insertion."""
-    row: dict[str, Any] = {"id": entry_id}
+    row: FlatRow = {"id": entry_id}
 
     row["type"] = entry.get("type")
 
@@ -184,16 +183,16 @@ def flatten_entry(entry_id: str, entry: dict[str, Any]) -> dict[str, Any]:
     return row
 
 
-def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
+def unflatten_row(row: FlatRow) -> Entry:
     """Reconstruct the nested API dict from flat DataFrame columns."""
     name_de = row.get("name_de") or row.get("name")
     name_en = row.get("name_en")
     if name_de and name_en and name_de != name_en:
-        name_val: Any = {"en": name_en, "de": name_de}
+        name_val: Json = {"en": name_en, "de": name_de}
     else:
         name_val = name_de
 
-    result: dict[str, Any] = {
+    result: Entry = {
         "id": row["id"],
         "type": row["type"],
         "name": name_val,
@@ -220,8 +219,8 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
         if accuracy := row.get("coords_accuracy"):
             result["coords"]["accuracy"] = accuracy
 
-    props: dict[str, Any] = {}
-    ids: dict[str, Any] = {}
+    props: Entry = {}
+    ids: Entry = {}
     if b_id := row.get("props_ids_b_id"):
         ids["b_id"] = b_id
     if roomcode := row.get("props_ids_roomcode"):
@@ -231,7 +230,7 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
     if ids:
         props["ids"] = ids
 
-    address: dict[str, Any] = {}
+    address: Entry = {}
     if street := row.get("props_address_street"):
         address["street"] = street
     if plz_place := row.get("props_address_plz_place"):
@@ -241,7 +240,7 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
     if address:
         props["address"] = address
 
-    stats: dict[str, Any] = {}
+    stats: Entry = {}
     for key in [
         "n_rooms",
         "n_rooms_reg",
@@ -285,7 +284,7 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
         result["props"] = props
 
     if row.get("usage_name_de") or row.get("usage_din_277"):
-        usage: dict[str, Any] = {}
+        usage: Entry = {}
         if name_de := row.get("usage_name_de"):
             usage["name"] = {"en": row.get("usage_name_en"), "de": name_de}
         if din_277 := row.get("usage_din_277"):
@@ -296,7 +295,7 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
             usage["din277_name"] = din277_name
         result["usage"] = usage
 
-    ranking: dict[str, Any] = {}
+    ranking: Entry = {}
     for key in ["rank_type", "rank_usage", "rank_boost", "rank_custom", "rank_combined"]:
         if (rank := row.get(f"ranking_{key}")) is not None:
             ranking[key] = rank
@@ -333,7 +332,7 @@ def unflatten_row(row: dict[str, Any]) -> dict[str, Any]:
     if rooms_overview_json := row.get("sections_rooms_overview_json"):
         result.setdefault("sections", {})["rooms_overview"] = orjson.loads(rooms_overview_json)
 
-    sources: dict[str, Any] = {}
+    sources: Entry = {}
     if sources_base_json := row.get("sources_base_json"):
         sources["base"] = orjson.loads(sources_base_json)
     if sources_patched := row.get("sources_patched"):

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -1,6 +1,5 @@
 import re
 from pathlib import Path
-from typing import Any
 
 import orjson
 import polars as pl
@@ -11,13 +10,14 @@ from external.loaders.tumonline_orgs import load_tumonline_orgs
 from external.models.common import PydanticConfiguration
 from external.schemas.events import EventsSchema
 from external.schemas.tumonline_orgs import TumonlineOrgsSchema
+from pipeline_types import Entry, Json
 from utils import TranslatableStr
 from utils import TranslatableStr as _
 
 from processors.df_utils import unflatten_row
 
 
-def _orjson_default(o: Any) -> Any:
+def _orjson_default(o: Json) -> Json:
     if isinstance(o, PydanticConfiguration):
         return o.model_dump()
     raise TypeError(f"Object of type {type(o)} is not JSON serializable")
@@ -31,14 +31,14 @@ _REMOVED_NAMES_RE = re.compile(rb"bestelmeyer|gustav[ -]+niemann|prandtl|messers
 _ALLOWED_VARIATION_RE = re.compile(rb"prandtl[ -]+str", re.IGNORECASE)
 
 
-def _de(value: Any) -> Any:
+def _de(value: Json) -> Json:
     """Pick the German variant from a TranslatableStr-shaped dict; pass-through otherwise."""
     if isinstance(value, dict) and value.keys() <= {"de", "en"}:
         return value.get("de", value.get("en", {}))
     return value
 
 
-def maybe_slugify(value: str | None | TranslatableStr | dict[str, Any]) -> str | None:
+def maybe_slugify(value: str | None | TranslatableStr | dict[str, Json]) -> str | None:
     """Slugify a value if it exists"""
     if value is None:
         return None
@@ -57,7 +57,7 @@ def normalise_id(_id: str) -> str | None:
     return ".".join(parts)
 
 
-def reconstruct_data(df: pl.DataFrame) -> dict[str, Any]:
+def reconstruct_data(df: pl.DataFrame) -> dict[str, Entry]:
     """Reconstruct nested data dict from flat DataFrame (shared by search and API export)."""
     data = {}
     for row in df.to_dicts():
@@ -66,7 +66,7 @@ def reconstruct_data(df: pl.DataFrame) -> dict[str, Any]:
     return data
 
 
-def export_for_search(data: dict[str, Any]) -> None:
+def export_for_search(data: dict[str, Entry]) -> None:
     """Export a subset of the data for the /search api"""
     export = []
     for _id, entry in data.items():
@@ -140,7 +140,7 @@ def export_for_search(data: dict[str, Any]) -> None:
     search_df.write_parquet(OUTPUT_DIR_PATH / "search_data.parquet", use_pyarrow=True, compression_level=3)
 
 
-def extract_parent_building_names(data: dict[str, Any], parents: list[str], building_parents_index: int) -> list[str]:
+def extract_parent_building_names(data: dict[str, Entry], parents: list[str], building_parents_index: int) -> list[str]:
     """Extract the parents building names from the data"""
     # For rooms, the (joined_)building parents are extra to put more emphasis on them.
     short_names = [data[p]["short_name"] for p in parents[building_parents_index:] if "short_name" in data[p]]
@@ -173,7 +173,7 @@ def export_for_status() -> None:
     df.write_parquet(OUTPUT_DIR_PATH / "status_data.parquet", use_pyarrow=True, compression_level=3)
 
 
-def export_for_api(data: dict[str, Any]) -> None:
+def export_for_api(data: dict[str, Entry]) -> None:
     """Add some more information about parents to the data and export for the /locations/:id api"""
     export_data = []
     for entry in data.values():
@@ -188,7 +188,7 @@ def export_for_api(data: dict[str, Any]) -> None:
     df.write_parquet(OUTPUT_DIR_PATH / "alias_data.parquet", use_pyarrow=True, compression_level=3)
 
 
-def extract_exported_item(data: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+def extract_exported_item(data: dict[str, Entry], entry: Entry) -> Entry:
     """Extract the item that will be finally exported to the api"""
     parent_names = [data[p]["name"] if p != "root" else _("Standorte", "Sites") for p in entry["parents"]]
     # Parallel to `parents`/`parent_names`: each parent's type lets the client build the canonical

--- a/data/processors/images.py
+++ b/data/processors/images.py
@@ -5,7 +5,7 @@ import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 import orjson
 import polars as pl
@@ -13,6 +13,7 @@ import utils
 import yaml
 from external.models.common import PydanticConfiguration
 from PIL import Image
+from pipeline_types import Json
 from pydantic import Field
 from pydantic.networks import HttpUrl
 
@@ -38,7 +39,7 @@ class ImageSource(PydanticConfiguration):
     def load_all(cls) -> dict[str, list[ImageSource]]:
         """Load the image sources from the img-sources.yaml file"""
         with (IMAGE_BASE_PATH / "img-sources.yaml").open(encoding="utf-8") as file:
-            raw: dict[str, dict[int, dict[str, Any]]] = yaml.safe_load(file.read())
+            raw: dict[str, dict[int, dict[str, Json]]] = yaml.safe_load(file.read())
             image_sources = {k: [ImageSource(**v) for v in vs.values()] for k, vs in raw.items()}
         for key in image_sources:
             if not isinstance(key, str):
@@ -120,7 +121,7 @@ def parse_image_filename(image_name: str) -> tuple[str, int]:
     return _id, _index
 
 
-def _add_source_info(fname: str, source_data: dict[int, dict[str, Any]]) -> dict[str, Any] | None:
+def _add_source_info(fname: str, source_data: dict[int, dict[str, Json]]) -> dict[str, Json] | None:
     _id, _index = parse_image_filename(fname)
 
     required_fields = ["author", "license"]
@@ -129,7 +130,7 @@ def _add_source_info(fname: str, source_data: dict[int, dict[str, Any]]) -> dict
             _logger.warning(f"No {field} information for image '{fname}', it will not be used")
             return None
 
-    def _parse(obj: str | dict[str, Any]) -> dict[str, Any]:
+    def _parse(obj: str | dict[str, Json]) -> dict[str, Json]:
         return {"text": obj, "url": None} if isinstance(obj, str) else obj
 
     return {

--- a/data/processors/merge.py
+++ b/data/processors/merge.py
@@ -1,9 +1,9 @@
 from pathlib import Path
-from typing import Any
 
 import orjson
 import polars as pl
 import yaml
+from pipeline_types import Entry, FlatRow, Json
 from utils import TranslatableStr
 
 from processors.df_utils import flatten_entry
@@ -18,14 +18,14 @@ USAGES_CSV = SOURCES_PATH / "usages.csv"
 LINKS_YAML = SOURCES_PATH / "links.yaml"
 
 
-def load_yaml(path: Path) -> Any:
+def load_yaml(path: Path) -> Json:
     """
     Merge yaml data at path on top of the given data.
 
     This operates on the data dict directly without creating a copy.
     """
 
-    def add_translatable_str(value: str | list[Any] | dict[str, Any]) -> Any:
+    def add_translatable_str(value: str | list[Json] | dict[str, Json]) -> Json:
         """Recursively change all {de: ..., en:...] to a TranslatableStr"""
         if isinstance(value, bool | float | int | str) or value is None:
             return value
@@ -121,7 +121,7 @@ def _apply_patch_df(df: pl.DataFrame, patch_df: pl.DataFrame) -> pl.DataFrame:
     return result.drop(drop_cols)
 
 
-def _yaml_to_patch_df(yaml_data: dict[str, dict[str, Any]]) -> pl.DataFrame:
+def _yaml_to_patch_df(yaml_data: dict[str, Entry]) -> pl.DataFrame:
     """Convert a YAML dict of {id: entry_dict} to a flat DataFrame using flatten_entry."""
     rows = []
     for entry_id, entry in yaml_data.items():
@@ -178,7 +178,7 @@ def add_names(df: pl.DataFrame) -> pl.DataFrame:
     # Build a patch DataFrame with the right column names
     rows = []
     for row in names_df.iter_rows(named=True):
-        flat: dict[str, Any] = {"id": row["id"]}
+        flat: FlatRow = {"id": row["id"]}
         name = row.get("name")
         if name:
             flat["name"] = name

--- a/data/processors/patch.py
+++ b/data/processors/patch.py
@@ -2,7 +2,9 @@ import logging
 import re
 
 # python 3.11 feature => move to typing when 3.11 is mainstream
-from typing import Any, NotRequired, TypedDict
+from typing import NotRequired, TypedDict
+
+from pipeline_types import Entry
 
 _logger = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ class Patch(TypedDict):
     arch_name: NotRequired[str]
 
 
-def apply_roomcode_patch(objects: dict[str, dict[str, Any]], patches: list[Patch]) -> None:
+def apply_roomcode_patch(objects: dict[str, Entry], patches: list[Patch]) -> None:
     """
     Apply patches to objects.
 

--- a/data/processors/poi.py
+++ b/data/processors/poi.py
@@ -1,9 +1,9 @@
 import logging
 from pathlib import Path
-from typing import Any
 
 import orjson
 import polars as pl
+from pipeline_types import FlatRow
 from utils import TranslatableStr as _
 
 from processors import merge
@@ -24,7 +24,7 @@ def merge_poi(df: pl.DataFrame) -> pl.DataFrame:
     # Build parent lookup: id -> parents list
     parent_lookup = dict(zip(df["id"].to_list(), df["parents"].to_list(), strict=True))
 
-    new_rows: list[dict[str, Any]] = []
+    new_rows: list[FlatRow] = []
     for _id, poi in poi_data.items():
         if _id in existing_ids:
             raise ValueError(f"The id '{_id}' is already used, cannot use it for a new POI")
@@ -44,7 +44,7 @@ def merge_poi(df: pl.DataFrame) -> pl.DataFrame:
         for link in links:
             link["text"] = _(link["text"])
 
-        row: dict[str, Any] = {
+        row: FlatRow = {
             "id": _id,
             "type": "poi",
             "parents": parents,

--- a/data/processors/roomfinder.py
+++ b/data/processors/roomfinder.py
@@ -1,13 +1,13 @@
 import logging
 import re
 from pathlib import Path
-from typing import Any
 
 import orjson
 import polars as pl
 import yaml
 from external.loaders.roomfinder import load_buildings as load_rf_buildings
 from external.loaders.roomfinder import load_rooms as load_rf_rooms
+from pipeline_types import FlatRow, Json
 
 from processors.df_utils import ensure_column
 
@@ -138,7 +138,7 @@ def _rf_source_json(r_id: str) -> str:
     ).decode()
 
 
-def _rf_data_json(room: dict[str, Any]) -> str:
+def _rf_data_json(room: FlatRow) -> str:
     return orjson.dumps(
         {
             "r_alias": room["r_alias"],
@@ -170,12 +170,10 @@ def merge_roomfinder_rooms(df: pl.DataFrame) -> pl.DataFrame:
     )
 
     # Minimal id lookup for parent resolution and current-name reads.
-    id_lookup: dict[str, dict[str, Any]] = {
-        row["id"]: row for row in df.select("id", "parents", "name").iter_rows(named=True)
-    }
+    id_lookup: dict[str, FlatRow] = {row["id"]: row for row in df.select("id", "parents", "name").iter_rows(named=True)}
 
-    updates: dict[str, dict[str, Any]] = {}
-    new_rows: list[dict[str, Any]] = []
+    updates: dict[str, FlatRow] = {}
+    new_rows: list[FlatRow] = []
 
     for room in load_rf_rooms().iter_rows(named=True):
         try:
@@ -291,7 +289,7 @@ def merge_roomfinder_rooms(df: pl.DataFrame) -> pl.DataFrame:
 
 
 def _find_room_id(
-    room: dict[str, Any], id_lookup: dict[str, Any], arch_name_lookup: dict[str, str], patches: dict[str, Any]
+    room: FlatRow, id_lookup: dict[str, FlatRow], arch_name_lookup: dict[str, str], patches: dict[str, Json]
 ) -> str | None:
     if room["r_id"] in patches["ignore"]:
         return None

--- a/data/processors/sections.py
+++ b/data/processors/sections.py
@@ -1,9 +1,10 @@
 import logging
 import typing
-from typing import Any, TypedDict
+from typing import TypedDict
 
 import orjson
 import polars as pl
+from pipeline_types import Entry, FlatRow, Json
 from utils import TranslatableStr
 
 _logger = logging.getLogger(__name__)
@@ -194,7 +195,7 @@ def _build_sorted_floor_list(room_data: list[Room]) -> list[str]:
     return sorted(floors, key=floor_quantifier)
 
 
-def _get_floor_details(generators: dict[str, Any], room_data: list[Room]) -> list[FloorDetails]:
+def _get_floor_details(generators: dict[str, Json], room_data: list[Room]) -> list[FloorDetails]:
     """Infer for each floor the metadata and name string"""
     floors = _build_sorted_floor_list(room_data)
     floors_details: list[FloorDetails] = []
@@ -303,7 +304,7 @@ _COMPUTE_PROPS_INPUT_COLS = (
 )
 
 
-def _compute_props_json(row: dict[str, Any]) -> str:
+def _compute_props_json(row: FlatRow) -> str:
     props = _reconstruct_props(row)
     computed = _gen_computed_props(row["id"], row, props) if props else []
 
@@ -334,9 +335,9 @@ def compute_props(df: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def _reconstruct_props(row: dict[str, Any]) -> dict[str, Any]:
+def _reconstruct_props(row: FlatRow) -> Entry:
     """Reconstruct a nested props dict from flat DataFrame columns for use by helper functions."""
-    props: dict[str, Any] = {}
+    props: Entry = {}
 
     # ids
     ids = {}
@@ -385,7 +386,7 @@ def _reconstruct_props(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _append_if_present(
-    props: dict[str, Any],
+    props: Entry,
     computed_results: list[dict[TranslatableStr, TranslatableStr | str]],
     key: str,
     human_name: TranslatableStr,
@@ -397,7 +398,7 @@ def _append_if_present(
 def _gen_computed_props(
     _id: str,
     entry: dict[str, str],
-    props: dict[str, Any],
+    props: Entry,
 ) -> list[dict[TranslatableStr | str, TranslatableStr | str]]:
     computed: list[dict[TranslatableStr, TranslatableStr | str]] = []
     if "ids" in props:
@@ -415,7 +416,7 @@ def _gen_computed_props(
             computed.append({_("Stockwerk"): floor_name})
         else:
             computed.append({_("Stockwerk"): f"{floor['floor']} (" + floor_name + ")"})
-    b_prefix_raw: Any = entry.get("b_prefix_list") or entry.get("b_prefix")
+    b_prefix_raw: Json = entry.get("b_prefix_list") or entry.get("b_prefix")
     if b_prefix_raw and b_prefix_raw != _id:
         if isinstance(b_prefix_raw, list):
             b_prefix_vals = b_prefix_raw
@@ -493,7 +494,7 @@ def generate_buildings_overview(df: pl.DataFrame) -> pl.DataFrame:
         ).iter_rows(named=True)
     }
 
-    def _build_overview(row: dict[str, Any]) -> str:
+    def _build_overview(row: FlatRow) -> str:
         _id = row["id"]
         generators = orjson.loads(row["generators_json"]) if row["generators_json"] else {}
         options = generators.get("buildings_overview", {"n_visible": 6, "list_start": []})
@@ -509,7 +510,7 @@ def generate_buildings_overview(df: pl.DataFrame) -> pl.DataFrame:
         )
 
         merged_ids = options["list_start"] + [b["id"] for b in buildings if b["id"] not in options["list_start"]]
-        b_overview: dict[str, Any] = {"n_visible": options["n_visible"], "entries": []}
+        b_overview: dict[str, Json] = {"n_visible": options["n_visible"], "entries": []}
         for child_id in merged_ids:
             child = lookup.get(child_id)
             if child is None:
@@ -583,7 +584,7 @@ def generate_rooms_overview(df: pl.DataFrame) -> pl.DataFrame:
         .iter_rows(named=True)
     }
 
-    def _build_overview(row: dict[str, Any]) -> str:
+    def _build_overview(row: FlatRow) -> str:
         rooms_by_usage: dict[TranslatableStr, list[dict[str, str]]] = {}
         for child_id in row["children_flat"] or []:
             child = rooms_lookup.get(child_id)

--- a/data/processors/sitemap.py
+++ b/data/processors/sitemap.py
@@ -2,12 +2,13 @@ import logging
 import xml.etree.ElementTree as ET  # nosec: used for writing files, defusedxml only supports parse()
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, TypedDict
+from typing import Literal, TypedDict
 
 import backoff
 import orjson
 import requests
 from defusedxml import ElementTree as defusedET
+from pipeline_types import Entry
 
 _logger = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ WEB_SITEMAP_URL = "https://nav.tum.de/sitemap-webclient.xml"
 
 def generate_sitemap(
     *,
-    old_data: list[Any],
+    old_data: list[Entry],
     old_sitemaps: SimplifiedSitemaps,
     web_sitemap: dict[str, datetime],
 ) -> None:
@@ -52,7 +53,7 @@ def generate_sitemap(
     """
     # Re-parsing the output file instead of using the in-memory data, because the export
     # doesn't include all fields and this guarantees the same types (no numpy floats).
-    new_data: list[Any] = orjson.loads((OUTPUT_DIR_PATH / "api_data.json").read_bytes())
+    new_data: list[Entry] = orjson.loads((OUTPUT_DIR_PATH / "api_data.json").read_bytes())
 
     sitemaps: Sitemaps = _extract_sitemap_data(new_data, old_data, old_sitemaps)
 
@@ -62,7 +63,7 @@ def generate_sitemap(
     _write_sitemapindex_xml(OUTPUT_DIR_PATH / "sitemap.xml", sitemaps, web_sitemap)
 
 
-def fetch_old_data() -> list[Any]:
+def fetch_old_data() -> list[Entry]:
     """Download the previously-published api_data.json. Safe to call from a worker thread."""
     try:
         return _download_old_data()
@@ -80,7 +81,7 @@ def fetch_online_sitemaps() -> SimplifiedSitemaps:
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException)
-def _download_old_data() -> list[Any]:
+def _download_old_data() -> list[Entry]:
     """Download the currently online data from the server"""
     req = requests.get(OLD_DATA_URL, headers={"Accept-Encoding": "gzip"}, timeout=120)
     if req.status_code != 200:
@@ -92,7 +93,7 @@ def _download_old_data() -> list[Any]:
     return old_data  # type: ignore[no-any-return]
 
 
-def _extract_sitemap_data(new_data: list[Any], old_data: list[Any], old_sitemaps: SimplifiedSitemaps) -> Sitemaps:
+def _extract_sitemap_data(new_data: list[Entry], old_data: list[Entry], old_sitemaps: SimplifiedSitemaps) -> Sitemaps:
     """
     Extract sitemap data.
 

--- a/data/processors/test_aliases.py
+++ b/data/processors/test_aliases.py
@@ -1,13 +1,13 @@
 import json
-from typing import Any
 
 import polars as pl
+from pipeline_types import FlatRow
 
 from processors.aliases import add_aliases, building_short_name_lookup
 from processors.df_utils import unflatten_row
 
 
-def _meta(rows: list[dict[str, Any]]) -> pl.DataFrame:
+def _meta(rows: list[FlatRow]) -> pl.DataFrame:
     """Build the (id, type, short_name, parents) frame the lookup consumes."""
     return pl.DataFrame(rows, infer_schema_length=None)
 

--- a/data/processors/test_export.py
+++ b/data/processors/test_export.py
@@ -1,11 +1,10 @@
-from typing import Any
-
+from pipeline_types import Entry
 from utils import TranslatableStr
 
 from processors.export import extract_exported_item
 
 
-def _data() -> dict[str, dict[str, Any]]:
+def _data() -> dict[str, Entry]:
     """Build a minimal ancestor chain root -> garching -> mi, keyed by id as the pipeline keys it."""
     return {
         "root": {"id": "root", "type": "root", "name": TranslatableStr("Standorte", "Sites"), "parents": []},

--- a/data/processors/tumonline.py
+++ b/data/processors/tumonline.py
@@ -2,12 +2,12 @@ import logging
 import re
 import string
 from pathlib import Path
-from typing import Any
 
 import orjson
 import polars as pl
 import yaml
 from external.loaders.tumonline import load_buildings, load_orgs, load_rooms, load_usages
+from pipeline_types import FlatRow, Json
 from utils import TranslatableStr as _
 
 from processors.df_utils import ensure_column, ensure_columns, to_json_or_none, translatable_to_columns
@@ -79,7 +79,7 @@ def merge_tumonline_buildings(df: pl.DataFrame) -> pl.DataFrame:
     Returns a new DataFrame with tumonline building data merged in.
     """
     error = False
-    buildings_rows: list[dict[str, Any]] = []
+    buildings_rows: list[FlatRow] = []
     for building in load_buildings().iter_rows(named=True):
         b_id = building["building_key"]
         b_name = " ".join(building["name"].split()).strip()
@@ -236,7 +236,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
         for brow in df.filter(pl.col("type").is_in(_BUILDING_TYPES)).select("id", "parents").iter_rows(named=True)
     }
 
-    candidate_rows: list[dict[str, Any]] = []
+    candidate_rows: list[FlatRow] = []
     missing_buildings: dict[str, int] = {}
 
     for room_code, room in rooms.items():
@@ -358,7 +358,7 @@ def merge_tumonline_rooms(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
-def _addition_to_row(addition: dict[str, Any]) -> dict[str, Any]:
+def _addition_to_row(addition: dict[str, Json]) -> FlatRow:
     """Reshape an ``additions:`` entry to match the row layout returned by ``load_rooms``."""
     address = addition.get("address") or {}
     seats = addition.get("seats") or {}
@@ -384,13 +384,13 @@ def _addition_to_row(addition: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
+def _clean_tumonline_rooms() -> dict[str, FlatRow]:
     """
     Apply some known corrections / patches on the TUMonline room data.
 
     It also searches for inconsistencies not yet patched
     """
-    rooms: dict[str, dict[str, Any]] = {row["room_key"]: row for row in load_rooms().iter_rows(named=True)}
+    rooms: dict[str, FlatRow] = {row["room_key"]: row for row in load_rooms().iter_rows(named=True)}
 
     with (SOURCES_PATH / "15_patches-rooms_tumonline.yaml").open(encoding="utf-8") as file:
         patches = yaml.safe_load(file.read())
@@ -466,11 +466,11 @@ def _clean_tumonline_rooms() -> dict[str, dict[str, Any]]:
 
 
 def _infer_arch_name(
-    room: dict[str, Any],
+    room: FlatRow,
     arch_name_parts: tuple[str, str],
     used_arch_names: dict[str, tuple[str, str, str]],
     roomcode_parts: tuple[str, str, str],
-    rooms: dict[str, dict[str, Any]],
+    rooms: dict[str, FlatRow],
 ) -> None:
     """Infer the arch name and other related properties"""
     # Some rooms don't have an arch_name. The value is then usually just like "@1234".
@@ -528,7 +528,7 @@ def _infer_arch_name(
         room["patched"] = True
 
 
-def _maybe_set_alt_name(room_code: str, arch_name_parts: tuple[str, str], room: dict[str, Any]) -> None:
+def _maybe_set_alt_name(room_code: str, arch_name_parts: tuple[str, str], room: FlatRow) -> None:
     """
     Deduces the alt_name from the roomname
 

--- a/data/utils.py
+++ b/data/utils.py
@@ -2,9 +2,9 @@ import logging
 import os
 from math import acos, cos, radians, sin
 from pathlib import Path
-from typing import Any
 
 from PIL import Image
+from pipeline_types import Json
 from ruamel.yaml import YAML
 
 yaml = YAML(typ="rt")
@@ -73,7 +73,7 @@ class TranslatableStr(dict[str, str]):
             return TranslatableStr(other + self["de"], other + self["en"])
         raise ValueError(f"{other} + {self} is not implmented")
 
-    def format(self, *args: Any, **kwargs: Any) -> TranslatableStr:
+    def format(self, *args: Json, **kwargs: Json) -> TranslatableStr:
         """Apply the format-method to the contained data, as if the class itsself was a string."""
         self["de"] = self["de"].format(*args, **kwargs)
         self["en"] = self["en"].format(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ plugins = [
 
 follow_imports = "silent"
 disallow_any_generics = true
+disallow_any_explicit = true
 check_untyped_defs = true
 
 [tool.pydantic-mypy]
@@ -222,6 +223,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # the path root, which adding an `__init__.py` (INP001's fix) would break.
 "data/compile.py" = ["INP001"]
 "data/utils.py" = ["INP001"]
+"data/pipeline_types.py" = ["INP001"]
 
 [tool.ruff.lint.pep8-naming]
 # `dataframely` rules and pydantic validators receive the class as first argument.


### PR DESCRIPTION
## What

Adds a lint that disallows bare `Any` in the `data/` pipeline and refactors the existing ~70 usages to satisfy it.

- Enables mypy `disallow_any_explicit = true` (enforced by the existing `uv run mypy data` CI gate). A fresh bare `Any` anywhere under `data/` now fails type-check.
- Routes the pipeline's genuinely-dynamic boundaries through three named aliases in a new `data/pipeline_types.py`:
  - **`Json`** — a deserialized JSON/YAML value (source file, HTTP payload, (de)serialization helper).
  - **`Entry`** — a nested API location entry; recursive and field-optional across entry kinds, so no fixed `TypedDict` fits.
  - **`FlatRow`** — a flat polars row dict, as yielded by `iter_rows(named=True)` or assembled column-by-column.

Only `Json` carries the single `# type: ignore[explicit-any]`; `Entry`/`FlatRow` compose it, so all the rationale lives in one reviewable place instead of ~65 inline suppressions.

## Why named aliases over inline ignores

The boundaries this codebase genuinely can't statically type are few and recurring (deserialized source data, the heterogeneous API entry, polars rows). Naming them once makes each call site read as intent (`entry: Entry`, `row: FlatRow`) and keeps a single, greppable escape hatch — a reviewer should treat a new use of one of these the same way they'd treat `Any`. Stable sub-shapes were already modeled as `TypedDict`s (`FloorDetails`, `Room`, `SitemapEntry`, `Patch`, the areatree models) and are left untouched.

A handful of sites get their real concrete type rather than an alias (e.g. a pytest fixture parameter becomes `pytest.LogCaptureFixture`).

## Note for reviewers

The module **cannot** be named `_types.py`: `_types` is a CPython builtin (`sys.builtin_module_names`), and the BuiltinImporter shadows the local file at runtime — mypy resolves the local one and passes, but it `ImportError`s under pytest. Hence `pipeline_types.py` (`types.py` collides with stdlib too).

## Verification

`uv run mypy data`, `uv run ruff check data`, and `uv run pytest data` (199 passed) all green. Confirmed end-to-end that a fresh bare `Any` is rejected by the repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)