### PR TITLE
refactor: discriminate lecture search results on `kind`/`facet` and drop the redundant per-lecture `type`

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1490,7 +1490,6 @@ components:
       description: A lecture search result, carrying its bilingual titles and upcoming occurrences.
       required:
         - id
-        - type
         - name
         - subtext
         - title_de
@@ -1526,10 +1525,6 @@ components:
           type: string
           description: The English title of the lecture.
           example: Introduction to Informatics 1
-        type:
-          type: string
-          description: the type of the result; always `lecture` for this variant
-          example: lecture
         upcoming:
           type: array
           items:

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -154,7 +154,6 @@ pub struct LectureMSHit {
     pub ms_id: String,
     /// Mirrors `title_de` for compatibility with the monolingual `name` field.
     pub name: String,
-    pub r#type: String,
     /// Human label of the `TUMonline` `stp_type` (e.g. "Vorlesung").
     pub type_common_name: String,
     pub title_de: String,

--- a/server/src/refresh/lectures.rs
+++ b/server/src/refresh/lectures.rs
@@ -302,7 +302,6 @@ async fn stale_lecture_ids(
 struct LectureDocument {
     ms_id: String,
     facet: &'static str,
-    r#type: &'static str,
     type_common_name: String,
     title_de: String,
     title_en: String,
@@ -322,7 +321,6 @@ impl LectureDocument {
         Self {
             ms_id: group.ms_id(),
             facet: LECTURE_FACET,
-            r#type: LECTURE_FACET,
             type_common_name: group
                 .stp_type
                 .clone()

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -238,7 +238,6 @@ fn make_lecture_entry(
     let name = highlighted_name_for_hit(hit, highlight);
     super::LectureEntry {
         id: lecture.ms_id.clone(),
-        r#type: lecture.r#type.clone(),
         subtext: lecture.type_common_name.clone(),
         name,
         title_de: lecture.title_de.clone(),

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -79,9 +79,6 @@ pub struct LectureEntry {
     /// The id of the lecture
     #[schema(example = "lecture_5f2c…")]
     id: String,
-    /// the type of the result; always `lecture` for this variant
-    #[schema(example = "lecture")]
-    r#type: String,
     /// The display name of the result. Supports highlighting.
     #[schema(example = "Einführung in die Informatik 1")]
     name: String,
@@ -962,7 +959,6 @@ mod test {
         let lecture = serde_json::json!({
             "ms_id": "lecture_testfixture0001",
             "facet": "lecture",
-            "type": "lecture",
             "type_common_name": "Vorlesung",
             "title_de": "Grundlagen der Navigatumlehre",
             "title_en": "Foundations of Navigatum Teaching",
@@ -1075,7 +1071,6 @@ mod test {
         let lecture = serde_json::json!({
             "ms_id": "lecture_testfixture0001",
             "facet": "lecture",
-            "type": "lecture",
             "type_common_name": "Vorlesung",
             "title_de": "Quantenrobotik Praktikum",
             "title_en": "Quantum Robotics Lab",

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_deprioritised_below_geo_on_shared_tokens.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_deprioritised_below_geo_on_shared_tokens.snap
@@ -15,7 +15,6 @@ info: q=Quantenrobotik Praktikum
 - facet: lectures
   entries:
     - id: lecture_testfixture0001
-      type: lecture
       name: "\u0019Quantenrobotik\u0017 \u0019Praktikum\u0017"
       subtext: Vorlesung
       title_de: Quantenrobotik Praktikum

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_facet_query.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lecture_facet_query.snap
@@ -7,7 +7,6 @@ info: q=Navigatumlehre
 - facet: lectures
   entries:
     - id: lecture_testfixture0001
-      type: lecture
       name: "Grundlagen der \u0019Navigatumlehre\u0017"
       subtext: Vorlesung
       title_de: Grundlagen der Navigatumlehre

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lectures_derived_from_calendar_surface_in_search.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__lectures_derived_from_calendar_surface_in_search.snap
@@ -6,7 +6,6 @@ expression: results.0
 - facet: lectures
   entries:
     - id: lecture_db2d1afb6ae25e08
-      type: lecture
       name: "\u0019Quantenfeldtheorie\u0017 im Teststand"
       subtext: Vorlesung
       title_de: Quantenfeldtheorie im Teststand

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -812,11 +812,6 @@ export type components = {
        */
       readonly title_en: string;
       /**
-       * @description the type of the result; always `lecture` for this variant
-       * @example lecture
-       */
-      readonly type: string;
-      /**
        * @description The upcoming occurrences of this lecture, in chronological order.
        *
        *     The first element's `start_at` matches `next_occurrence_at`. The list is

--- a/webclient/app/components/PreviewIcon.vue
+++ b/webclient/app/components/PreviewIcon.vue
@@ -6,13 +6,16 @@ import {
   mdiOfficeBuildingOutline,
   mdiSchool,
 } from "@mdi/js";
+import type { components } from "~/api_types/index.js";
 
-// The icon keys off the opaque `type` string and whether a `parsed_id` matched;
-// it is fed a small projection rather than a full search result, so it stays
-// decoupled from the result union's variants.
+type LocationEntry = components["schemas"]["LocationEntry"];
+
+// Lectures are discriminated by `kind`; within a location the opaque `type`
+// string selects the building/room/POI icon.
 interface ResultEntryItem {
-  type: string;
-  parsed_id?: string | null;
+  kind?: "location" | "lecture";
+  type: LocationEntry["type"];
+  parsed_id?: LocationEntry["parsed_id"];
 }
 defineProps<{ item: ResultEntryItem }>();
 </script>
@@ -24,16 +27,11 @@ defineProps<{ item: ResultEntryItem }>();
       <MdiIcon :path="mdiMapMarker" :size="20" v-else class="md:!w-6 md:!h-6" />
     </div>
     <div v-else class="text-white dark:text-black bg-blue-500 dark:bg-blue-400 rounded-full p-2">
+      <MdiIcon :path="mdiSchool" :size="20" v-if="item.kind === 'lecture'" class="mx-auto md:!w-6 md:!h-6" />
       <MdiIcon
         :path="mdiOfficeBuildingOutline"
         :size="20"
-        v-if="item.type === 'building'"
-        class="mx-auto md:!w-6 md:!h-6"
-      />
-      <MdiIcon
-        :path="mdiSchool"
-        :size="20"
-        v-else-if="item.type === 'lecture'"
+        v-else-if="item.type === 'building'"
         class="mx-auto md:!w-6 md:!h-6"
       />
       <MdiIcon :path="mdiOfficeBuilding" :size="20" v-else class="mx-auto md:!w-6 md:!h-6" />

--- a/webclient/app/components/PreviewIcon.vue
+++ b/webclient/app/components/PreviewIcon.vue
@@ -14,7 +14,7 @@ type LocationEntry = components["schemas"]["LocationEntry"];
 // string selects the building/room/POI icon.
 interface ResultEntryItem {
   kind?: "location" | "lecture";
-  type: LocationEntry["type"];
+  type?: LocationEntry["type"];
   parsed_id?: LocationEntry["parsed_id"];
 }
 defineProps<{ item: ResultEntryItem }>();

--- a/webclient/app/components/SearchResultItem.vue
+++ b/webclient/app/components/SearchResultItem.vue
@@ -35,7 +35,7 @@ const lectureMeta = computed(() => {
 
 <template>
   <div class="flex gap-1 px-2 py-3 md:gap-3 md:px-4" :class="{ 'bg-blue-200 dark:bg-blue-700': highlighted }">
-    <PreviewIcon :item="{ type: item.type, parsed_id: undefined }" />
+    <PreviewIcon :item="{ kind: item.kind, type: item.type, parsed_id: undefined }" />
     <div class="text-zinc-600 dark:text-zinc-300 flex flex-1 flex-col gap-0.5">
       <template v-if="item.kind === 'lecture'">
         <span class="text-zinc-900 dark:text-zinc-50 line-clamp-1 font-medium">{{ lectureTitleText }}</span>

--- a/webclient/app/components/SearchResultItem.vue
+++ b/webclient/app/components/SearchResultItem.vue
@@ -35,7 +35,9 @@ const lectureMeta = computed(() => {
 
 <template>
   <div class="flex gap-1 px-2 py-3 md:gap-3 md:px-4" :class="{ 'bg-blue-200 dark:bg-blue-700': highlighted }">
-    <PreviewIcon :item="{ kind: item.kind, type: item.type, parsed_id: undefined }" />
+    <PreviewIcon
+      :item="item.kind === 'lecture' ? { kind: 'lecture' } : { kind: 'location', type: item.type }"
+    />
     <div class="text-zinc-600 dark:text-zinc-300 flex flex-1 flex-col gap-0.5">
       <template v-if="item.kind === 'lecture'">
         <span class="text-zinc-900 dark:text-zinc-50 line-clamp-1 font-medium">{{ lectureTitleText }}</span>

--- a/webclient/app/components/SearchResultItemLink.vue
+++ b/webclient/app/components/SearchResultItemLink.vue
@@ -14,9 +14,7 @@ const emit = defineEmits(["click", "mouseover"]);
 // route and render as a plain, non-navigable row.
 const to = computed<EntityPath | null>(() => {
   if (props.item.kind === "lecture") return null;
-  return isRoutableEntityType(props.item.type)
-    ? entityPath(props.item.id, props.item.type)
-    : null;
+  return isRoutableEntityType(props.item.type) ? entityPath(props.item.id, props.item.type) : null;
 });
 </script>
 

--- a/webclient/app/components/SearchResultItemLink.vue
+++ b/webclient/app/components/SearchResultItemLink.vue
@@ -12,9 +12,12 @@ const emit = defineEmits(["click", "mouseover"]);
 // Entity results link to their canonical /{type}/{id} path. Non-routable results
 // (e.g. Nominatim addresses, only surfaced on the navigate page) have no entity
 // route and render as a plain, non-navigable row.
-const to = computed<EntityPath | null>(() =>
-  isRoutableEntityType(props.item.type) ? entityPath(props.item.id, props.item.type) : null
-);
+const to = computed<EntityPath | null>(() => {
+  if (props.item.kind === "lecture") return null;
+  return isRoutableEntityType(props.item.type)
+    ? entityPath(props.item.id, props.item.type)
+    : null;
+});
 </script>
 
 <template>


### PR DESCRIPTION
Removes the per-lecture `type` field (always the constant `"lecture"`, identical to the section `facet`) end to end — index write, deserialize, API response, OpenAPI, and generated types — and points the webclient's `PreviewIcon` at the `kind` discriminator every other consumer already uses.