### PR TITLE
feat(data,webclient): live open/closed indicator for opening hours (#3105)

### DIFF
--- a/data/processors/opening_hours.py
+++ b/data/processors/opening_hours.py
@@ -3,6 +3,7 @@ import polars as pl
 from external.loaders.opening_hours import load_opening_hours
 from external.loaders.semesters import load_semester
 
+from processors.public_holiday_expander import bavarian_holiday_dates, contains_ph, expand_public_holidays
 from processors.semester_block_expander import Semester, contains_macro, expand_semester_blocks
 
 # Optional keys are omitted when null, not emitted as null.
@@ -19,9 +20,11 @@ def merge_opening_hours(
     """
     Attach opening-hours schedules to their entries as an `opening_hours_json` payload.
 
-    `lecture:`/`break:` macros are expanded against `semesters` into plain OSM
-    before the payload is built, so downstream only sees standard OSM. `schedules`
-    and `semesters` are injectable for tests; both default to the validated CSV.
+    `lecture:`/`break:` macros are expanded against `semesters`, and `PH` rules
+    against the Bavarian holidays covering those semesters, into plain OSM before
+    the payload is built, so downstream only sees standard OSM with no holiday
+    database required. `schedules` and `semesters` are injectable for tests; both
+    default to the validated CSV.
     """
     schedules = load_opening_hours() if schedules is None else schedules
     if semesters is None:
@@ -31,18 +34,28 @@ def merge_opening_hours(
     if unknown:
         raise ValueError(f"opening-hours schedule targets unknown entry id(s): {sorted(unknown)}")
 
+    # The semester span bounds which holidays a `PH` rule expands into; computed once for all rows.
+    holiday_years = {year for semester in semesters for year in range(semester.start.year, semester.end.year + 1)}
+    holiday_dates = bavarian_holiday_dates(holiday_years)
+
     payloads = []
     for row in schedules.iter_rows(named=True):
         osm = expand_semester_blocks(row["opening_hours"], semesters)
         if contains_macro(osm):
             raise ValueError(f"opening-hours for entry {row['id']!r} still has macros after expansion: {osm!r}")
+        if contains_ph(osm) and not holiday_dates:
+            raise ValueError(
+                f"opening-hours for entry {row['id']!r} uses `PH` but no Bavarian holidays were available "
+                f"to expand it against; is the semester list empty? {osm!r}"
+            )
+        osm = expand_public_holidays(osm, holiday_dates)
         if not osm.strip():
             raise ValueError(
                 f"opening-hours for entry {row['id']!r} expanded to an empty schedule; "
                 f"check the semester list covers its macros: {row['opening_hours']!r}"
             )
         payload = {key: row[column] for column, key in _REQUIRED_KEYS.items()}
-        payload["osm"] = osm  # expanded, macro-free - not the raw on-disk string.
+        payload["osm"] = osm  # expanded plain OSM (no macros, no `PH`) - not the raw on-disk string.
         payload.update({key: row[key] for key in _OPTIONAL_KEYS if row[key] is not None})
         payloads.append({"id": row["id"], "opening_hours_json": orjson.dumps(payload).decode()})
 

--- a/data/processors/opening_hours_state.py
+++ b/data/processors/opening_hours_state.py
@@ -1,0 +1,46 @@
+"""
+Pure reference evaluator for an opening-hours schedule's live state.
+
+The webclient computes *open now / closed / closes in X* from the OSM string itself;
+this is the Python counterpart it mirrors, used to validate shipped schedules in tests.
+`now` is always passed in (never `datetime.now()`) so results are reproducible. It wraps
+`opening-hours-py`, a dev-only dependency, so it stays out of the runtime compile path.
+
+The schedule must be plain OSM - macros and `PH` are expanded upstream
+(`semester_block_expander`, `public_holiday_expander`). `now` is wall-clock in the
+schedule's timezone (Europe/Berlin for TUM); pass an aware or naive datetime.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+import opening_hours
+
+
+@dataclass(frozen=True)
+class OpeningHoursState:
+    """
+    A schedule's live state at one instant.
+
+    `until` is the end of the currently open interval (set only when open);
+    `next_change` is the next opening time (set only when closed). Either is
+    `None` when the schedule never changes again from `now` - a `24/7` place is
+    open with no `until`, a place whose every interval is in the past is closed
+    with no `next_change`.
+    """
+
+    state: Literal["open", "closed"]
+    until: datetime | None
+    next_change: datetime | None
+
+
+def evaluate_state(schedule: str, now: datetime) -> OpeningHoursState:
+    """Evaluate `schedule` (plain OSM) at `now`. See the module docstring for `now`'s timezone."""
+    hours = opening_hours.OpeningHours(schedule)
+    # An `unknown` interval is not an open one; fold it into closed so callers see a binary state.
+    is_open = hours.state(now) == opening_hours.State.OPEN
+    change = hours.next_change(now)
+    if is_open:
+        return OpeningHoursState(state="open", until=change, next_change=None)
+    return OpeningHoursState(state="closed", until=None, next_change=change)

--- a/data/processors/public_holiday_expander.py
+++ b/data/processors/public_holiday_expander.py
@@ -1,0 +1,75 @@
+"""
+The only place opening-hours `PH` (public-holiday) rules are turned into dates.
+
+`opening-hours-py` resolves only *national* German holidays and the JS client has no
+holiday calendar at all, so a `PH off` rule alone would stay open on Bavarian holidays
+(Epiphany, Fronleichnam, Allerheiligen). `expand_public_holidays` bakes them in at
+compile time instead, leaving self-contained plain OSM that every parser evaluates
+identically. Kept isolated like `semester_block_expander` so any OSM parser stays swappable.
+"""
+
+import re
+from collections.abc import Iterable, Sequence
+from datetime import date
+
+import holidays
+
+# A standalone `PH` rule: the selector is exactly `PH`, optionally followed by a
+# modifier or times (`off`, `closed`, `09:00-20:00`). Combined selectors such as
+# `Mo-Fr,PH ...` are deliberately not matched - see `expand_public_holidays`.
+_PH_RULE_RE = re.compile(r"^PH\b\s*(.*)$", re.DOTALL)
+# Any `PH` token, to tell a combined selector apart from a schedule that has no PH.
+_PH_TOKEN_RE = re.compile(r"\bPH\b")
+# OSM month abbreviations are English and locale-independent, so format them by hand.
+_MONTHS = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
+
+
+def contains_ph(schedule: str) -> bool:
+    """Whether `schedule` carries any `PH` (public-holiday) selector."""
+    return _PH_TOKEN_RE.search(schedule) is not None
+
+
+def expand_public_holidays(schedule: str, holiday_dates: Sequence[date]) -> str:
+    """
+    Rewrite standalone `PH` rules into explicit per-date OSM rules, and return plain OSM.
+
+    Each `PH <rest>` rule (e.g. `PH off`, `PH 09:00-12:00`) becomes one
+    `<date> <rest>` rule per date in `holiday_dates`, appended after the regular
+    rules so the holiday overrides the weekday schedule on that day. A schedule
+    with no `PH` is returned verbatim; with no holidays the `PH` rule drops, as it
+    would have no effect. Combined selectors (`Mo-Fr,PH off`) are rejected rather
+    than risk a fragile rewrite.
+    """
+    if not contains_ph(schedule):
+        return schedule
+
+    kept: list[str] = []
+    ph_bodies: list[str] = []
+    for raw_block in schedule.split(";"):
+        block = raw_block.strip()
+        if not block:
+            continue
+        match = _PH_RULE_RE.match(block)
+        if match is None:
+            if _PH_TOKEN_RE.search(block):
+                raise ValueError(
+                    f"combined PH selector is not supported, split it into a standalone `PH` rule: {block!r}"
+                )
+            kept.append(block)  # plain OSM rule; carried through untouched.
+            continue
+        ph_bodies.append(match.group(1).strip())
+
+    dates = sorted(set(holiday_dates))
+    overrides = [f"{_osm_date(day)} {body}".strip() for body in ph_bodies for day in dates]
+    return "; ".join(kept + overrides)
+
+
+def bavarian_holiday_dates(years: Iterable[int]) -> list[date]:
+    """Bavarian (`DE-BY`) public-holiday dates across `years`, the source for `PH` expansion."""
+    calendar = holidays.country_holidays("DE", subdiv="BY", years=sorted(set(years)))
+    return sorted(calendar.keys())
+
+
+def _osm_date(day: date) -> str:
+    """Format an OSM monthday selector, e.g. `2026 Jan 06` (zero-padded day, English month)."""
+    return f"{day.year} {_MONTHS[day.month - 1]} {day.day:02d}"

--- a/data/processors/test_opening_hours.py
+++ b/data/processors/test_opening_hours.py
@@ -1,4 +1,5 @@
-from datetime import date
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
 
 import opening_hours
 import orjson
@@ -10,6 +11,8 @@ from external.schemas.opening_hours import OpeningHoursSchema
 
 from processors.df_utils import unflatten_row
 from processors.opening_hours import merge_opening_hours
+from processors.opening_hours_state import evaluate_state
+from processors.public_holiday_expander import contains_ph
 from processors.semester_block_expander import Semester, contains_macro
 from processors.studierendenwerk import mensa_opening_hours
 from processors.ub_tum import ub_tum_opening_hours
@@ -125,6 +128,27 @@ def test_merge_raises_when_macros_cannot_be_expanded() -> None:
         merge_opening_hours(_entries(), schedules=schedule, semesters=[])
 
 
+def test_merge_expands_ph_into_dated_holiday_rules() -> None:
+    """A `PH off` schedule lands as plain OSM with the semester's Bavarian holidays baked in as dates."""
+    schedule = _schedule(opening_hours="Mo-Fr 08:00-22:00; PH off")
+    df = merge_opening_hours(_entries(), schedules=schedule, semesters=[_SEMESTER])
+
+    payload = orjson.loads(dict(zip(df["id"], df["opening_hours_json"], strict=True))["5603"])
+    assert not contains_ph(payload["osm"]), payload["osm"]
+    assert opening_hours.validate(payload["osm"])
+    # Fronleichnam (19 Jun 2025, a Thursday) is a Bavaria-only holiday inside _SEMESTER's span.
+    assert "2025 Jun 19 off" in payload["osm"]
+    closed_on_holiday = evaluate_state(payload["osm"], datetime(2025, 6, 19, 10, 0, tzinfo=ZoneInfo("Europe/Berlin")))
+    assert closed_on_holiday.state == "closed"
+
+
+def test_merge_raises_when_ph_cannot_be_expanded() -> None:
+    """A `PH` schedule with no semesters (hence no holiday horizon) must raise, not drop the rule."""
+    schedule = _schedule(opening_hours="Mo-Fr 08:00-22:00; PH off")
+    with pytest.raises(ValueError, match=r"5603.*PH"):
+        merge_opening_hours(_entries(), schedules=schedule, semesters=[])
+
+
 def test_committed_schedules_expand_to_valid_plain_osm() -> None:
     """
     Assert every shipped schedule expands to macro-free OSM that parses.
@@ -143,6 +167,10 @@ def test_committed_schedules_expand_to_valid_plain_osm() -> None:
 
     payloads = [orjson.loads(value) for value in df["opening_hours_json"] if value is not None]
     assert payloads, "expected at least one committed schedule"
+    a_workday_noon = datetime(2026, 6, 8, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
     for payload in payloads:
         assert not contains_macro(payload["osm"]), payload["osm"]
+        assert not contains_ph(payload["osm"]), payload["osm"]
         assert opening_hours.validate(payload["osm"]), payload["osm"]
+        # Every shipped schedule must also evaluate to a live state without error.
+        assert evaluate_state(payload["osm"], a_workday_noon).state in {"open", "closed"}

--- a/data/processors/test_opening_hours_state.py
+++ b/data/processors/test_opening_hours_state.py
@@ -1,0 +1,90 @@
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from processors.opening_hours_state import evaluate_state
+from processors.public_holiday_expander import expand_public_holidays
+from processors.semester_block_expander import Semester, expand_semester_blocks
+
+# Library hours are wall-clock local time; evaluate state in the library's own zone.
+_BERLIN = ZoneInfo("Europe/Berlin")
+# A plain weekday schedule reused across the cardinal cases.
+_WEEKDAYS = "Mo-Fr 08:00-22:00"
+
+
+def _at(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=_BERLIN)
+
+
+def test_monday_morning_is_open_until_evening() -> None:
+    """A Monday mid-morning reads open, with `until` the same day's closing time."""
+    state = evaluate_state(_WEEKDAYS, _at(2026, 6, 8, 9, 0))  # 2026-06-08 is a Monday.
+
+    assert state.state == "open"
+    assert state.until == _at(2026, 6, 8, 22, 0)
+    assert state.next_change is None
+
+
+def test_friday_closing_minute_flips_from_open_to_closed() -> None:
+    """One minute before close is still open; the closing minute itself is closed."""
+    just_before = evaluate_state(_WEEKDAYS, _at(2026, 6, 5, 21, 59))  # 2026-06-05 is a Friday.
+    assert just_before.state == "open"
+    assert just_before.until == _at(2026, 6, 5, 22, 0)
+
+    at_close = evaluate_state(_WEEKDAYS, _at(2026, 6, 5, 22, 0))
+    assert at_close.state == "closed"
+    # The weekend is closed, so the next opening is the following Monday morning.
+    assert at_close.next_change == _at(2026, 6, 8, 8, 0)
+
+
+def test_sunday_is_closed_until_monday_morning() -> None:
+    """Sunday reads closed with the next opening on Monday."""
+    state = evaluate_state(_WEEKDAYS, _at(2026, 6, 7, 15, 0))  # 2026-06-07 is a Sunday.
+
+    assert state.state == "closed"
+    assert state.until is None
+    assert state.next_change == _at(2026, 6, 8, 8, 0)
+
+
+def test_bavarian_holiday_is_closed_despite_weekday_hours() -> None:
+    """A `PH off` schedule, expanded against a Bavarian holiday, is closed on that weekday."""
+    epiphany = date(2026, 1, 6)  # Heilige Drei Könige - a Tuesday, Bavaria-only holiday.
+    schedule = expand_public_holidays(f"{_WEEKDAYS}; PH off", [epiphany])
+
+    state = evaluate_state(schedule, _at(2026, 1, 6, 10, 0))
+
+    assert state.state == "closed"
+    # Closed all day; reopens the next working day, Wednesday.
+    assert state.next_change == _at(2026, 1, 7, 8, 0)
+
+
+def test_mid_break_uses_break_hours_not_lecture_hours() -> None:
+    """Inside the semester break the shorter break hours apply, not the lecture-period hours."""
+    # Lectures start 13 Apr 2026, so the calendar run-up (01-12 Apr) is break time.
+    semester = Semester("2026S", date(2026, 4, 1), date(2026, 4, 13), date(2026, 8, 5), date(2026, 9, 30))
+    schedule = expand_semester_blocks(f"lecture: {_WEEKDAYS}; break: Mo-Fr 09:00-18:00", [semester])
+    monday_in_break = (2026, 4, 6)  # 2026-04-06 is a Monday in the run-up break.
+
+    before_break_open = evaluate_state(schedule, _at(*monday_in_break, 8, 30))
+    assert before_break_open.state == "closed"  # 08:30 is before the 09:00 break opening.
+    assert before_break_open.next_change == _at(*monday_in_break, 9, 0)
+
+    during = evaluate_state(schedule, _at(*monday_in_break, 9, 30))
+    assert during.state == "open"
+    assert during.until == _at(*monday_in_break, 18, 0)  # break closes at 18:00, not the lecture 22:00.
+
+
+def test_always_open_has_no_closing_time() -> None:
+    """A `24/7` schedule is open with no upcoming change."""
+    state = evaluate_state("24/7", _at(2026, 6, 8, 3, 0))
+
+    assert state.state == "open"
+    assert state.until is None
+    assert state.next_change is None
+
+
+def test_schedule_with_only_past_intervals_is_closed_forever() -> None:
+    """A schedule whose every interval is in the past is closed with no next change."""
+    state = evaluate_state("2020 Jan 01 09:00-17:00", _at(2026, 6, 8, 10, 0))
+
+    assert state.state == "closed"
+    assert state.next_change is None

--- a/data/processors/test_public_holiday_expander.py
+++ b/data/processors/test_public_holiday_expander.py
@@ -1,0 +1,99 @@
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+import opening_hours
+import pytest
+
+from processors.public_holiday_expander import (
+    bavarian_holiday_dates,
+    contains_ph,
+    expand_public_holidays,
+)
+
+# Library hours are wall-clock local time; evaluate state in the library's own zone.
+_BERLIN = ZoneInfo("Europe/Berlin")
+# Epiphany (Bavaria-only) and Fronleichnam (Bavaria-only) in 2026, both ordinary weekdays.
+_EPIPHANY = date(2026, 1, 6)  # a Tuesday.
+_FRONLEICHNAM = date(2026, 6, 4)  # a Thursday.
+
+
+def test_plain_osm_without_ph_is_returned_verbatim() -> None:
+    """A schedule with no `PH` selector is passed through untouched."""
+    assert expand_public_holidays("Mo-Fr 08:00-22:00", [_EPIPHANY]) == "Mo-Fr 08:00-22:00"
+
+
+def test_ph_off_becomes_one_dated_off_rule_per_holiday() -> None:
+    """`PH off` expands to a dated `off` override per holiday, appended after the regular rules."""
+    out = expand_public_holidays("Mo-Fr 08:00-22:00; PH off", [_EPIPHANY, _FRONLEICHNAM])
+
+    assert out == "Mo-Fr 08:00-22:00; 2026 Jan 06 off; 2026 Jun 04 off"
+    assert opening_hours.validate(out)
+    hours = opening_hours.OpeningHours(out)
+    # The holiday overrides the weekday schedule; the surrounding Tuesdays stay open.
+    assert not hours.is_open(datetime(2026, 1, 6, 10, 0, tzinfo=_BERLIN))
+    assert hours.is_open(datetime(2026, 1, 13, 10, 0, tzinfo=_BERLIN))
+
+
+def test_ph_closed_keyword_is_carried_through() -> None:
+    """`closed` (an `off` synonym) is preserved in the dated rule."""
+    out = expand_public_holidays("Mo-Fr 08:00-22:00; PH closed", [_EPIPHANY])
+
+    assert out == "Mo-Fr 08:00-22:00; 2026 Jan 06 closed"
+    assert opening_hours.validate(out)
+
+
+def test_ph_with_times_expands_to_dated_time_ranges() -> None:
+    """A `PH <times>` rule (open only on holidays) expands to dated time ranges."""
+    out = expand_public_holidays("Mo-Su 00:00-24:00; PH 10:00-14:00", [_EPIPHANY])
+
+    assert out == "Mo-Su 00:00-24:00; 2026 Jan 06 10:00-14:00"
+    assert opening_hours.validate(out)
+
+
+def test_ph_rule_overrides_regardless_of_its_position() -> None:
+    """A leading `PH off` still wins: its dated overrides are appended after the weekday rule."""
+    out = expand_public_holidays("PH off; Mo-Fr 08:00-22:00", [_EPIPHANY])
+
+    assert out == "Mo-Fr 08:00-22:00; 2026 Jan 06 off"
+    assert not opening_hours.OpeningHours(out).is_open(datetime(2026, 1, 6, 10, 0, tzinfo=_BERLIN))
+
+
+def test_no_holidays_drops_the_ph_rule() -> None:
+    """With no holidays in range the `PH` rule has no effect and is dropped."""
+    assert expand_public_holidays("Mo-Fr 08:00-22:00; PH off", []) == "Mo-Fr 08:00-22:00"
+
+
+def test_duplicate_holidays_are_collapsed_and_ordered() -> None:
+    """Holiday dates are de-duplicated and emitted in calendar order."""
+    out = expand_public_holidays("Mo-Fr 08:00-22:00; PH off", [_FRONLEICHNAM, _EPIPHANY, _EPIPHANY])
+
+    assert out == "Mo-Fr 08:00-22:00; 2026 Jan 06 off; 2026 Jun 04 off"
+
+
+def test_combined_ph_selector_is_rejected() -> None:
+    """A `PH` combined with weekdays is not supported and must raise rather than mis-expand."""
+    with pytest.raises(ValueError, match="combined PH selector"):
+        expand_public_holidays("Mo-Fr,PH off", [_EPIPHANY])
+
+
+@pytest.mark.parametrize(
+    ("schedule", "expected"),
+    [
+        ("Mo-Fr 08:00-22:00", False),
+        ('Mo-Fr 08:00-22:00 "Pharmacy"', False),
+        ("PH off", True),
+        ("Mo-Fr 08:00-22:00; PH off", True),
+    ],
+)
+def test_contains_ph(schedule: str, expected: bool) -> None:
+    """`contains_ph` recognises a `PH` selector but not incidental letters."""
+    assert contains_ph(schedule) is expected
+
+
+def test_bavarian_holiday_dates_include_bavaria_only_days() -> None:
+    """The Bavarian calendar carries regional holidays national calendars omit, sorted ascending."""
+    dates = bavarian_holiday_dates([2026])
+
+    assert _EPIPHANY in dates  # Bavaria-only; absent from a national DE calendar.
+    assert date(2026, 11, 1) in dates  # Allerheiligen, also Bavaria-only.
+    assert dates == sorted(dates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "brotli>=1.2.0",
   "dataframely==2.10.1",
   "defusedxml==0.7.1",
+  "holidays==0.98",
   "lxml==6.1.1",
   "orjson==3.11.9",
   "Pillow==12.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,18 @@ wheels = [
 ]
 
 [[package]]
+name = "holidays"
+version = "0.98"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/a1/63c1a45599a82d91a3b5c7a4de5a6050ca253f8c0e74dd14fade3728e033/holidays-0.98.tar.gz", hash = "sha256:09b078a4695d53a35ea01517b331942f3232b3b7e3877f74f6d5227adbedc76e", size = 913785, upload-time = "2026-06-01T19:17:33.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/0c/51baf49265bd6c8f05bea02ae6ebc96a81218ae364fae89dd6a3e3f7d349/holidays-0.98-py3-none-any.whl", hash = "sha256:65c9ba3402f1d10cc715af0510cdc847e60d8854df640515d546748ca4a24e60", size = 1482103, upload-time = "2026-06-01T19:17:32.01Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +383,7 @@ dependencies = [
     { name = "brotli" },
     { name = "dataframely" },
     { name = "defusedxml" },
+    { name = "holidays" },
     { name = "lxml" },
     { name = "orjson" },
     { name = "pillow" },
@@ -406,6 +419,7 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "dataframely", specifier = "==2.10.1" },
     { name = "defusedxml", specifier = "==0.7.1" },
+    { name = "holidays", specifier = "==0.98" },
     { name = "lxml", specifier = "==6.1.1" },
     { name = "orjson", specifier = "==3.11.9" },
     { name = "pillow", specifier = "==12.2.0" },
@@ -759,6 +773,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +883,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
     { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]

--- a/webclient/app/components/DetailsOpeningHoursCard.vue
+++ b/webclient/app/components/DetailsOpeningHoursCard.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { mdiChevronDown, mdiOpenInNew } from "@mdi/js";
+import { mdiChevronDown, mdiClockCheckOutline, mdiClockRemoveOutline, mdiOpenInNew } from "@mdi/js";
 import { useToggle } from "@vueuse/core";
 import type { components } from "~/api_types";
 import {
+  computeOpeningHoursState,
   type OpeningHoursDay,
+  type OpeningHoursLiveState,
   type OpeningHoursRange,
   parseOpeningHoursWeek,
+  WEEKDAY_KEYS,
 } from "~/utils/openingHours";
 
 type OpeningHoursResponse = components["schemas"]["OpeningHoursResponse"];
@@ -19,22 +22,65 @@ const { t, locale } = useI18n({ useScope: "local" });
 // `undefined` while parsing, `null` once it has failed.
 const week = ref<readonly OpeningHoursDay[] | null | undefined>(undefined);
 const parseFailed = computed(() => week.value === null);
+const liveState = ref<OpeningHoursLiveState | null | undefined>(undefined);
+// The instant the week and live state were evaluated at; the live hint is relative to it.
+const evaluatedAt = ref<Date | null>(null);
 
-async function refreshWeek(): Promise<void> {
-  week.value = await parseOpeningHoursWeek(props.openingHours.osm, new Date());
+async function refresh(): Promise<void> {
+  const now = new Date();
+  const [parsedWeek, state] = await Promise.all([
+    parseOpeningHoursWeek(props.openingHours.osm, now),
+    computeOpeningHoursState(props.openingHours.osm, now),
+  ]);
+  week.value = parsedWeek;
+  liveState.value = state;
+  evaluatedAt.value = now;
 }
 
-onMounted(refreshWeek);
-watch(() => props.openingHours.osm, refreshWeek);
+onMounted(refresh);
+watch(() => props.openingHours.osm, refresh);
 
 const today = computed<OpeningHoursDay | null>(
   () => week.value?.find((day) => day.isToday) ?? null
 );
 
+// Below this many minutes to closing, surface a "closes in X minutes" hint instead of the time.
+const CLOSES_SOON_MINUTES = 60;
+
+// The live indicator's `open` flag and localized detail line, or `null` while loading or unparsable.
+const liveStatus = computed<{ open: boolean; detail: string | null } | null>(() => {
+  const state = liveState.value;
+  const now = evaluatedAt.value;
+  if (!state || !now) return null;
+  if (state.open) {
+    if (!state.nextChange) return { open: true, detail: null };
+    const minutes = Math.ceil((state.nextChange.getTime() - now.getTime()) / 60_000);
+    if (minutes <= CLOSES_SOON_MINUTES) return { open: true, detail: t("closes_in", minutes) };
+    return { open: true, detail: t("closes_at", { time: formatTime(state.nextChange) }) };
+  }
+  if (!state.nextChange) return { open: false, detail: null };
+  if (isSameDay(state.nextChange, now))
+    return { open: false, detail: t("opens_at", { time: formatTime(state.nextChange) }) };
+  const day = t(`day.${WEEKDAY_KEYS[(state.nextChange.getDay() + 6) % 7]}`);
+  return { open: false, detail: t("opens_on", { day, time: formatTime(state.nextChange) }) };
+});
+
 const [expanded, toggleExpanded] = useToggle(false);
 
 function formatRanges(ranges: readonly OpeningHoursRange[]): string {
   return ranges.map((range) => `${range.from}-${range.to}`).join(", ");
+}
+
+function formatTime(date: Date): string {
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
 }
 
 const lastUpdated = computed(() => formatIsoDate(props.openingHours.last_update));
@@ -65,6 +111,20 @@ function formatIsoDate(iso: string): string {
         <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
       </Btn>
     </div>
+
+    <p v-if="liveStatus" class="flex items-center gap-1.5 text-sm">
+      <MdiIcon
+        :path="liveStatus.open ? mdiClockCheckOutline : mdiClockRemoveOutline"
+        :size="18"
+        class="shrink-0"
+        :class="liveStatus.open ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'"
+        aria-hidden="true"
+      />
+      <span class="text-zinc-800 dark:text-zinc-100 font-medium">
+        {{ liveStatus.open ? t("open_now") : t("closed_now") }}
+      </span>
+      <span v-if="liveStatus.detail" class="text-zinc-500 dark:text-zinc-400">{{ liveStatus.detail }}</span>
+    </p>
 
     <p
       v-if="parseFailed"
@@ -135,6 +195,12 @@ de:
   source: Quelle
   today: Heute
   closed: geschlossen
+  open_now: Geöffnet
+  closed_now: Geschlossen
+  closes_in: "schließt in einer Minute | schließt in {count} Minuten"
+  closes_at: "schließt um {time}"
+  opens_at: "öffnet um {time}"
+  opens_on: "öffnet {day} um {time}"
   last_updated: "zuletzt aktualisiert am {date}"
   valid_until: "gültig bis {date}"
   day:
@@ -150,6 +216,12 @@ en:
   source: Source
   today: Today
   closed: closed
+  open_now: Open
+  closed_now: Closed
+  closes_in: "closes in one minute | closes in {count} minutes"
+  closes_at: "closes at {time}"
+  opens_at: "opens at {time}"
+  opens_on: "opens {day} at {time}"
   last_updated: "last updated on {date}"
   valid_until: "valid until {date}"
   day:

--- a/webclient/app/utils/openingHours.ts
+++ b/webclient/app/utils/openingHours.ts
@@ -71,3 +71,29 @@ export async function parseOpeningHoursWeek(
     return null;
   }
 }
+
+/** The live open/closed verdict of a schedule at one instant. */
+export interface OpeningHoursLiveState {
+  readonly open: boolean;
+  /** When the current state ends; `null` when it never changes (`24/7`, or never opens again). */
+  readonly nextChange: Date | null;
+}
+
+/**
+ * Evaluate whether a schedule is open at `now` and when that state next changes. Holidays are
+ * already baked into the OSM string as explicit dates by the pipeline, so no holiday context is
+ * needed here. Returns `null` when the string cannot be parsed, mirroring `parseOpeningHoursWeek`.
+ */
+export async function computeOpeningHoursState(
+  osm: string,
+  now: Date
+): Promise<OpeningHoursLiveState | null> {
+  try {
+    const { default: OpeningHours } = await import("opening_hours");
+    // `null` for the same reason as in `parseOpeningHoursWeek`: the ESM build omits the `mode` enum.
+    const oh = new OpeningHours(osm, null);
+    return { open: oh.getState(now), nextChange: oh.getNextChange(now) ?? null };
+  } catch {
+    return null;
+  }
+}

--- a/webclient/test/openingHours.test.ts
+++ b/webclient/test/openingHours.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  computeOpeningHoursState,
   type OpeningHoursDay,
   parseOpeningHoursWeek,
   WEEKDAY_KEYS,
@@ -62,5 +63,44 @@ describe("parseOpeningHoursWeek", () => {
 
   it("returns null for a malformed OSM string instead of throwing", async () => {
     expect(await parseOpeningHoursWeek("Mo-Fr 08:00-99:99", WEDNESDAY)).toBeNull();
+  });
+});
+
+describe("computeOpeningHoursState", () => {
+  const WEEKDAYS = "Mo-Fr 08:00-22:00";
+
+  it("reports open with the upcoming closing time during opening hours", async () => {
+    const state = await computeOpeningHoursState(WEEKDAYS, new Date(2026, 5, 8, 10, 0)); // Mon 10:00.
+    expect(state?.open).toBe(true);
+    expect(state?.nextChange?.getTime()).toBe(new Date(2026, 5, 8, 22, 0).getTime());
+  });
+
+  it("reports closed with the next opening time outside opening hours", async () => {
+    const state = await computeOpeningHoursState(WEEKDAYS, new Date(2026, 5, 7, 15, 0)); // Sun 15:00.
+    expect(state?.open).toBe(false);
+    expect(state?.nextChange?.getTime()).toBe(new Date(2026, 5, 8, 8, 0).getTime()); // Mon 08:00.
+  });
+
+  it("treats the closing minute itself as closed", async () => {
+    const state = await computeOpeningHoursState(WEEKDAYS, new Date(2026, 5, 5, 22, 0)); // Fri 22:00.
+    expect(state?.open).toBe(false);
+  });
+
+  it("reports an all-day schedule as open with no upcoming change", async () => {
+    const state = await computeOpeningHoursState("24/7", new Date(2026, 5, 8, 3, 0));
+    expect(state).toEqual({ open: true, nextChange: null });
+  });
+
+  it("honours a baked-in holiday date as closed", async () => {
+    // Holidays reach the client as explicit `<date> off` rules, not `PH`.
+    const osm = `${WEEKDAYS}; 2026 Jan 06 off`;
+    const onHoliday = await computeOpeningHoursState(osm, new Date(2026, 0, 6, 10, 0)); // Tue holiday.
+    const nextDay = await computeOpeningHoursState(osm, new Date(2026, 0, 13, 10, 0)); // ordinary Tue.
+    expect(onHoliday?.open).toBe(false);
+    expect(nextDay?.open).toBe(true);
+  });
+
+  it("returns null for a malformed OSM string instead of throwing", async () => {
+    expect(await computeOpeningHoursState("Mo-Fr 08:00-99:99", new Date(2026, 5, 8))).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Implements **#3105** (parent epic **#3050**): a live *open now / closed / closes in X minutes* indicator on opening-hours, plus the next opening time when closed. State is computed client-side from the canonical OSM string — no per-minute server state.

## Changes

**Data**
- **`opening_hours_state`** — a pure, time-mockable reference evaluator: `(schedule, now) -> {state, until?, next_change?}` wrapping `opening-hours-py`. `now` is always explicit (never `datetime.now()`). Date-matrix tests cover Monday morning, Friday closing minute, Sunday, a Bavarian holiday, and mid-break.
- **`public_holiday_expander`** — bakes Bavarian (`DE-BY`) public holidays into the canonical OSM as explicit `<date> off` rules at **compile time**, mirroring `semester_block_expander`. Wired into `merge_opening_hours`; adds the `holidays` dependency.

**Webclient**
- **`computeOpeningHoursState`** in `openingHours.ts`, and an accessible status line in `DetailsOpeningHoursCard.vue` — a semantic clock icon (matching the `DetailsIrisCoverageCard` convention) plus a DE/EN text label.

## Why the holiday handling looks the way it does

The issue assumed `opening-hours-py` has "Bavarian PH baked in". It does **not** — measured against the pinned v1.4.0, the `PH` selector with `country="DE"` matches only *national* holidays; Bavaria-only ones (Epiphany, Fronleichnam, Mariä Himmelfahrt, Allerheiligen) stay open. The **JS** lib *does* resolve them via a `Bayern` nominatim object — an asymmetry that would make pipeline validation and webclient rendering disagree.

The fix expands `PH` into explicit `<date> off` rules from the maintained `holidays` package at compile time, so the shipped OSM is **self-contained**: both the Python and JS libraries evaluate it identically with no holiday database. (`humanized_opening_hours` was evaluated and rejected — AGPLv3, unmaintained since 2018, and it still needs `python-holidays` underneath.)

## Acceptance criteria

- [x] `opening_hours_state` is pure with explicit `now`; date-matrix tests (Mon morning, Fri closing minute, Sunday, Bavarian holiday, mid-break).
- [x] Webclient shows open-now / closed / closes-in-X-minutes and the next opening time when closed, from the OSM string.
- [x] State conveyed as accessible text (+ distinct icon shapes), not colour alone.
- [x] DE/EN labels render for the indicator and day names.

## Notes / follow-ups

- **Timezone:** live state is computed in browser-local time, consistent with the existing week view (correct for Berlin-tz users). A global tz layer is out of scope for v1.
- **Mariä Himmelfahrt (Aug 15)** is not in the default `holidays` BY set (it treats it as Catholic-municipality-only) — relevant once real branch schedules adopt `PH off`.

## Verification

- `uv run pytest data` (all pass), `uv run mypy data`, `uv run ruff check data` — clean.
- `pnpm --dir webclient test` (88 pass), `pnpm --dir webclient lint`, `pnpm --dir webclient type-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)