### PR TITLE
fix(server,webclient): stop edit form laundering generated display names into names.csv

### DIFF
--- a/server/src/routes/feedback/proposed_edits/csv_edit.rs
+++ b/server/src/routes/feedback/proposed_edits/csv_edit.rs
@@ -2,6 +2,29 @@ use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
+/// A single column's value in an upsert.
+pub(super) enum Field {
+    /// Overwrite the column with this value.
+    Set(String),
+    /// Keep the existing row's value, or empty when inserting a new row. This
+    /// lets an edit refresh only the columns it owns without clobbering a
+    /// curated sibling column it was never given a value for.
+    Keep,
+}
+
+/// Upsert a single row into a sorted-by-id CSV, keyed by its first column.
+///
+/// Full-overwrite variant: every column in `new_fields` is set. See
+/// [`apply_csv_upsert_fields`] for the per-column semantics shared by both.
+pub(super) fn apply_csv_upsert(
+    key: &str,
+    csv_file: &Path,
+    new_fields: &[String],
+) -> anyhow::Result<()> {
+    let fields: Vec<Field> = new_fields.iter().map(|f| Field::Set(f.clone())).collect();
+    apply_csv_upsert_fields(key, csv_file, &fields)
+}
+
 /// Upsert a single row into a sorted-by-id CSV, keyed by its first column.
 ///
 /// The file is rewritten with `new_fields` inserted (or replacing the existing
@@ -9,12 +32,13 @@ use std::path::Path;
 /// data pipeline keeps its source CSVs diff-friendly. `new_fields` only needs to
 /// cover the leading columns the edit owns; any trailing columns the schema
 /// defines are padded empty on insert and **preserved** from the existing row on
