### PR TITLE
fix(webclient): remove dead maplibre-gl-indoor integration

### DIFF
--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -8,8 +8,6 @@ import {
   Marker,
   NavigationControl,
 } from "maplibre-gl";
-import type { IndoorMapOptions } from "maplibre-gl-indoor";
-import { IndoorControl, MapServerHandler } from "maplibre-gl-indoor";
 import type { components } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
 import { useIsMobile } from "~/composables/useIsMobile";
@@ -45,7 +43,6 @@ const props = defineProps<{
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
-const runtimeConfig = useRuntimeConfig();
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
 const fullscreenContainerEl = ref<HTMLElement | null>(null);
 // Maplibre bug: the map doesn't update to the new size when changing between
@@ -351,18 +348,6 @@ function initMap(containerId: string): MapLibreMap {
 
     afterLoaded.value();
   });
-
-  const indoorOptions = {
-    showFeaturesWithEmptyLevel: false,
-  } as IndoorMapOptions;
-  const mapServerHandler = MapServerHandler.manage(
-    `${runtimeConfig.public.apiURL}/api/maps/indoor`,
-    map,
-    indoorOptions
-  );
-
-  // Add the specific control
-  mapServerHandler.map.addControl(new IndoorControl(), "bottom-left");
 
   return map;
 }

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -30,7 +30,6 @@
 		"@vueuse/router": "14.3.0",
 		"better-sqlite3": "12.10.0",
 		"maplibre-gl": "5.24.0",
-		"maplibre-gl-indoor": "0.0.22",
 		"nuxt": "4.4.7",
 		"opening_hours": "^3.13.0",
 		"prom-client": "^15.1.3",

--- a/webclient/pnpm-lock.yaml
+++ b/webclient/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       maplibre-gl:
         specifier: 5.24.0
         version: 5.24.0
-      maplibre-gl-indoor:
-        specifier: 0.0.22
-        version: 0.0.22
       nuxt:
         specifier: 4.4.7
         version: 4.4.7(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@biomejs/biome@2.4.16)(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
@@ -2485,24 +2482,6 @@ packages:
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
-  '@turf/bbox@7.2.0':
-    resolution: {integrity: sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==}
-
-  '@turf/destination@7.2.0':
-    resolution: {integrity: sha512-8DUxtOO0Fvrh1xclIUj3d9C5WS20D21F5E+j+X9Q+ju6fcM4huOqTg5ckV1DN2Pg8caABEc5HEZJnGch/5YnYQ==}
-
-  '@turf/distance@7.2.0':
-    resolution: {integrity: sha512-HBjjXIgEcD/wJYjv7/6OZj5yoky2oUvTtVeIAqO3lL80XRvoYmVg6vkOIu6NswkerwLDDNT9kl7+BFLJoHbh6Q==}
-
-  '@turf/helpers@7.3.5':
-    resolution: {integrity: sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==}
-
-  '@turf/invariant@7.3.5':
-    resolution: {integrity: sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==}
-
-  '@turf/meta@7.3.5':
-    resolution: {integrity: sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==}
-
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -4199,9 +4178,6 @@ packages:
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
-
-  maplibre-gl-indoor@0.0.22:
-    resolution: {integrity: sha512-b+uSYqk1kiLBvyBXNhI4MzEWq1qcuGcdoT9aRZvU6+zNqAsK2JIngePZh98hn/7HaRSB2ijb+OabU1OvbSJ3uQ==}
 
   maplibre-gl@5.24.0:
     resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
@@ -8130,44 +8106,6 @@ snapshots:
       '@tanstack/virtual-core': 3.17.0
       vue: 3.5.35(typescript@6.0.3)
 
-  '@turf/bbox@7.2.0':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@turf/meta': 7.3.5
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
-  '@turf/destination@7.2.0':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@turf/invariant': 7.3.5
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
-  '@turf/distance@7.2.0':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@turf/invariant': 7.3.5
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
-  '@turf/helpers@7.3.5':
-    dependencies:
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
-  '@turf/invariant@7.3.5':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
-  '@turf/meta@7.3.5':
-    dependencies:
-      '@turf/helpers': 7.3.5
-      '@types/geojson': 7946.0.16
-      tslib: 2.8.1
-
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -10043,13 +9981,6 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
-
-  maplibre-gl-indoor@0.0.22:
-    dependencies:
-      '@turf/bbox': 7.2.0
-      '@turf/destination': 7.2.0
-      '@turf/distance': 7.2.0
-      maplibre-gl: 5.24.0
 
   maplibre-gl@5.24.0:
     dependencies:
@@ -11943,7 +11874,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   tunnel-agent@0.6.0:
     dependencies:


### PR DESCRIPTION
## What

`IndoorMap.vue` (the interactive map behind `/navigate`) still wired up `maplibre-gl-indoor`'s `MapServerHandler` against `${apiURL}/api/maps/indoor` and added an `IndoorControl`. That backend endpoint was removed in #2291, and indoor maps have since moved to **vector tiles served by Martin** — baked into `navigatum-basemap.json` and driven by the `FloorControl` composable (as used by `DetailsInteractiveMap.vue` / `LocationPickerModal.vue`).

So this code was both dead and actively breaking: with the endpoint gone, panning/zooming past zoom 16.25 makes `MapServerHandler.loadMapsInBounds()` `fetch` the now-404 route and then iterate the non-array error body (`for (const a of i)`), which throws inside the map and errors out `/navigate`.

## Change

`IndoorMap.vue` was the **only** consumer of `maplibre-gl-indoor`, so this removes:

- the `maplibre-gl-indoor` imports (`MapServerHandler`, `IndoorControl`, `IndoorMapOptions`),
- the `MapServerHandler.manage(...)` + `IndoorControl` wiring in `initMap()`,
- the now-unused `runtimeConfig`,
- the `maplibre-gl-indoor` dependency in `package.json` (and its orphaned `@turf/*` transitive deps in the lockfile).

No functional loss: the vector `indoor` source in the basemap style still renders passively; this only drops the broken legacy overlay. Wiring `FloorControl` into `/navigate` for floor switching (to match the details map) is a separate feature and intentionally out of scope here.

## Testing

- `pnpm --dir webclient type-check` — passes.
- `pnpm --dir webclient lint` (`biome lint --error-on-warnings`) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)