### PR TITLE
ci(server): bump CARGO_NET_RETRY to survive flaky crates.io downloads

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -53,6 +53,10 @@ ENV     USER=root
 ENV     RUSTFLAGS="-C target-feature=-crt-static -C link-arg=-fuse-ld=mold"
 # since our builds are from-scratch, we don't need incremental compliation here
 ENV     CARGO_INCREMENTAL=0
+# crates.io downloads occasionally drop mid-transfer on CI runners ("unexpected
+# eof while reading"), failing the whole image build. Cargo's default of 3
+# retries is not enough under that flakiness, so retry harder.
+ENV     CARGO_NET_RETRY=10
 # added in the build
 ARG     GIT_COMMIT_SHA=development
 ENV     GIT_COMMIT_SHA=${GIT_COMMIT_SHA}


### PR DESCRIPTION
The dominant source of CI flakiness is the **server Docker image build**, not the test suite. It fails when cargo's crate download drops mid-transfer on the runner:

```
#33 1.061 error: failed to get `chrono` as a dependency ...
#33 1.061   download of ch/ro/chrono failed
#33 1.061   [56] Failure when receiving data from the peer
            (OpenSSL SSL_read: unexpected eof while reading, errno 0)
```

This is an attempt against this.. lets see