### PR TITLE
ci: move docker layer cache to GHCR and prune PR caches

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -57,8 +57,9 @@ jobs:
         id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          provenance: mode=max
-          sbom: true
+          # Attestations only matter for images published from main.
+          provenance: ${{ github.event_name == 'push' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name == 'push' }}
           context: ${{ inputs.context }} # zizmor: ignore[template-injection]
           push: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
           file: "${{ inputs.context }}/${{ inputs.dockerfile }}"
@@ -67,8 +68,9 @@ jobs:
           build-args: |
             GIT_COMMIT_SHA=${{ github.sha }}
             GIT_COMMIT_MESSAGE="${github.event.head_commit.message//\n/}"
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          # GHCR cache is shared across branches and free for public repos, unlike the 10GB Actions cache.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
       - name: Attest
         if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,22 @@
+name: Cleanup caches
+
+# A PR's caches are scoped to its own ref and unreadable by other PRs, so delete them when it closes.
+# Fork PRs have a read-only pull_request token, so pull_request_target is needed for actions:write.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] never checks out or runs PR code; only deletes this PR's caches
+    types: [ closed ]
+
+permissions: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches scoped to the closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: gh cache delete --all --ref "$PR_REF" --succeed-on-no-caches


### PR DESCRIPTION
## Why

The repo's GitHub Actions cache sits at **~10.5 GB against the 10 GB cap** — and **~10.3 GB of that is buildkit blobs** from `cache-to: type=gha`. Actions caches are branch-scoped, so each PR writes ~0.5 GB of blobs that no other PR can read; with the budget overflowing, they get LRU-evicted before reuse. Net effect: the docker layer cache is a near-permanent miss, and the server image recompiles its entire Rust dependency stage from scratch on most builds (~17 min).

## What

- **Docker layer cache → GHCR registry** (`_docker-build.yml`): `type=gha` → `type=registry,…:buildcache,mode=max`. GHCR storage is free for public repos and doesn't count against the 10 GB Actions budget, and a registry tag is shared across branches — every PR reads the cache `main` last wrote. Only pushes to `main` write it, so PRs can't clobber it and forks need no write access (they just read). `mode=max` now caches the expensive dependency stage. Applies to server, webclient, and martin (shared workflow).
- **Provenance/SBOM gated to `main`**: skipped on PR builds, where attestations have no consumer.
- **New `cleanup-caches.yml`**: on PR close, deletes that PR's branch-scoped Actions caches (rust-cache etc.) in one `gh cache delete --all --ref …` call. Uses `pull_request_target` because most PRs are from forks, whose `pull_request` token is read-only; it never checks out or runs PR code.

## Verification

- `zizmor --offline` clean on both workflows (the single `pull_request_target` carries an inline ignore with justification).
- All `uses:` remain SHA-pinned; the cleanup job has no `uses:`.

## Notes

- First `main` build after merge is still cold (it creates the `:buildcache` tag); every build after benefits.
- `cleanup-caches.yml` is intentionally not part of the merge-protection `done` checks (it runs post-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)