### PR TITLE
test(server): fix lecture fixture missing required upcoming field

### DIFF
--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -957,6 +957,14 @@ mod test {
             "parent_building_names": [],
             "parent_keywords": ["garching"],
             "next_occurrence_at": "2024-10-15T08:00:00Z",
+            "upcoming": [
+                {
+                    "start_at": "2024-10-15T08:00:00Z",
+                    "end_at": "2024-10-15T10:00:00Z",
+                    "room_code": "5606.EG.011",
+                    "room_name": "Testhörsaal",
+                },
+            ],
         });
         let task = ms
             .client

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_deprioritised_below_geo_on_shared_tokens.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_deprioritised_below_geo_on_shared_tokens.snap
@@ -21,6 +21,11 @@ info: q=Quantenrobotik Praktikum
       title_de: Quantenrobotik Praktikum
       title_en: Quantum Robotics Lab
       next_occurrence_at: "2024-10-15T08:00:00Z"
+      upcoming:
+        - start_at: "2024-10-15T08:00:00Z"
+          end_at: "2024-10-15T10:00:00Z"
+          room_code: 5606.EG.011
+          room_name: Testhörsaal
   n_visible: 1
   estimatedTotalHits: "[estimatedTotalHits]"
 - facet: sites


### PR DESCRIPTION
## Why

#3190 and #3189 merged within one minute of each other; each passed CI in isolation. #3189 made `LectureMSHit::upcoming` required, and #3190's new `test_lecture_deprioritised_below_geo_on_shared_tokens` fixture omits it - so post-merge `main` deterministically fails the test (deserialize panic at `mod.rs:992`), breaking every downstream PR build.

## What

Add `upcoming` to the lecture fixture and the matching entry to the insta snapshot, mirroring the shape already used by `test_lecture_facet_query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)