-/// update, so an edit can refresh part of a record without dropping curated
-/// optional fields.
-pub(super) fn apply_csv_upsert(
+/// update. A [`Field::Keep`] column is likewise preserved from the existing row,
+/// so an edit can refresh part of a record without dropping curated fields it
+/// did not mean to touch.
+pub(super) fn apply_csv_upsert_fields(
     key: &str,
     csv_file: &Path,
-    new_fields: &[String],
+    new_fields: &[Field],
 ) -> anyhow::Result<()> {
     let temp_file = csv_file.with_extension("tmp");
 
@@ -45,14 +69,8 @@ pub(super) fn apply_csv_upsert(
             let existing_key = record.get(0).unwrap_or("");
 
             if !wrote_edit && existing_key >= key {
-                let extras: Option<Vec<String>> = (existing_key == key).then(|| {
-                    record
-                        .iter()
-                        .skip(new_fields.len())
-                        .map(ToString::to_string)
-                        .collect()
-                });
-                write_padded_row(&mut writer, new_fields, col_count, extras.as_deref())?;
+                let existing = (existing_key == key).then_some(&record);
+                write_row(&mut writer, new_fields, col_count, existing)?;
                 wrote_edit = true;
                 if existing_key == key {
                     continue;
@@ -68,7 +86,7 @@ pub(super) fn apply_csv_upsert(
         }
 
         if !wrote_edit {
-            write_padded_row(&mut writer, new_fields, col_count, None)?;
+            write_row(&mut writer, new_fields, col_count, None)?;
         }
     }
 
@@ -76,25 +94,24 @@ pub(super) fn apply_csv_upsert(
     Ok(())
 }
 
-fn write_padded_row<W: Write>(
+fn write_row<W: Write>(
     writer: &mut W,
-    new_fields: &[String],
+    new_fields: &[Field],
     col_count: usize,
-    extras: Option<&[String]>,
+    existing: Option<&csv::StringRecord>,
 ) -> io::Result<()> {
-    let mut fields: Vec<String> = new_fields.iter().map(|f| csv_escape(f)).collect();
-    let known = new_fields.len();
-    if col_count > known {
-        let trailing = col_count - known;
-        if let Some(ex) = extras {
-            for i in 0..trailing {
-                fields.push(ex.get(i).map(|s| csv_escape(s)).unwrap_or_default());
-            }
-        } else {
-            for _ in 0..trailing {
-                fields.push(String::new());
-            }
-        }
+    let mut fields: Vec<String> = Vec::with_capacity(col_count);
+    for i in 0..col_count {
+        let value = match new_fields.get(i) {
+            Some(Field::Set(v)) => csv_escape(v),
+            // Columns the edit does not own (`Keep`, or beyond `new_fields`) keep
+            // the existing row's value, or are padded empty when inserting.
+            Some(Field::Keep) | None => existing
+                .and_then(|r| r.get(i))
+                .map(csv_escape)
+                .unwrap_or_default(),
+        };
+        fields.push(value);
     }
     writeln!(writer, "{}", fields.join(","))
 }

--- a/server/src/routes/feedback/proposed_edits/mod.rs
+++ b/server/src/routes/feedback/proposed_edits/mod.rs
@@ -72,13 +72,13 @@ pub struct EditRequest {
 
 pub enum ApplyError {
     // Split out from `Other` so the handler can return a structured 422 with a per-key error
-    // list instead of a generic 500.
-    AdditionValidation(Vec<AdditionValidationFailure>),
+    // list instead of a generic 500. Covers both addition and property-edit validation.
+    Validation(Vec<ValidationFailure>),
     Other(anyhow::Error),
 }
 
 #[derive(Debug, serde::Serialize)]
-pub struct AdditionValidationFailure {
+pub struct ValidationFailure {
     pub key: String,
     pub error: String,
 }
@@ -110,15 +110,33 @@ impl EditRequest {
             let mut failures = Vec::new();
             for (key, addition) in &self.additions.0 {
                 if let Err(e) = addition.validate(key, &snap) {
-                    failures.push(AdditionValidationFailure {
+                    failures.push(ValidationFailure {
                         key: key.clone(),
                         error: e.to_string(),
                     });
                 }
             }
             if !failures.is_empty() {
-                return Err(ApplyError::AdditionValidation(failures));
+                return Err(ApplyError::Validation(failures));
             }
+        }
+
+        // Reject property edits whose name looks like a pipeline-generated display
+        // string before any writes, so a stale or third-party client cannot
+        // launder a `{id} (...)` value into the curated names.csv (#3181).
+        let mut property_failures = Vec::new();
+        for (key, edit) in &self.edits.0 {
+            for property in edit.properties.iter().flatten() {
+                if let Err(e) = property.validate(key) {
+                    property_failures.push(ValidationFailure {
+                        key: key.clone(),
+                        error: e.to_string(),
+                    });
+                }
+            }
+        }
+        if !property_failures.is_empty() {
+            return Err(ApplyError::Validation(property_failures));
         }
 
         let desc = worktree.apply_and_gen_description(self, branch_name)?;
@@ -386,8 +404,8 @@ pub async fn propose_edits(
                     .await
             }
         }
-        Err(ApplyError::AdditionValidation(failures)) => {
-            info!(?failures, "addition validation failed");
+        Err(ApplyError::Validation(failures)) => {
+            info!(?failures, "edit validation failed");
             HttpResponse::UnprocessableEntity()
                 .content_type("application/json")
                 .body(serde_json::to_string(&failures).unwrap_or_else(|_| "[]".to_string()))

--- a/server/src/routes/feedback/proposed_edits/property.rs
+++ b/server/src/routes/feedback/proposed_edits/property.rs
@@ -273,7 +273,10 @@ mod tests {
             short_name: None,
         };
         let err = edit.validate("0507.01.767").unwrap_err();
-        assert!(err.to_string().contains("auto-generated display name"), "{err}");
+        assert!(
+            err.to_string().contains("auto-generated display name"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/server/src/routes/feedback/proposed_edits/property.rs
+++ b/server/src/routes/feedback/proposed_edits/property.rs
@@ -1,11 +1,20 @@
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use super::AppliableEdit;
-use super::csv_edit::apply_csv_upsert;
+use super::csv_edit::{Field, apply_csv_upsert, apply_csv_upsert_fields};
+
+/// The data pipeline renders entries without a curated name as `{id} ({type})`
+/// (e.g. `0507.01.767 (Besprechungsraum)`). A human name never starts with a
+/// room/building code followed by ` (`, so this pattern reliably flags a
+/// generated display name that leaked back through the edit form (#3181).
+static GENERATED_NAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[0-9][0-9A-Za-z@.]*\s+\(").expect("valid static regex"));
 
 #[derive(Deserialize, Debug, Clone, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -40,20 +49,56 @@ impl PropertyEdit {
     fn usages_csv_path(base_dir: &Path) -> PathBuf {
         base_dir.join("data").join("sources").join("usages.csv")
     }
+
+    /// Reject values that would launder a pipeline-generated display string back
+    /// into the curated source CSVs. Run before any writes so a stale or
+    /// third-party client cannot poison `names.csv` even though the webform no
+    /// longer pre-fills the editable name field with the decorated display name.
+    pub(super) fn validate(&self, key: &str) -> anyhow::Result<()> {
+        if let Self::Name {
+            name: Some(name), ..
+        } = self
+        {
+            let name = name.trim();
+            if name.starts_with(&format!("{key} (")) || GENERATED_NAME_RE.is_match(name) {
+                anyhow::bail!(
+                    "the name {name:?} looks like an auto-generated display name (`<id> (<type>)`), not a human-entered name; refusing to launder it into names.csv"
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 impl AppliableEdit for PropertyEdit {
     fn apply(&self, key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<String> {
         match self {
             Self::Name { name, short_name } => {
-                let name_val = name.as_deref().unwrap_or("");
-                let short_val = short_name.as_deref().unwrap_or("");
-                apply_csv_upsert(
+                // `None` (and a blank string) means "leave this column untouched"
+                // rather than "set it empty", so editing only the short name does
+                // not wipe a curated name, and vice versa.
+                let name = name.as_deref().map(str::trim).filter(|n| !n.is_empty());
+                let short_name = short_name.as_deref();
+                apply_csv_upsert_fields(
                     key,
                     &Self::names_csv_path(base_dir),
-                    &[key.to_string(), name_val.to_string(), short_val.to_string()],
+                    &[
+                        Field::Set(key.to_string()),
+                        name.map_or(Field::Keep, |n| Field::Set(n.to_string())),
+                        short_name.map_or(Field::Keep, |s| Field::Set(s.to_string())),
+                    ],
                 )?;
-                Ok(format!("name: `{name_val}`, short_name: `{short_val}`"))
+                let mut parts = Vec::new();
+                if let Some(name) = name {
+                    parts.push(format!("name: `{name}`"));
+                }
+                if let Some(short_name) = short_name {
+                    parts.push(format!("short_name: `{short_name}`"));
+                }
+                if parts.is_empty() {
+                    anyhow::bail!("a name property edit must change the name or the short name");
+                }
+                Ok(parts.join(", "))
             }
             Self::Usage {
                 name_de,
@@ -174,6 +219,91 @@ mod tests {
         beta,Beta,,
         zulu,Z,,
         ");
+    }
+
+    #[test]
+    fn test_short_name_only_edit_keeps_existing_name() {
+        // Regression for #3181: editing only the short name must not wipe the
+        // curated name (a `None` name means "leave untouched", not "set empty").
+        let (dir, sources_dir) = setup();
+        fs::write(
+            sources_dir.join("names.csv"),
+            format!("{NAMES_HEADER}\nalpha,Besprechungsraum,,1951\n"),
+        )
+        .unwrap();
+
+        let edit = PropertyEdit::Name {
+            name: None,
+            short_name: Some("BR".to_string()),
+        };
+        let desc = edit.apply("alpha", dir.path(), "branch").unwrap();
+        assert_snapshot!(desc, @"short_name: `BR`");
+        assert_snapshot!(fs::read_to_string(sources_dir.join("names.csv")).unwrap(), @r"
+        id,name,short_name,arch_name
+        alpha,Besprechungsraum,BR,1951
+        ");
+    }
+
+    #[test]
+    fn test_name_only_edit_keeps_existing_short_name() {
+        let (dir, sources_dir) = setup();
+        fs::write(
+            sources_dir.join("names.csv"),
+            format!("{NAMES_HEADER}\nalpha,Old,SN,1951\n"),
+        )
+        .unwrap();
+
+        let edit = PropertyEdit::Name {
+            name: Some("New".to_string()),
+            short_name: None,
+        };
+        let desc = edit.apply("alpha", dir.path(), "branch").unwrap();
+        assert_snapshot!(desc, @"name: `New`");
+        assert_snapshot!(fs::read_to_string(sources_dir.join("names.csv")).unwrap(), @r"
+        id,name,short_name,arch_name
+        alpha,New,SN,1951
+        ");
+    }
+
+    #[test]
+    fn test_validate_rejects_generated_display_name() {
+        // The exact #3181 payload: the entry's own decorated display name.
+        let edit = PropertyEdit::Name {
+            name: Some("0507.01.767 (Besprechungsraum)".to_string()),
+            short_name: None,
+        };
+        let err = edit.validate("0507.01.767").unwrap_err();
+        assert!(err.to_string().contains("auto-generated display name"), "{err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_mangled_id_prefix() {
+        // The user tweaked the id prefix the form offered them (767 -> 765); the
+        // result still looks like a generated `<id> (...)` string, not a name.
+        let edit = PropertyEdit::Name {
+            name: Some("0507.01.765 (Besprechungsraum)".to_string()),
+            short_name: None,
+        };
+        assert!(edit.validate("0507.01.767").is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_human_name() {
+        let edit = PropertyEdit::Name {
+            name: Some("Besprechungsraum Studentische Vertretung / SV".to_string()),
+            short_name: Some("SV".to_string()),
+        };
+        assert!(edit.validate("0206.EG.003").is_ok());
+    }
+
+    #[test]
+    fn test_validate_ignores_absent_name() {
+        // A short-name-only edit carries no name and must pass validation.
+        let edit = PropertyEdit::Name {
+            name: None,
+            short_name: Some("SV".to_string()),
+        };
+        assert!(edit.validate("0206.EG.003").is_ok());
     }
 
     #[test]

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -90,9 +90,13 @@ const suggestEdit = () => {
     floor: floorIds[0] ?? null,
   };
 
-  const fields = emptyPropertyFields();
-  editProposal.value.propertyFields = { ...fields, name: props.data.name };
-  editProposal.value.originalPropertyFields = { ...fields, name: props.data.name };
+  // Start the name field empty rather than pre-filling `props.data.name`: that
+  // is the decorated display name (`{id} ({name})`), not a curated name, so
+  // pre-filling it would launder the generated string back into names.csv on
+  // save. The current display name is offered as a read-only placeholder for
+  // context, and a name edit is only sent once the user actually types one.
+  editProposal.value.propertyFields = emptyPropertyFields();
+  editProposal.value.originalPropertyFields = emptyPropertyFields();
 
   editProposal.value.open = true;
 };

--- a/webclient/app/components/DetailsNearbyTransportSection.vue
+++ b/webclient/app/components/DetailsNearbyTransportSection.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-import { mdiArrowRightThin, mdiChevronDown, mdiChevronUp, mdiHelpCircle, mdiOpenInNew } from "@mdi/js";
+import {
+  mdiArrowRightThin,
+  mdiChevronDown,
+  mdiChevronUp,
+  mdiHelpCircle,
+  mdiOpenInNew,
+} from "@mdi/js";
 import { useToggle } from "@vueuse/core";
 import type { components } from "~/api_types";
 import {

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -579,7 +579,7 @@ de:
   opening_hours_source_required: Bitte gib eine Quelle (URL) für die Öffnungszeiten an.
   opening_hours_invalid_range: Bitte korrigiere die ungültigen Zeiträume (Ende muss nach dem Anfang liegen).
   field_name: Name
-  field_name_help: Nur der Name des Raums, ohne die Raumnummer (z.B. „Hörsaal 1 Friedrich L. Bauer"). Leer lassen, um den aktuellen Namen zu behalten.
+  field_name_help: Nur der Name des Raums, ohne die Raumnummer (z.B. 'Hörsaal 1 Friedrich L. Bauer'). Leer lassen, um den aktuellen Namen zu behalten.
   field_short_name: Kurzname
   field_short_name_help: Der Kurzname wird in Suchergebnissen angezeigt (z.B. „Hörsaal 1" oder „5602.EG.001")
   field_category: Kategorie
@@ -626,7 +626,7 @@ en:
   opening_hours_source_required: Please provide a source (URL) for the opening hours.
   opening_hours_invalid_range: Please fix the invalid time ranges (the end must be after the start).
   field_name: Name
-  field_name_help: Only the room's name, without its room number (e.g. "Lecture Hall 1 Friedrich L. Bauer"). Leave empty to keep the current name.
+  field_name_help: Only the room's name, without its room number (e.g. 'Lecture Hall 1 Friedrich L. Bauer'). Leave empty to keep the current name.
   field_short_name: Short name
   field_short_name_help: The short name is shown in search results (e.g. "Lecture Hall 1" or "5602.EG.001")
   field_category: Category

--- a/webclient/app/components/EditProposalModal.vue
+++ b/webclient/app/components/EditProposalModal.vue
@@ -405,6 +405,7 @@ function getEditTypeDisplay(roomId: string): string {
                 id="edit-name"
                 v-model="editProposal.propertyFields.name"
                 type="text"
+                :placeholder="editProposal.selected.name ?? ''"
                 class="focusable input-field rounded border px-2 py-1 w-full text-sm"
               />
               <p class="text-zinc-500 dark:text-zinc-400 text-xs mt-1">{{ t("field_name_help") }}</p>
@@ -578,7 +579,7 @@ de:
   opening_hours_source_required: Bitte gib eine Quelle (URL) für die Öffnungszeiten an.
   opening_hours_invalid_range: Bitte korrigiere die ungültigen Zeiträume (Ende muss nach dem Anfang liegen).
   field_name: Name
-  field_name_help: Der vollständige Name, wie er auf der Detailseite angezeigt wird (z.B. „Hörsaal 1 Friedrich L. Bauer")
+  field_name_help: Nur der Name des Raums, ohne die Raumnummer (z.B. „Hörsaal 1 Friedrich L. Bauer"). Leer lassen, um den aktuellen Namen zu behalten.
   field_short_name: Kurzname
   field_short_name_help: Der Kurzname wird in Suchergebnissen angezeigt (z.B. „Hörsaal 1" oder „5602.EG.001")
   field_category: Kategorie
@@ -625,7 +626,7 @@ en:
   opening_hours_source_required: Please provide a source (URL) for the opening hours.
   opening_hours_invalid_range: Please fix the invalid time ranges (the end must be after the start).
   field_name: Name
-  field_name_help: The full name shown on the detail page (e.g. "Lecture Hall 1 Friedrich L. Bauer")
+  field_name_help: Only the room's name, without its room number (e.g. "Lecture Hall 1 Friedrich L. Bauer"). Leave empty to keep the current name.
   field_short_name: Short name
   field_short_name_help: The short name is shown in search results (e.g. "Lecture Hall 1" or "5602.EG.001")
   field_category: Category


### PR DESCRIPTION
The property-edit form pre-filled the name field with the decorated display name (`{id} ({name})`) and the server wrote it verbatim, laundering generated strings into the curated `names.csv` (as seen in #3181) — this stops it on the client (no pre-fill, display name shown only as placeholder), adds a server-side 422 guard rejecting id-prefixed names, and makes the names upsert keep untouched columns so a short-name edit can't wipe a curated name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)