### PR TITLE
feat(map): /map page with toggleable WC layer

### DIFF
--- a/map/README.md
+++ b/map/README.md
@@ -192,11 +192,11 @@ Every poi row carries an `indoor` discriminator (`toilet`, `shower`, `elevator`,
 The `pois` table uses `any` ids (`osm_type` + `osm_id`) rather than an area table, because the area
 id type cannot store node ids.
 
-### Browse layers on `/map`
+### Filtering on `/map`
 
-[`navigatum-basemap.json`](./martin/styles/navigatum-basemap.json) splits the icon pois into
-per-category symbol layers - `indoor-toilets`, `indoor-showers`, and `indoor-elevators` - all
-visible by default at `minzoom: 17`. The label pois (rooms, auditoriums, …) stay on `indoor-pois`.
-The webclient `/map` page toggles the visibility of these split layers; its `LAYER_REGISTRY`
-(`webclient/app/composables/mapLayers.ts`) groups toilets and showers into the "WCs" overlay. A new
-browse layer is one more `LayerDef` plus one more split style layer.
+The webclient `/map` page does not change the shared style. Its filter panel highlights a category
+by dimming everything else: selecting the "WCs" filter fades the non-matching POI icons, labels, and
+room fills (via runtime `setPaintProperty`) while keeping `indoor='toilet'`/`'shower'` features
+vibrant. The filters live in `FILTER_REGISTRY` (`webclient/app/composables/mapLayers.ts`); each maps
+to the `indoor` values it keeps vibrant, so a new filter is one more `FilterDef`. Because this reads
+the existing `indoor_pois` source, it needs no style or tile-server change to ship.

--- a/map/README.md
+++ b/map/README.md
@@ -195,7 +195,7 @@ id type cannot store node ids.
 ### Browse layers on `/map`
 
 [`navigatum-basemap.json`](./martin/styles/navigatum-basemap.json) splits the icon pois into
-per-category symbol layers — `indoor-toilets`, `indoor-showers`, and `indoor-elevators` — all
+per-category symbol layers - `indoor-toilets`, `indoor-showers`, and `indoor-elevators` - all
 visible by default at `minzoom: 17`. The label pois (rooms, auditoriums, …) stay on `indoor-pois`.
 The webclient `/map` page toggles the visibility of these split layers; its `LAYER_REGISTRY`
 (`webclient/app/composables/mapLayers.ts`) groups toilets and showers into the "WCs" overlay. A new

--- a/map/README.md
+++ b/map/README.md
@@ -170,3 +170,33 @@ To run tests, we recommend downloading the jar file from the [Planetiler release
 ```bash
 java -jar planetiler.jar verify ./map/planetiler/shortbread_custom.yml --watch
 ```
+
+## Indoor data (osm2pgsql)
+
+The indoor overlay is a separate pipeline from the planetiler basemap above. `osm2pgsql` reads the
+OpenStreetMap extract through [`osm2pgsql/style.lua`](./osm2pgsql/style.lua) into Postgres tables
+(`rooms`, `pois`, `doors`, `indoor_ways`), which [martin](./martin) then serves as the `indoor_*`
+vector layers (see `server/migrations` for the tile functions). It is wired up in
+[`compose.data.yml`](/compose.data.yml).
+
+Every poi row carries an `indoor` discriminator (`toilet`, `shower`, `elevator`, `auditorium`,
+`room`, …) instead of a separate category column. POIs are ingested from all three OSM geometries:
+
+- **ways and relations** contribute a label point (pole of inaccessibility, or centroid for
+  elevators).
+- **nodes** contribute a point with a synthesized `area` of `0`. A bare `amenity=toilets` /
+  `amenity=shower` node (no `room=` tag) is normalized to `indoor='toilet'` / `'shower'`, but only
+  when it carries indoor context (an `indoor=*` or `level=*` tag) so stray outdoor amenities are
+  not pulled in.
+
+The `pois` table uses `any` ids (`osm_type` + `osm_id`) rather than an area table, because the area
+id type cannot store node ids.
+
+### Browse layers on `/map`
+
+[`navigatum-basemap.json`](./martin/styles/navigatum-basemap.json) splits the icon pois into
+per-category symbol layers — `indoor-toilets`, `indoor-showers`, and `indoor-elevators` — all
+visible by default at `minzoom: 17`. The label pois (rooms, auditoriums, …) stay on `indoor-pois`.
+The webclient `/map` page toggles the visibility of these split layers; its `LAYER_REGISTRY`
+(`webclient/app/composables/mapLayers.ts`) groups toilets and showers into the "WCs" overlay. A new
+browse layer is one more `LayerDef` plus one more split style layer.

--- a/map/martin/styles/navigatum-basemap.json
+++ b/map/martin/styles/navigatum-basemap.json
@@ -5372,7 +5372,12 @@
       "type": "symbol",
       "source": "indoor",
       "minzoom": 17,
-      "filter": ["all"],
+      "filter": [
+        "all",
+        ["!=", ["get", "indoor"], "toilet"],
+        ["!=", ["get", "indoor"], "shower"],
+        ["!=", ["get", "indoor"], "elevator"]
+      ],
       "layout": {
         "text-allow-overlap": {
           "stops": [
@@ -5510,6 +5515,85 @@
         ]
       },
       "source-layer": "indoor_pois"
+    },
+    {
+      "id": "indoor-toilets",
+      "type": "symbol",
+      "source": "indoor",
+      "source-layer": "indoor_pois",
+      "minzoom": 17,
+      "filter": ["==", ["get", "indoor"], "toilet"],
+      "layout": {
+        "visibility": "visible",
+        "symbol-placement": "point",
+        "symbol-sort-key": ["get", "area"],
+        "icon-optional": false,
+        "icon-allow-overlap": false,
+        "icon-overlap": "never",
+        "icon-image": [
+          "case",
+          ["get", "is_male_toilet"],
+          "toilet_male",
+          ["get", "is_female_toilet"],
+          "toilet_female",
+          "toilet"
+        ],
+        "icon-size": {
+          "stops": [[17, 0.5], [22, 6]],
+          "base": 2
+        }
+      },
+      "paint": {
+        "icon-color": "#9B468D"
+      }
+    },
+    {
+      "id": "indoor-showers",
+      "type": "symbol",
+      "source": "indoor",
+      "source-layer": "indoor_pois",
+      "minzoom": 17,
+      "filter": ["==", ["get", "indoor"], "shower"],
+      "layout": {
+        "visibility": "visible",
+        "symbol-placement": "point",
+        "symbol-sort-key": ["get", "area"],
+        "icon-optional": false,
+        "icon-allow-overlap": false,
+        "icon-overlap": "never",
+        "icon-image": "noun-shower-51",
+        "icon-size": {
+          "stops": [[17, 0.5], [22, 6]],
+          "base": 2
+        }
+      },
+      "paint": {
+        "icon-color": "#573FDE"
+      }
+    },
+    {
+      "id": "indoor-elevators",
+      "type": "symbol",
+      "source": "indoor",
+      "source-layer": "indoor_pois",
+      "minzoom": 17,
+      "filter": ["==", ["get", "indoor"], "elevator"],
+      "layout": {
+        "visibility": "visible",
+        "symbol-placement": "point",
+        "symbol-sort-key": ["get", "area"],
+        "icon-optional": false,
+        "icon-allow-overlap": false,
+        "icon-overlap": "never",
+        "icon-image": "elevator",
+        "icon-size": {
+          "stops": [[17, 0.5], [22, 6]],
+          "base": 2
+        }
+      },
+      "paint": {
+        "icon-color": "#072140"
+      }
     },
     {
       "id": "indoorsteps-white-base",

--- a/map/martin/styles/navigatum-basemap.json
+++ b/map/martin/styles/navigatum-basemap.json
@@ -5372,12 +5372,7 @@
       "type": "symbol",
       "source": "indoor",
       "minzoom": 17,
-      "filter": [
-        "all",
-        ["!=", ["get", "indoor"], "toilet"],
-        ["!=", ["get", "indoor"], "shower"],
-        ["!=", ["get", "indoor"], "elevator"]
-      ],
+      "filter": ["all"],
       "layout": {
         "text-allow-overlap": {
           "stops": [
@@ -5515,85 +5510,6 @@
         ]
       },
       "source-layer": "indoor_pois"
-    },
-    {
-      "id": "indoor-toilets",
-      "type": "symbol",
-      "source": "indoor",
-      "source-layer": "indoor_pois",
-      "minzoom": 17,
-      "filter": ["==", ["get", "indoor"], "toilet"],
-      "layout": {
-        "visibility": "visible",
-        "symbol-placement": "point",
-        "symbol-sort-key": ["get", "area"],
-        "icon-optional": false,
-        "icon-allow-overlap": false,
-        "icon-overlap": "never",
-        "icon-image": [
-          "case",
-          ["get", "is_male_toilet"],
-          "toilet_male",
-          ["get", "is_female_toilet"],
-          "toilet_female",
-          "toilet"
-        ],
-        "icon-size": {
-          "stops": [[17, 0.5], [22, 6]],
-          "base": 2
-        }
-      },
-      "paint": {
-        "icon-color": "#9B468D"
-      }
-    },
-    {
-      "id": "indoor-showers",
-      "type": "symbol",
-      "source": "indoor",
-      "source-layer": "indoor_pois",
-      "minzoom": 17,
-      "filter": ["==", ["get", "indoor"], "shower"],
-      "layout": {
-        "visibility": "visible",
-        "symbol-placement": "point",
-        "symbol-sort-key": ["get", "area"],
-        "icon-optional": false,
-        "icon-allow-overlap": false,
-        "icon-overlap": "never",
-        "icon-image": "noun-shower-51",
-        "icon-size": {
-          "stops": [[17, 0.5], [22, 6]],
-          "base": 2
-        }
-      },
-      "paint": {
-        "icon-color": "#573FDE"
-      }
-    },
-    {
-      "id": "indoor-elevators",
-      "type": "symbol",
-      "source": "indoor",
-      "source-layer": "indoor_pois",
-      "minzoom": 17,
-      "filter": ["==", ["get", "indoor"], "elevator"],
-      "layout": {
-        "visibility": "visible",
-        "symbol-placement": "point",
-        "symbol-sort-key": ["get", "area"],
-        "icon-optional": false,
-        "icon-allow-overlap": false,
-        "icon-overlap": "never",
-        "icon-image": "elevator",
-        "icon-size": {
-          "stops": [[17, 0.5], [22, 6]],
-          "base": 2
-        }
-      },
-      "paint": {
-        "icon-color": "#072140"
-      }
     },
     {
       "id": "indoorsteps-white-base",

--- a/map/osm2pgsql/style.lua
+++ b/map/osm2pgsql/style.lua
@@ -43,23 +43,29 @@ tables.rooms =
       }
     )
 tables.pois =
-    osm2pgsql.define_area_table(
-      "pois",
+    osm2pgsql.define_table(
       {
-        { column = "indoor",               type = "text",    not_null = true },
-        { column = "ref",                  type = "text" },
-        { column = "name",                 type = "text" },
-        { column = "students_have_access", type = "boolean", not_null = true },
-        { column = "is_male_toilet",       type = "boolean", not_null = true },
-        { column = "is_female_toilet",     type = "boolean", not_null = true },
-        { column = "is_unisex_toilet",     type = "boolean", not_null = true },
-        { column = "is_wheelchair_toilet", type = "boolean", not_null = true },
-        { column = "is_shower",            type = "boolean", not_null = true },
-        { column = "area",                 type = "real",    not_null = true },
-        { column = "level_min",            type = "real",    not_null = true },
-        { column = "level_max",            type = "real",    not_null = true },
-        -- why can this not be a point???
-        { column = "geom",                 type = "point",   not_null = true }
+        name = "pois",
+        -- `any` ids (osm_type + osm_id) let nodes, ways, and relations share one table.
+        -- The `area` id type a `define_area_table` would give us rejects node inserts, but
+        -- bare `amenity=toilets`/`shower` points are node geometry, so we need node ids here.
+        ids = { type = "any", id_column = "osm_id", type_column = "osm_type" },
+        columns = {
+          { column = "indoor",               type = "text",    not_null = true },
+          { column = "ref",                  type = "text" },
+          { column = "name",                 type = "text" },
+          { column = "students_have_access", type = "boolean", not_null = true },
+          { column = "is_male_toilet",       type = "boolean", not_null = true },
+          { column = "is_female_toilet",     type = "boolean", not_null = true },
+          { column = "is_unisex_toilet",     type = "boolean", not_null = true },
+          { column = "is_wheelchair_toilet", type = "boolean", not_null = true },
+          { column = "is_shower",            type = "boolean", not_null = true },
+          { column = "area",                 type = "real",    not_null = true },
+          { column = "level_min",            type = "real",    not_null = true },
+          { column = "level_max",            type = "real",    not_null = true },
+          -- a point is all we render; the geometry is reduced to one before insertion.
+          { column = "geom",                 type = "point",   not_null = true }
+        }
       }
     )
 
@@ -272,6 +278,18 @@ function osm2pgsql.process_node(object)
   if clean_tags_indoor(object.tags) then
     return
   end
+  -- A bare `amenity=toilets`/`shower` node has no `room=` tag, so it arrives as the inferred
+  -- indoor='yes'. Normalise it into the poi space so node-geometry toilets and showers render
+  -- as the same icons as their room= counterparts. Ways and relations are intentionally left
+  -- alone (they reach the poi space via the `room=` smudging in clean_tags_indoor). The guard
+  -- in clean_tags_indoor (indoor or level required) keeps stray outdoor amenity nodes out.
+  if object.tags.indoor ~= "toilet" and object.tags.indoor ~= "shower" then
+    if object.tags.amenity == "toilet" or object.tags.amenity == "toilets" then
+      object.tags.indoor = "toilet"
+    elseif object.tags.amenity == "shower" or object.tags.amenity == "showers" then
+      object.tags.indoor = "shower"
+    end
+  end
   if object.tags.indoor == "door" then
     -- pois should not need layers. Using them is likely a bug
     object.tags.layer = nil
@@ -289,6 +307,27 @@ function osm2pgsql.process_node(object)
       tables.doors:insert(
         {
           width_cm = object.tags.width,
+          level_min = level.min,
+          level_max = level.max,
+          geom = object:as_point()
+        }
+      )
+    end
+  elseif object.tags.indoor == "toilet" or object.tags.indoor == "shower" then
+    -- Node-geometry toilets/showers (e.g. a bare `amenity=toilets` point) carry no area,
+    -- so we synthesize `area = 0`; the poi icon does not depend on it. We never carry
+    -- `name`/`ref` for these POIs — they render as icons only, like their room= counterparts.
+    for _, level in ipairs(SantiseLevel(object.tags.level)) do
+      tables.pois:insert(
+        {
+          indoor = object.tags.indoor,
+          students_have_access = object.tags.access ~= "private" and object.tags.access ~= "no",
+          is_male_toilet = object.tags.indoor == "toilet" and object.tags.male == "yes",
+          is_female_toilet = object.tags.indoor == "toilet" and object.tags.female == "yes",
+          is_unisex_toilet = object.tags.indoor == "toilet" and object.tags.unisex == "yes",
+          is_wheelchair_toilet = object.tags.indoor == "toilet" and object.tags.wheelchair == "yes",
+          is_shower = object.tags.indoor == "shower",
+          area = 0,
           level_min = level.min,
           level_max = level.max,
           geom = object:as_point()

--- a/map/osm2pgsql/style.lua
+++ b/map/osm2pgsql/style.lua
@@ -46,9 +46,8 @@ tables.pois =
     osm2pgsql.define_table(
       {
         name = "pois",
-        -- `any` ids (osm_type + osm_id) let nodes, ways, and relations share one table.
-        -- The `area` id type a `define_area_table` would give us rejects node inserts, but
-        -- bare `amenity=toilets`/`shower` points are node geometry, so we need node ids here.
+        -- `any` ids (osm_type + osm_id) so nodes can share this table: the `area` id type a
+        -- `define_area_table` gives rejects node inserts, but bare amenity=toilets points are nodes.
         ids = { type = "any", id_column = "osm_id", type_column = "osm_type" },
         columns = {
           { column = "indoor",               type = "text",    not_null = true },
@@ -278,11 +277,9 @@ function osm2pgsql.process_node(object)
   if clean_tags_indoor(object.tags) then
     return
   end
-  -- A bare `amenity=toilets`/`shower` node has no `room=` tag, so it arrives as the inferred
-  -- indoor='yes'. Normalise it into the poi space so node-geometry toilets and showers render
-  -- as the same icons as their room= counterparts. Ways and relations are intentionally left
-  -- alone (they reach the poi space via the `room=` smudging in clean_tags_indoor). The guard
-  -- in clean_tags_indoor (indoor or level required) keeps stray outdoor amenity nodes out.
+  -- Bare amenity=toilets/shower nodes lack a room= tag, so normalise them into the poi space
+  -- here (nodes only; ways/relations get smudged in clean_tags_indoor). The indoor-or-level
+  -- guard there keeps context-less outdoor amenities out.
   if object.tags.indoor ~= "toilet" and object.tags.indoor ~= "shower" then
     if object.tags.amenity == "toilet" or object.tags.amenity == "toilets" then
       object.tags.indoor = "toilet"
@@ -314,9 +311,8 @@ function osm2pgsql.process_node(object)
       )
     end
   elseif object.tags.indoor == "toilet" or object.tags.indoor == "shower" then
-    -- Node-geometry toilets/showers (e.g. a bare `amenity=toilets` point) carry no area,
-    -- so we synthesize `area = 0`; the poi icon does not depend on it. We never carry
-    -- `name`/`ref` for these POIs - they render as icons only, like their room= counterparts.
+    -- Point geometry has no area, so synthesize `area = 0` (the icon does not use it). No
+    -- name/ref: these render as icons only.
     for _, level in ipairs(SantiseLevel(object.tags.level)) do
       tables.pois:insert(
         {

--- a/map/osm2pgsql/style.lua
+++ b/map/osm2pgsql/style.lua
@@ -316,7 +316,7 @@ function osm2pgsql.process_node(object)
   elseif object.tags.indoor == "toilet" or object.tags.indoor == "shower" then
     -- Node-geometry toilets/showers (e.g. a bare `amenity=toilets` point) carry no area,
     -- so we synthesize `area = 0`; the poi icon does not depend on it. We never carry
-    -- `name`/`ref` for these POIs — they render as icons only, like their room= counterparts.
+    -- `name`/`ref` for these POIs - they render as icons only, like their room= counterparts.
     for _, level in ipairs(SantiseLevel(object.tags.level)) do
       tables.pois:insert(
         {

--- a/tests/specs/map.ui.spec.ts
+++ b/tests/specs/map.ui.spec.ts
@@ -9,9 +9,9 @@ const EMPTY_STYLE = { version: 8, sources: {}, layers: [] };
 // Garching centroid - the page's default center, so a feature placed here lands at canvas center.
 const CENTER: [number, number] = [11.670099, 48.266921];
 
-// A style carrying a single clickable `indoor-toilets` feature. The page wires its popup click
-// handler to that layer id, so this deterministically drives the popup without live data. A
-// `circle` layer needs no sprite to be clickable, unlike the real `symbol` icon layer.
+// A style carrying a single clickable toilet in the `indoor-pois` layer the page wires its popup
+// handler to, so this deterministically drives the popup without live data. A `circle` layer
+// needs no sprite to be clickable, unlike the real `symbol` icon layer.
 const STYLE_WITH_TOILET = {
   version: 8,
   sources: {
@@ -30,7 +30,7 @@ const STYLE_WITH_TOILET = {
     },
   },
   layers: [
-    { id: "indoor-toilets", type: "circle", source: "test-pois", paint: { "circle-radius": 24 } },
+    { id: "indoor-pois", type: "circle", source: "test-pois", paint: { "circle-radius": 24 } },
   ],
 };
 
@@ -41,44 +41,40 @@ async function stubBasemap(page: Page, style: object): Promise<void> {
 }
 
 test.describe("Browse map (/map)", () => {
-  test("loads with the layer panel and WCs enabled by default", async ({ page }) => {
+  test("loads with the filter panel and no filter active by default", async ({ page }) => {
     await stubBasemap(page, EMPTY_STYLE);
     await page.goto("/map", { waitUntil: "networkidle" });
 
     await expect(page.getByRole("region", { name: "Map" })).toBeVisible();
 
-    const panel = page.getByRole("region", { name: "Ebenen" });
+    const panel = page.getByRole("region", { name: "Filter" });
     await expect(panel).toBeVisible();
 
     const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
-    await expect(wcs).toBeChecked();
-    // The default selection is reflected into the URL so deep links round-trip.
-    await expect(page).toHaveURL(/[?&]layers=wcs/);
+    await expect(wcs).not.toBeChecked();
+    await expect(page).not.toHaveURL(/[?&]filter=wcs/);
   });
 
-  test("toggling WCs flips the checkbox and the ?layers= query", async ({ page }) => {
+  test("toggling WCs flips the checkbox and the ?filter= query", async ({ page }) => {
     await stubBasemap(page, EMPTY_STYLE);
     await page.goto("/map", { waitUntil: "networkidle" });
 
     const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
-    await expect(wcs).toBeChecked();
+    await wcs.check();
+    await expect(page).toHaveURL(/[?&]filter=wcs/);
 
     await wcs.uncheck();
     await expect(wcs).not.toBeChecked();
-    // An explicit empty value (not an absent key) so an "all off" state survives a reload.
-    await expect(page).toHaveURL(/[?&]layers=(?:#|&|$)/);
-
-    await wcs.check();
-    await expect(page).toHaveURL(/[?&]layers=wcs/);
+    await expect(page).not.toHaveURL(/[?&]filter=wcs/);
   });
 
-  test("shows a zoom-in hint only below zoom 17", async ({ page }) => {
+  test("shows a zoom-in hint only below zoom 17 while the filter is active", async ({ page }) => {
     await stubBasemap(page, EMPTY_STYLE);
 
-    await page.goto("/map#15/48.2669/11.6701", { waitUntil: "networkidle" });
+    await page.goto("/map?filter=wcs#15/48.2669/11.6701", { waitUntil: "networkidle" });
     await expect(page.getByText(/Hineinzoomen/)).toBeVisible();
 
-    await page.goto("/map#18/48.2669/11.6701", { waitUntil: "networkidle" });
+    await page.goto("/map?filter=wcs#18/48.2669/11.6701", { waitUntil: "networkidle" });
     await expect(page.getByText(/Hineinzoomen/)).toHaveCount(0);
   });
 
@@ -89,17 +85,15 @@ test.describe("Browse map (/map)", () => {
     const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
     await expect(wcs).toBeVisible();
 
-    await page.getByRole("button", { name: "Ebenen" }).click();
+    await page.getByRole("button", { name: "Filter" }).click();
     await expect(wcs).toBeHidden();
 
     await page.reload({ waitUntil: "networkidle" });
-    await expect(page.getByRole("region", { name: "Ebenen" })).toBeVisible();
+    await expect(page.getByRole("region", { name: "Filter" })).toBeVisible();
     await expect(page.getByRole("checkbox", { name: "Toiletten & Duschen" })).toBeHidden();
   });
 
-  test("clicking a toilet marker opens a popup with attributes and an OSM edit link", async ({
-    page,
-  }) => {
+  test("clicking a toilet opens a popup with attributes and an OSM edit link", async ({ page }) => {
     await stubBasemap(page, STYLE_WITH_TOILET);
     await page.goto("/map", { waitUntil: "networkidle" });
     await expect(page.getByRole("region", { name: "Map" })).toBeVisible();

--- a/tests/specs/map.ui.spec.ts
+++ b/tests/specs/map.ui.spec.ts
@@ -6,7 +6,7 @@ import { expect, type Page, test } from "@playwright/test";
 // panel, and zoom-driven hint all render.
 const EMPTY_STYLE = { version: 8, sources: {}, layers: [] };
 
-// Garching centroid — the page's default center, so a feature placed here lands at canvas center.
+// Garching centroid - the page's default center, so a feature placed here lands at canvas center.
 const CENTER: [number, number] = [11.670099, 48.266921];
 
 // A style carrying a single clickable `indoor-toilets` feature. The page wires its popup click

--- a/tests/specs/map.ui.spec.ts
+++ b/tests/specs/map.ui.spec.ts
@@ -1,0 +1,123 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// The browse map pulls its style from the production Martin tileserver, whose POI data drifts
+// and is occasionally unavailable. Stub the style so the tests exercise our page (panel, URL
+// state, popup) rather than live tiles. An empty style still fires `load`, so the controls,
+// panel, and zoom-driven hint all render.
+const EMPTY_STYLE = { version: 8, sources: {}, layers: [] };
+
+// Garching centroid — the page's default center, so a feature placed here lands at canvas center.
+const CENTER: [number, number] = [11.670099, 48.266921];
+
+// A style carrying a single clickable `indoor-toilets` feature. The page wires its popup click
+// handler to that layer id, so this deterministically drives the popup without live data. A
+// `circle` layer needs no sprite to be clickable, unlike the real `symbol` icon layer.
+const STYLE_WITH_TOILET = {
+  version: 8,
+  sources: {
+    "test-pois": {
+      type: "geojson",
+      data: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { indoor: "toilet", is_male_toilet: true, is_wheelchair_toilet: true },
+            geometry: { type: "Point", coordinates: CENTER },
+          },
+        ],
+      },
+    },
+  },
+  layers: [
+    { id: "indoor-toilets", type: "circle", source: "test-pois", paint: { "circle-radius": 24 } },
+  ],
+};
+
+async function stubBasemap(page: Page, style: object): Promise<void> {
+  await page.route("https://nav.tum.de/martin/style/navigatum-basemap.json", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(style) })
+  );
+}
+
+test.describe("Browse map (/map)", () => {
+  test("loads with the layer panel and WCs enabled by default", async ({ page }) => {
+    await stubBasemap(page, EMPTY_STYLE);
+    await page.goto("/map", { waitUntil: "networkidle" });
+
+    await expect(page.getByRole("region", { name: "Map" })).toBeVisible();
+
+    const panel = page.getByRole("region", { name: "Ebenen" });
+    await expect(panel).toBeVisible();
+
+    const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
+    await expect(wcs).toBeChecked();
+    // The default selection is reflected into the URL so deep links round-trip.
+    await expect(page).toHaveURL(/[?&]layers=wcs/);
+  });
+
+  test("toggling WCs flips the checkbox and the ?layers= query", async ({ page }) => {
+    await stubBasemap(page, EMPTY_STYLE);
+    await page.goto("/map", { waitUntil: "networkidle" });
+
+    const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
+    await expect(wcs).toBeChecked();
+
+    await wcs.uncheck();
+    await expect(wcs).not.toBeChecked();
+    // An explicit empty value (not an absent key) so an "all off" state survives a reload.
+    await expect(page).toHaveURL(/[?&]layers=(?:#|&|$)/);
+
+    await wcs.check();
+    await expect(page).toHaveURL(/[?&]layers=wcs/);
+  });
+
+  test("shows a zoom-in hint only below zoom 17", async ({ page }) => {
+    await stubBasemap(page, EMPTY_STYLE);
+
+    await page.goto("/map#15/48.2669/11.6701", { waitUntil: "networkidle" });
+    await expect(page.getByText(/Hineinzoomen/)).toBeVisible();
+
+    await page.goto("/map#18/48.2669/11.6701", { waitUntil: "networkidle" });
+    await expect(page.getByText(/Hineinzoomen/)).toHaveCount(0);
+  });
+
+  test("collapsing the panel persists across a reload", async ({ page }) => {
+    await stubBasemap(page, EMPTY_STYLE);
+    await page.goto("/map", { waitUntil: "networkidle" });
+
+    const wcs = page.getByRole("checkbox", { name: "Toiletten & Duschen" });
+    await expect(wcs).toBeVisible();
+
+    await page.getByRole("button", { name: "Ebenen" }).click();
+    await expect(wcs).toBeHidden();
+
+    await page.reload({ waitUntil: "networkidle" });
+    await expect(page.getByRole("region", { name: "Ebenen" })).toBeVisible();
+    await expect(page.getByRole("checkbox", { name: "Toiletten & Duschen" })).toBeHidden();
+  });
+
+  test("clicking a toilet marker opens a popup with attributes and an OSM edit link", async ({
+    page,
+  }) => {
+    await stubBasemap(page, STYLE_WITH_TOILET);
+    await page.goto("/map", { waitUntil: "networkidle" });
+    await expect(page.getByRole("region", { name: "Map" })).toBeVisible();
+
+    // The feature sits at the default center, i.e. the canvas centre, which is what a default
+    // click targets.
+    await page.locator("#map-browse canvas").first().click();
+
+    const popup = page.locator(".maplibregl-popup-content");
+    await expect(popup).toBeVisible();
+    await expect(popup).toContainText("Toilette");
+    await expect(popup).toContainText("Herren");
+    await expect(popup).toContainText("Rollstuhlgerecht");
+
+    const editLink = popup.getByRole("link", { name: "In OpenStreetMap bearbeiten" });
+    await expect(editLink).toHaveAttribute(
+      "href",
+      /openstreetmap\.org\/edit#map=21\/48\.266921\d*\/11\.670099\d*/
+    );
+  });
+});

--- a/webclient/app/components/MapLayerPanel.vue
+++ b/webclient/app/components/MapLayerPanel.vue
@@ -4,11 +4,9 @@ import type { LayerDef } from "~/composables/mapLayers";
 
 const props = defineProps<{
   layers: readonly LayerDef[];
-  /** Currently enabled layer ids; the parent reassigns the Set so identity changes drive reactivity. */
+  // Reassigned wholesale by the parent so identity changes drive reactivity.
   enabled: Set<string>;
-  /** Whether the layer list is collapsed (peek-only on mobile, header-only on desktop). */
   collapsed: boolean;
-  /** Live map zoom, to decide whether a layer's "zoom in" hint applies. */
   zoom: number;
 }>();
 const emit = defineEmits<{

--- a/webclient/app/components/MapLayerPanel.vue
+++ b/webclient/app/components/MapLayerPanel.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { mdiChevronDown, mdiChevronUp, mdiLayersOutline } from "@mdi/js";
-import type { LayerDef } from "~/composables/mapLayers";
+import { mdiChevronDown, mdiChevronUp, mdiFilterVariant } from "@mdi/js";
+import type { FilterDef } from "~/composables/mapLayers";
 
 const props = defineProps<{
-  layers: readonly LayerDef[];
+  filters: readonly FilterDef[];
   // Reassigned wholesale by the parent so identity changes drive reactivity.
-  enabled: Set<string>;
+  active: Set<string>;
   collapsed: boolean;
   zoom: number;
 }>();
@@ -16,14 +16,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: "local" });
 
-function showHint(layer: LayerDef): boolean {
-  return props.enabled.has(layer.id) && props.zoom < layer.hintBelowZoom;
+function showHint(filter: FilterDef): boolean {
+  return props.active.has(filter.id) && props.zoom < filter.hintBelowZoom;
 }
 </script>
 
 <template>
   <section
-    class="border-zinc-200 dark:border-zinc-700 bg-white/95 dark:bg-zinc-800/95 pointer-events-auto absolute z-10 flex flex-col overflow-hidden border shadow-lg backdrop-blur-sm bottom-0 inset-x-0 rounded-t-xl border-b-0 md:bottom-auto md:inset-x-auto md:left-4 md:top-4 md:w-72 md:rounded-xl md:border-b"
+    class="border-zinc-200 dark:border-zinc-700 bg-white/95 dark:bg-zinc-800/95 pointer-events-auto absolute z-10 flex flex-col overflow-hidden border shadow-lg backdrop-blur-sm bottom-0 inset-x-0 rounded-t-md border-b-0 md:bottom-auto md:inset-x-auto md:left-4 md:top-4 md:w-72 md:rounded-md md:border-b"
     :aria-label="t('panel_title')"
   >
     <button
@@ -33,31 +33,31 @@ function showHint(layer: LayerDef): boolean {
       @click="emit('update:collapsed', !collapsed)"
     >
       <span class="flex items-center gap-2">
-        <MdiIcon :path="mdiLayersOutline" :size="20" />
+        <MdiIcon :path="mdiFilterVariant" :size="20" />
         {{ t("panel_title") }}
       </span>
       <MdiIcon :path="collapsed ? mdiChevronUp : mdiChevronDown" :size="20" />
     </button>
 
     <ul v-show="!collapsed" class="flex flex-col gap-1 px-2 pb-3">
-      <li v-for="layer in layers" :key="layer.id">
+      <li v-for="filter in filters" :key="filter.id">
         <label
-          class="hover:bg-zinc-100 dark:hover:bg-zinc-700/60 flex cursor-pointer items-center justify-between gap-3 rounded-lg px-2 py-2"
+          class="hover:bg-zinc-100 dark:hover:bg-zinc-700/60 flex cursor-pointer items-center justify-between gap-3 rounded-md px-2 py-2"
         >
           <span class="text-zinc-700 dark:text-zinc-200 flex items-center gap-2">
-            <MdiIcon :path="layer.icon" :size="22" />
-            {{ t(layer.labelKey) }}
+            <MdiIcon :path="filter.icon" :size="22" />
+            {{ t(filter.labelKey) }}
           </span>
           <input
             type="checkbox"
             class="h-4 w-4 accent-blue-600 dark:accent-blue-400"
-            :checked="enabled.has(layer.id)"
-            :aria-label="t(layer.labelKey)"
-            @change="emit('toggle', layer.id)"
+            :checked="active.has(filter.id)"
+            :aria-label="t(filter.labelKey)"
+            @change="emit('toggle', filter.id)"
           />
         </label>
-        <p v-if="showHint(layer)" class="text-zinc-500 dark:text-zinc-400 px-2 pb-1 text-xs">
-          {{ t("zoom_hint", { name: t(layer.labelKey) }) }}
+        <p v-if="showHint(filter)" class="text-zinc-500 dark:text-zinc-400 px-2 pb-1 text-xs">
+          {{ t("zoom_hint", { name: t(filter.labelKey) }) }}
         </p>
       </li>
     </ul>
@@ -66,13 +66,13 @@ function showHint(layer: LayerDef): boolean {
 
 <i18n lang="yaml">
 de:
-  panel_title: Ebenen
+  panel_title: Filter
   zoom_hint: Hineinzoomen, um {name} zu sehen
-  layers:
+  filters:
     wcs: Toiletten & Duschen
 en:
-  panel_title: Layers
+  panel_title: Filter
   zoom_hint: Zoom in to see {name}
-  layers:
+  filters:
     wcs: Toilets & showers
 </i18n>

--- a/webclient/app/components/MapLayerPanel.vue
+++ b/webclient/app/components/MapLayerPanel.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { mdiChevronDown, mdiChevronUp, mdiLayersOutline } from "@mdi/js";
+import type { LayerDef } from "~/composables/mapLayers";
+
+const props = defineProps<{
+  layers: readonly LayerDef[];
+  /** Currently enabled layer ids; the parent reassigns the Set so identity changes drive reactivity. */
+  enabled: Set<string>;
+  /** Whether the layer list is collapsed (peek-only on mobile, header-only on desktop). */
+  collapsed: boolean;
+  /** Live map zoom, to decide whether a layer's "zoom in" hint applies. */
+  zoom: number;
+}>();
+const emit = defineEmits<{
+  toggle: [id: string];
+  "update:collapsed": [value: boolean];
+}>();
+
+const { t } = useI18n({ useScope: "local" });
+
+function showHint(layer: LayerDef): boolean {
+  return props.enabled.has(layer.id) && props.zoom < layer.hintBelowZoom;
+}
+</script>
+
+<template>
+  <section
+    class="border-zinc-200 dark:border-zinc-700 bg-white/95 dark:bg-zinc-800/95 pointer-events-auto absolute z-10 flex flex-col overflow-hidden border shadow-lg backdrop-blur-sm bottom-0 inset-x-0 rounded-t-xl border-b-0 md:bottom-auto md:inset-x-auto md:left-4 md:top-4 md:w-72 md:rounded-xl md:border-b"
+    :aria-label="t('panel_title')"
+  >
+    <button
+      type="button"
+      class="focusable text-zinc-700 dark:text-zinc-200 flex w-full items-center justify-between gap-2 px-4 py-3 font-semibold"
+      :aria-expanded="!collapsed"
+      @click="emit('update:collapsed', !collapsed)"
+    >
+      <span class="flex items-center gap-2">
+        <MdiIcon :path="mdiLayersOutline" :size="20" />
+        {{ t("panel_title") }}
+      </span>
+      <MdiIcon :path="collapsed ? mdiChevronUp : mdiChevronDown" :size="20" />
+    </button>
+
+    <ul v-show="!collapsed" class="flex flex-col gap-1 px-2 pb-3">
+      <li v-for="layer in layers" :key="layer.id">
+        <label
+          class="hover:bg-zinc-100 dark:hover:bg-zinc-700/60 flex cursor-pointer items-center justify-between gap-3 rounded-lg px-2 py-2"
+        >
+          <span class="text-zinc-700 dark:text-zinc-200 flex items-center gap-2">
+            <MdiIcon :path="layer.icon" :size="22" />
+            {{ t(layer.labelKey) }}
+          </span>
+          <input
+            type="checkbox"
+            class="h-4 w-4 accent-blue-600 dark:accent-blue-400"
+            :checked="enabled.has(layer.id)"
+            :aria-label="t(layer.labelKey)"
+            @change="emit('toggle', layer.id)"
+          />
+        </label>
+        <p v-if="showHint(layer)" class="text-zinc-500 dark:text-zinc-400 px-2 pb-1 text-xs">
+          {{ t("zoom_hint", { name: t(layer.labelKey) }) }}
+        </p>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<i18n lang="yaml">
+de:
+  panel_title: Ebenen
+  zoom_hint: Hineinzoomen, um {name} zu sehen
+  layers:
+    wcs: Toiletten & Duschen
+en:
+  panel_title: Layers
+  zoom_hint: Zoom in to see {name}
+  layers:
+    wcs: Toilets & showers
+</i18n>

--- a/webclient/app/composables/mapLayers.ts
+++ b/webclient/app/composables/mapLayers.ts
@@ -1,34 +1,34 @@
 import { mdiToilet } from "@mdi/js";
 
-/** A toggleable overlay on the `/map` page. A new layer = one `LayerDef` + one split style layer. */
-export interface LayerDef {
-  /** Stable key used in the `?layers=` query and in `localStorage`. */
+/** A map filter that highlights one category by dimming everything else. */
+export interface FilterDef {
+  /** Stable key used in the `?filter=` query and in `localStorage`. */
   readonly id: string;
   /** i18n key (local scope of the `/map` page) for the panel label. */
   readonly labelKey: string;
   /** MDI path rendered as the panel icon. */
   readonly icon: string;
-  /** MapLibre style-layer ids whose `visibility` this overlay flips. */
-  readonly styleLayerIds: readonly string[];
+  /** The `indoor` property values this filter keeps vibrant. */
+  readonly indoorValues: readonly string[];
   /** Below this zoom the data is not in the tiles yet, so we show a "zoom in" hint. */
   readonly hintBelowZoom: number;
 }
 
-export const LAYER_REGISTRY = [
+export const FILTER_REGISTRY = [
   {
     id: "wcs",
-    labelKey: "layers.wcs",
+    labelKey: "filters.wcs",
     icon: mdiToilet,
-    styleLayerIds: ["indoor-toilets", "indoor-showers"],
+    indoorValues: ["toilet", "shower"],
     hintBelowZoom: 17,
   },
-] as const satisfies readonly LayerDef[];
+] as const satisfies readonly FilterDef[];
 
-export type LayerId = (typeof LAYER_REGISTRY)[number]["id"];
+export type FilterId = (typeof FILTER_REGISTRY)[number]["id"];
 
-export const LAYERS_QUERY_PARAM = "layers";
+export const FILTER_QUERY_PARAM = "filter";
 export const LEVEL_QUERY_PARAM = "level";
-export const ENABLED_LAYERS_STORAGE_KEY = "map:enabledLayers";
+export const ACTIVE_FILTERS_STORAGE_KEY = "map:activeFilters";
 export const PANEL_COLLAPSED_STORAGE_KEY = "map:panelCollapsed";
 
 // Mirrors the `FLOOR_LEVELS` ids in `FloorControl.ts`, duplicated to keep this module free of the
@@ -37,51 +37,50 @@ export const SELECTABLE_LEVELS: readonly number[] = [6, 5, 4, 3, 2, 1, 0, -1];
 export const DEFAULT_LEVEL = 0;
 
 /**
- * Parse a comma-separated `?layers=` value into the set of enabled layer ids, dropping
- * anything not in the registry. An empty or whitespace-only value yields an empty set
- * (every overlay off), which is distinct from the value being absent entirely.
+ * Parse a comma-separated `?filter=` value into the set of active filter ids, dropping anything
+ * not in the registry. An empty or whitespace-only value yields an empty set, which is distinct
+ * from the value being absent entirely.
  */
-export function parseEnabledLayers(
+export function parseFilters(
   param: string | null | undefined,
-  registry: readonly LayerDef[] = LAYER_REGISTRY
+  registry: readonly FilterDef[] = FILTER_REGISTRY
 ): Set<string> {
-  const known = new Set(registry.map((layer) => layer.id));
-  const enabled = new Set<string>();
+  const known = new Set(registry.map((f) => f.id));
+  const active = new Set<string>();
   for (const raw of (param ?? "").split(",")) {
     const id = raw.trim();
-    if (id && known.has(id)) enabled.add(id);
+    if (id && known.has(id)) active.add(id);
   }
-  return enabled;
+  return active;
 }
 
-/** Serialise enabled layer ids back into a stable, registry-ordered `?layers=` value. */
-export function serializeEnabledLayers(
-  enabled: Iterable<string>,
-  registry: readonly LayerDef[] = LAYER_REGISTRY
+/** Serialise active filter ids back into a stable, registry-ordered `?filter=` value. */
+export function serializeFilters(
+  active: Iterable<string>,
+  registry: readonly FilterDef[] = FILTER_REGISTRY
 ): string {
-  const set = enabled instanceof Set ? enabled : new Set(enabled);
+  const set = active instanceof Set ? active : new Set(active);
   return registry
-    .map((layer) => layer.id)
+    .map((f) => f.id)
     .filter((id) => set.has(id))
     .join(",");
 }
 
 /**
- * Resolve which overlays start enabled, honouring precedence: an explicit `?layers=` in the
- * URL wins (even when it selects nothing, so an "all off" deep link survives a reload), then
- * `localStorage`, then the default of every registry overlay on.
+ * Resolve which filters start active, honouring precedence: an explicit `?filter=` in the URL
+ * wins (even when empty, so a deep link survives a reload), then `localStorage`, then the default
+ * of no filter active.
  */
-export function resolveEnabledLayers(opts: {
+export function resolveActiveFilters(opts: {
   urlParam?: string | null;
   stored?: string | null;
-  registry?: readonly LayerDef[];
+  registry?: readonly FilterDef[];
 }): Set<string> {
-  const registry = opts.registry ?? LAYER_REGISTRY;
+  const registry = opts.registry ?? FILTER_REGISTRY;
   if (opts.urlParam !== undefined && opts.urlParam !== null)
-    return parseEnabledLayers(opts.urlParam, registry);
-  if (opts.stored !== undefined && opts.stored !== null)
-    return parseEnabledLayers(opts.stored, registry);
-  return new Set(registry.map((layer) => layer.id));
+    return parseFilters(opts.urlParam, registry);
+  if (opts.stored !== undefined && opts.stored !== null) return parseFilters(opts.stored, registry);
+  return new Set();
 }
 
 /** Parse a `?level=` value into a known integer floor, or `null` when absent or invalid. */

--- a/webclient/app/composables/mapLayers.ts
+++ b/webclient/app/composables/mapLayers.ts
@@ -1,0 +1,108 @@
+import { mdiToilet } from "@mdi/js";
+
+/**
+ * A toggleable map overlay on the `/map` browse page.
+ *
+ * The registry is a small static list, deliberately not server- or config-driven: a new
+ * layer is one more `LayerDef` plus one more split style layer (see `indoor-toilets` and
+ * friends in `map/martin/styles/navigatum-basemap.json`).
+ */
+export interface LayerDef {
+  /** Stable key used in the `?layers=` query and in `localStorage`. */
+  readonly id: string;
+  /** i18n key (local scope of the `/map` page) for the panel label. */
+  readonly labelKey: string;
+  /** MDI path rendered as the panel icon. */
+  readonly icon: string;
+  /** MapLibre style-layer ids whose `visibility` this overlay flips. */
+  readonly styleLayerIds: readonly string[];
+  /** Below this zoom the data is not in the tiles yet, so we show a "zoom in" hint. */
+  readonly hintBelowZoom: number;
+}
+
+export const LAYER_REGISTRY = [
+  {
+    id: "wcs",
+    labelKey: "layers.wcs",
+    icon: mdiToilet,
+    // Toilets and showers are toggled together as one "WCs" overlay.
+    styleLayerIds: ["indoor-toilets", "indoor-showers"],
+    hintBelowZoom: 17,
+  },
+] as const satisfies readonly LayerDef[];
+
+export type LayerId = (typeof LAYER_REGISTRY)[number]["id"];
+
+export const LAYERS_QUERY_PARAM = "layers";
+export const LEVEL_QUERY_PARAM = "level";
+export const ENABLED_LAYERS_STORAGE_KEY = "map:enabledLayers";
+export const PANEL_COLLAPSED_STORAGE_KEY = "map:panelCollapsed";
+
+/**
+ * Selectable floor levels, ground floor first. Mirrors the `id`s of `FLOOR_LEVELS` in
+ * `FloorControl.ts`; kept as a plain list here so this module stays free of the maplibre
+ * import (which cannot load under the node test environment).
+ */
+export const SELECTABLE_LEVELS: readonly number[] = [6, 5, 4, 3, 2, 1, 0, -1];
+export const DEFAULT_LEVEL = 0;
+
+/**
+ * Parse a comma-separated `?layers=` value into the set of enabled layer ids, dropping
+ * anything not in the registry. An empty or whitespace-only value yields an empty set
+ * (every overlay off), which is distinct from the value being absent entirely.
+ */
+export function parseEnabledLayers(
+  param: string | null | undefined,
+  registry: readonly LayerDef[] = LAYER_REGISTRY
+): Set<string> {
+  const known = new Set(registry.map((layer) => layer.id));
+  const enabled = new Set<string>();
+  for (const raw of (param ?? "").split(",")) {
+    const id = raw.trim();
+    if (id && known.has(id)) enabled.add(id);
+  }
+  return enabled;
+}
+
+/** Serialise enabled layer ids back into a stable, registry-ordered `?layers=` value. */
+export function serializeEnabledLayers(
+  enabled: Iterable<string>,
+  registry: readonly LayerDef[] = LAYER_REGISTRY
+): string {
+  const set = enabled instanceof Set ? enabled : new Set(enabled);
+  return registry
+    .map((layer) => layer.id)
+    .filter((id) => set.has(id))
+    .join(",");
+}
+
+/**
+ * Resolve which overlays start enabled, honouring precedence: an explicit `?layers=` in the
+ * URL wins (even when it selects nothing, so an "all off" deep link survives a reload), then
+ * `localStorage`, then the default of every registry overlay on.
+ */
+export function resolveEnabledLayers(opts: {
+  urlParam?: string | null;
+  stored?: string | null;
+  registry?: readonly LayerDef[];
+}): Set<string> {
+  const registry = opts.registry ?? LAYER_REGISTRY;
+  if (opts.urlParam !== undefined && opts.urlParam !== null)
+    return parseEnabledLayers(opts.urlParam, registry);
+  if (opts.stored !== undefined && opts.stored !== null)
+    return parseEnabledLayers(opts.stored, registry);
+  return new Set(registry.map((layer) => layer.id));
+}
+
+/** Parse a `?level=` value into a known integer floor, or `null` when absent or invalid. */
+export function parseLevel(param: string | null | undefined): number | null {
+  if (param === null || param === undefined || param.trim() === "") return null;
+  const level = Number(param);
+  if (!Number.isInteger(level) || !SELECTABLE_LEVELS.includes(level)) return null;
+  return level;
+}
+
+/** Resolve the initial floor, defaulting to the ground floor when `?level=` is unusable. */
+export function resolveLevel(param: string | null | undefined): number {
+  return parseLevel(param) ?? DEFAULT_LEVEL;
+}

--- a/webclient/app/composables/mapLayers.ts
+++ b/webclient/app/composables/mapLayers.ts
@@ -1,12 +1,6 @@
 import { mdiToilet } from "@mdi/js";
 
-/**
- * A toggleable map overlay on the `/map` browse page.
- *
- * The registry is a small static list, deliberately not server- or config-driven: a new
- * layer is one more `LayerDef` plus one more split style layer (see `indoor-toilets` and
- * friends in `map/martin/styles/navigatum-basemap.json`).
- */
+/** A toggleable overlay on the `/map` page. A new layer = one `LayerDef` + one split style layer. */
 export interface LayerDef {
   /** Stable key used in the `?layers=` query and in `localStorage`. */
   readonly id: string;
@@ -25,7 +19,6 @@ export const LAYER_REGISTRY = [
     id: "wcs",
     labelKey: "layers.wcs",
     icon: mdiToilet,
-    // Toilets and showers are toggled together as one "WCs" overlay.
     styleLayerIds: ["indoor-toilets", "indoor-showers"],
     hintBelowZoom: 17,
   },
@@ -38,11 +31,8 @@ export const LEVEL_QUERY_PARAM = "level";
 export const ENABLED_LAYERS_STORAGE_KEY = "map:enabledLayers";
 export const PANEL_COLLAPSED_STORAGE_KEY = "map:panelCollapsed";
 
-/**
- * Selectable floor levels, ground floor first. Mirrors the `id`s of `FLOOR_LEVELS` in
- * `FloorControl.ts`; kept as a plain list here so this module stays free of the maplibre
- * import (which cannot load under the node test environment).
- */
+// Mirrors the `FLOOR_LEVELS` ids in `FloorControl.ts`, duplicated to keep this module free of the
+// maplibre import (which fails to load under the node test environment).
 export const SELECTABLE_LEVELS: readonly number[] = [6, 5, 4, 3, 2, 1, 0, -1];
 export const DEFAULT_LEVEL = 0;
 

--- a/webclient/app/pages/index.vue
+++ b/webclient/app/pages/index.vue
@@ -205,7 +205,7 @@ de:
   show_details_for_building: Details für das Gebäude '{0}' anzeigen
   description: Finde Räume, Gebäude und andere Orte an der TUM mit Exzellenz. Eine moderne Alternative zum RoomFinder, entwickelt von Studierenden.
   explore_map: Karte erkunden
-  explore_map_subtitle: Stöbere auf der Karte und blende Ebenen wie Toiletten und Duschen ein.
+  explore_map_subtitle: Stöbere auf der Karte und filtere nach Orten wie Toiletten und Duschen.
   explore_map_aria: Die interaktive Karte erkunden
   sites_overview:
     others: Sonstige
@@ -220,7 +220,7 @@ en:
   show_details_for_building: show the details for the building '{0}'
   description: Find rooms, buildings and other places at TUM with excellence. A modern alternative to RoomFinder, developed by students.
   explore_map: Explore the map
-  explore_map_subtitle: Browse the map and toggle layers such as toilets and showers.
+  explore_map_subtitle: Browse the map and filter for places such as toilets and showers.
   explore_map_aria: Explore the interactive map
   sites_overview:
     others: Others

--- a/webclient/app/pages/index.vue
+++ b/webclient/app/pages/index.vue
@@ -5,6 +5,7 @@ import {
   mdiChevronRight,
   mdiChevronUp,
   mdiMapMarker,
+  mdiMapSearchOutline,
 } from "@mdi/js";
 import { entityPath, type RoutableEntityType } from "~/utils/entityPath";
 
@@ -176,6 +177,20 @@ const openPanels = ref<(boolean | undefined)[]>([]);
       </div>
     </div>
   </div>
+  <NuxtLink
+    :to="localePath('/map')"
+    :aria-label="t('explore_map_aria')"
+    class="focusable border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200 mt-4 flex flex-row items-center justify-between gap-4 rounded-lg border-2 p-5 !no-underline hover:text-blue-500 dark:hover:text-blue-400"
+  >
+    <div class="flex flex-row items-center gap-3">
+      <MdiIcon :path="mdiMapSearchOutline" :size="28" class="shrink-0" />
+      <div class="flex flex-col">
+        <span class="text-md font-semibold">{{ t("explore_map") }}</span>
+        <span class="text-zinc-500 dark:text-zinc-400 text-sm">{{ t("explore_map_subtitle") }}</span>
+      </div>
+    </div>
+    <MdiIcon :path="mdiArrowRight" :size="24" class="my-auto hidden h-6 w-6 shrink-0 md:block" />
+  </NuxtLink>
 </template>
 
 <i18n lang="yaml">
@@ -189,6 +204,9 @@ de:
   show_details_for_campus: Details für den Campus '{0}' anzeigen
   show_details_for_building: Details für das Gebäude '{0}' anzeigen
   description: Finde Räume, Gebäude und andere Orte an der TUM mit Exzellenz. Eine moderne Alternative zum RoomFinder, entwickelt von Studierenden.
+  explore_map: Karte erkunden
+  explore_map_subtitle: Stöbere auf der Karte und blende Ebenen wie Toiletten und Duschen ein.
+  explore_map_aria: Die interaktive Karte erkunden
   sites_overview:
     others: Sonstige
 en:
@@ -201,6 +219,9 @@ en:
   show_details_for_campus: show the details for the campus '{0}'
   show_details_for_building: show the details for the building '{0}'
   description: Find rooms, buildings and other places at TUM with excellence. A modern alternative to RoomFinder, developed by students.
+  explore_map: Explore the map
+  explore_map_subtitle: Browse the map and toggle layers such as toilets and showers.
+  explore_map_aria: Explore the interactive map
   sites_overview:
     others: Others
 </i18n>

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -186,6 +186,17 @@ function initMap(): MapLibreMap {
     );
     m.addControl(new FullscreenControl(), "top-right");
     m.addControl(floorControl, "top-right");
+
+    // Drop the legacy raster floor-plan overlays; the browse view shows only the vector indoor
+    // data. FloorControl's getLayer guards then skip them while still swapping the vector source
+    // per floor.
+    for (const layer of m.getStyle().layers) {
+      if (!layer.id.startsWith("indoor-raster-floor-")) continue;
+      const source = "source" in layer ? layer.source : undefined;
+      m.removeLayer(layer.id);
+      if (typeof source === "string" && m.getSource(source)) m.removeSource(source);
+    }
+
     // Ground floor by default.
     floorControl.setLevel(resolveLevel(queryString(LEVEL_QUERY_PARAM)));
 

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -33,17 +33,21 @@ useSeoMeta({
 
 const GARCHING_CENTER: [number, number] = [11.670099, 48.266921];
 const INITIAL_ZOOM = 17;
-// Opacity the non-matching map content fades to while a filter is active.
+// Opacity the non-matching indoor content fades to while a filter is active.
 const DIM = 0.2;
-// The combined POI layer that carries the toilet/shower icons (and other POIs we dim per-feature).
+// Translucent white wash over the basemap; lighter than the indoor dim so it reads as "a bit".
+const BASEMAP_SCRIM = "rgba(255, 255, 255, 0.45)";
+const SCRIM_LAYER = "filter-basemap-dim";
+// The combined POI layer whose markers open a popup.
 const POI_LAYER = "indoor-pois";
-// Other indoor content faded as a whole while a filter is active.
-const DIM_TARGETS: ReadonlyArray<{ id: string; prop: string }> = [
-  { id: "indoor-pois", prop: "text-opacity" },
-  { id: "indoor-rooms", prop: "fill-opacity" },
-  { id: "poi-indoor", prop: "icon-opacity" },
-  { id: "poi-indoor", prop: "text-opacity" },
-];
+// Indoor layers carrying an `indoor` field: keep the filter's values vibrant, dim the rest
+// per-feature (so e.g. the toilet room fill stays its bathroom colour while other rooms fade).
+const PER_FEATURE_TARGETS = [
+  { id: "indoor-pois", prop: "icon-opacity", type: "symbol" },
+  { id: "indoor-rooms", prop: "fill-opacity", type: "fill" },
+] as const;
+// Indoor content with no per-feature meaning: dim wholesale while a filter is active.
+const FLAT_TARGETS = [{ id: "indoor-pois", prop: "text-opacity", type: "symbol" }] as const;
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
@@ -86,6 +90,11 @@ function rememberPaint(m: MapLibreMap, id: string, prop: string): void {
   if (!originalPaint.has(key)) originalPaint.set(key, m.getPaintProperty(id, prop) ?? 1);
 }
 
+/** The id of the lowest indoor-source layer, used to slot the basemap scrim just beneath it. */
+function firstIndoorLayerId(m: MapLibreMap): string | undefined {
+  return m.getStyle().layers.find((l) => "source" in l && l.source === "indoor")?.id;
+}
+
 /** Highlight the active filters by dimming everything else; restore the original paint when none. */
 function applyFilterDim(): void {
   const m = map.value;
@@ -93,20 +102,32 @@ function applyFilterDim(): void {
   const vibrant = vibrantIndoorValues();
   const active = vibrant.length > 0;
 
-  // Fade the non-matching POI icons in place (a data-driven opacity keeps the matches vibrant).
-  if (m.getLayer(POI_LAYER)?.type === "symbol") {
-    rememberPaint(m, POI_LAYER, "icon-opacity");
-    m.setPaintProperty(
-      POI_LAYER,
-      "icon-opacity",
-      active
-        ? ["case", ["in", ["get", "indoor"], ["literal", vibrant]], 1, DIM]
-        : originalPaint.get(`${POI_LAYER}::icon-opacity`)
+  // Fade the whole basemap a little with one scrim slotted beneath the indoor layers.
+  const scrim = m.getLayer(SCRIM_LAYER);
+  if (active && !scrim) {
+    m.addLayer(
+      { id: SCRIM_LAYER, type: "background", paint: { "background-color": BASEMAP_SCRIM } },
+      firstIndoorLayerId(m)
     );
+  } else if (!active && scrim) {
+    m.removeLayer(SCRIM_LAYER);
   }
 
-  for (const { id, prop } of DIM_TARGETS) {
-    if (!m.getLayer(id)) continue;
+  // Fade non-matching indoor features in place, keeping the filter's values at their original paint.
+  for (const { id, prop, type } of PER_FEATURE_TARGETS) {
+    if (m.getLayer(id)?.type !== type) continue;
+    rememberPaint(m, id, prop);
+    const original = originalPaint.get(`${id}::${prop}`);
+    m.setPaintProperty(
+      id,
+      prop,
+      active
+        ? ["case", ["in", ["get", "indoor"], ["literal", vibrant]], original ?? 1, DIM]
+        : original
+    );
+  }
+  for (const { id, prop, type } of FLAT_TARGETS) {
+    if (m.getLayer(id)?.type !== type) continue;
     rememberPaint(m, id, prop);
     m.setPaintProperty(id, prop, active ? DIM : originalPaint.get(`${id}::${prop}`));
   }

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import type { MapGeoJSONFeature, MapLayerMouseEvent } from "maplibre-gl";
+import {
+  FullscreenControl,
+  GeolocateControl,
+  Map as MapLibreMap,
+  NavigationControl,
+  Popup,
+} from "maplibre-gl";
+import { FloorControl } from "~/composables/FloorControl";
+import {
+  ENABLED_LAYERS_STORAGE_KEY,
+  LAYER_REGISTRY,
+  LAYERS_QUERY_PARAM,
+  LEVEL_QUERY_PARAM,
+  PANEL_COLLAPSED_STORAGE_KEY,
+  resolveEnabledLayers,
+  resolveLevel,
+  serializeEnabledLayers,
+} from "~/composables/mapLayers";
+import { webglSupport } from "~/composables/webglSupport";
+
+definePageMeta({ layout: "navigation" });
+
+const { t } = useI18n({ useScope: "local" });
+const route = useRoute();
+
+useSeoMeta({
+  title: () => t("title"),
+  description: () => t("description"),
+});
+
+// Garching is the densest indoor-mapped campus, so it best demonstrates the WC layer on first load.
+const GARCHING_CENTER: [number, number] = [11.670099, 48.266921];
+const INITIAL_ZOOM = 17;
+
+// `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
+const map = shallowRef<MapLibreMap | undefined>(undefined);
+const poiPopup = shallowRef<Popup | undefined>(undefined);
+const initialLoaded = ref(false);
+const currentZoom = ref(INITIAL_ZOOM);
+// Reassigned (never mutated in place) so the panel's `Set` prop changes identity and re-renders.
+const enabledLayers = ref<Set<string>>(new Set(LAYER_REGISTRY.map((l) => l.id)));
+const panelCollapsed = ref(false);
+
+// Every style-layer id any overlay manages; also the layers whose markers open a popup.
+const allStyleLayerIds = LAYER_REGISTRY.flatMap((l) => l.styleLayerIds);
+
+/** Read a query value as a single string, distinguishing "absent" (null) from "present but empty" (""). */
+function queryString(key: string): string | null {
+  if (!(key in route.query)) return null;
+  const raw = route.query[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value ?? "";
+}
+
+/** Update one query parameter in place, leaving MapLibre's `#zoom/lat/lng` hash untouched. */
+function setQueryParam(key: string, value: string | null): void {
+  const url = new URL(window.location.href);
+  if (value === null) url.searchParams.delete(key);
+  else url.searchParams.set(key, value);
+  window.history.replaceState(window.history.state, "", url.toString());
+}
+
+function applyLayerVisibility(): void {
+  const m = map.value;
+  if (!m) return;
+  for (const layer of LAYER_REGISTRY) {
+    const visibility = enabledLayers.value.has(layer.id) ? "visible" : "none";
+    for (const styleLayerId of layer.styleLayerIds) {
+      if (m.getLayer(styleLayerId)) m.setLayoutProperty(styleLayerId, "visibility", visibility);
+    }
+  }
+}
+
+function toggleLayer(id: string): void {
+  const next = new Set(enabledLayers.value);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  enabledLayers.value = next;
+}
+
+watch(enabledLayers, (layers) => {
+  const serialized = serializeEnabledLayers(layers);
+  localStorage.setItem(ENABLED_LAYERS_STORAGE_KEY, serialized);
+  // Always reflect the exact selection (empty included) so an "all off" deep link survives a reload.
+  setQueryParam(LAYERS_QUERY_PARAM, serialized);
+  applyLayerVisibility();
+});
+
+watch(panelCollapsed, (collapsed) => {
+  localStorage.setItem(PANEL_COLLAPSED_STORAGE_KEY, collapsed ? "1" : "0");
+});
+
+function truthy(value: unknown): boolean {
+  return value === true || value === 1 || value === "true";
+}
+
+function buildPopupContent(feature: MapGeoJSONFeature, lng: number, lat: number): HTMLElement {
+  const props = feature.properties ?? {};
+  const isShower = props.indoor === "shower";
+
+  const root = document.createElement("div");
+  // Colours live in the `.maplibregl-popup-content` style rule below, not in nightwind-inverted
+  // utility classes, so the text stays dark on the popup's (always white) background in dark mode.
+  root.className = "flex flex-col gap-1 text-sm";
+
+  const title = document.createElement("p");
+  title.className = "font-semibold";
+  title.textContent = isShower ? t("poi.shower") : t("poi.toilet");
+  root.appendChild(title);
+
+  const addRow = (text: string) => {
+    const row = document.createElement("p");
+    row.className = "opacity-70";
+    row.textContent = text;
+    root.appendChild(row);
+  };
+
+  if (!isShower) {
+    const genders: string[] = [];
+    if (truthy(props.is_unisex_toilet)) genders.push(t("gender.unisex"));
+    if (truthy(props.is_male_toilet)) genders.push(t("gender.male"));
+    if (truthy(props.is_female_toilet)) genders.push(t("gender.female"));
+    if (genders.length) addRow(`${t("gender.label")}: ${genders.join(", ")}`);
+    if (truthy(props.is_wheelchair_toilet)) addRow(t("wheelchair_accessible"));
+  }
+
+  // Location-only deep link into the OSM editor (no element id is carried through the tiles).
+  const edit = document.createElement("a");
+  edit.href = `https://www.openstreetmap.org/edit#map=21/${lat.toFixed(7)}/${lng.toFixed(7)}`;
+  edit.target = "_blank";
+  edit.rel = "noopener noreferrer";
+  edit.textContent = t("edit_in_osm");
+  root.appendChild(edit);
+
+  return root;
+}
+
+function openPoiPopup(event: MapLayerMouseEvent): void {
+  const m = map.value;
+  const feature = event.features?.[0];
+  if (!m || !feature) return;
+
+  // Anchor the popup (and the OSM edit link) on the marker's own coordinates, not the click point.
+  const [lng, lat] =
+    feature.geometry.type === "Point"
+      ? (feature.geometry.coordinates as [number, number])
+      : [event.lngLat.lng, event.lngLat.lat];
+
+  poiPopup.value?.remove();
+  poiPopup.value = new Popup({ closeButton: true, closeOnClick: true })
+    .setLngLat([lng, lat])
+    .setDOMContent(buildPopupContent(feature, lng, lat))
+    .addTo(m);
+}
+
+function initMap(): MapLibreMap {
+  // Created here (not at setup) because its constructor touches `document`, which is absent on the server.
+  const floorControl = new FloorControl();
+  const m = new MapLibreMap({
+    container: "map-browse",
+    // Reflect the viewport in the URL hash so the map state is deep-linkable.
+    hash: true,
+    canvasContextAttributes: { antialias: true, preserveDrawingBuffer: false },
+    style: "https://nav.tum.de/martin/style/navigatum-basemap.json",
+    center: GARCHING_CENTER,
+    zoom: INITIAL_ZOOM,
+    validateStyle: import.meta.env.DEV,
+  });
+
+  m.on("zoom", () => {
+    currentZoom.value = m.getZoom();
+  });
+
+  m.on("load", () => {
+    initialLoaded.value = true;
+    // The hash may have set a zoom before `load`, before any `zoom` event fired, so seed it here.
+    currentZoom.value = m.getZoom();
+    m.addControl(new NavigationControl({ showCompass: false }), "top-right");
+    m.addControl(
+      new GeolocateControl({
+        positionOptions: { enableHighAccuracy: true },
+        trackUserLocation: true,
+      }),
+      "top-right"
+    );
+    m.addControl(new FullscreenControl(), "top-right");
+    m.addControl(floorControl, "top-right");
+    // Browse the ground floor by default, matching the tile source's default level.
+    floorControl.setLevel(resolveLevel(queryString(LEVEL_QUERY_PARAM)));
+
+    applyLayerVisibility();
+
+    for (const styleLayerId of allStyleLayerIds) {
+      m.on("click", styleLayerId, openPoiPopup);
+      m.on("mouseenter", styleLayerId, () => {
+        m.getCanvas().style.cursor = "pointer";
+      });
+      m.on("mouseleave", styleLayerId, () => {
+        m.getCanvas().style.cursor = "";
+      });
+    }
+  });
+
+  floorControl.on("level-changed", (event: { level: number | null }) => {
+    setQueryParam(LEVEL_QUERY_PARAM, event.level === null ? null : String(event.level));
+  });
+
+  return m;
+}
+
+onMounted(() => {
+  if (!webglSupport) return;
+  enabledLayers.value = resolveEnabledLayers({
+    urlParam: queryString(LAYERS_QUERY_PARAM),
+    stored: localStorage.getItem(ENABLED_LAYERS_STORAGE_KEY),
+  });
+  panelCollapsed.value = localStorage.getItem(PANEL_COLLAPSED_STORAGE_KEY) === "1";
+  map.value = initMap();
+});
+
+onBeforeUnmount(() => {
+  poiPopup.value?.remove();
+  map.value?.remove();
+});
+</script>
+
+<template>
+  <div class="relative h-[calc(100vh-60px)] w-full">
+    <ClientOnly>
+      <template v-if="webglSupport">
+        <div v-if="!initialLoaded" class="absolute inset-0 z-10 flex items-center justify-center">
+          <Spinner class="h-12 w-12 text-blue-500 dark:text-blue-400" />
+        </div>
+        <div id="map-browse" class="h-full w-full" />
+        <MapLayerPanel
+          :layers="LAYER_REGISTRY"
+          :enabled="enabledLayers"
+          :collapsed="panelCollapsed"
+          :zoom="currentZoom"
+          @toggle="toggleLayer"
+          @update:collapsed="(v) => (panelCollapsed = v)"
+        />
+      </template>
+      <MapGLNotSupported v-else />
+    </ClientOnly>
+  </div>
+</template>
+
+<i18n lang="yaml">
+de:
+  title: Karte
+  description: Durchsuche die TUM-Karte und blende Ebenen wie Toiletten und Duschen ein.
+  edit_in_osm: In OpenStreetMap bearbeiten
+  wheelchair_accessible: Rollstuhlgerecht
+  poi:
+    toilet: Toilette
+    shower: Dusche
+  gender:
+    label: Geschlecht
+    male: Herren
+    female: Damen
+    unisex: Unisex
+en:
+  title: Map
+  description: Browse the TUM map and toggle layers such as toilets and showers.
+  edit_in_osm: Edit in OpenStreetMap
+  wheelchair_accessible: Wheelchair accessible
+  poi:
+    toilet: Toilet
+    shower: Shower
+  gender:
+    label: Gender
+    male: Male
+    female: Female
+    unisex: Unisex
+</i18n>
+
+<style lang="postcss">
+@import "maplibre-gl/dist/maplibre-gl.css";
+
+/* The popup keeps MapLibre's white background in both themes, so pin dark text and a blue link
+   with raw CSS rather than nightwind-inverted utility classes on the elements. */
+.maplibregl-popup-content {
+  background: var(--color-white);
+  color: var(--color-zinc-800);
+}
+
+.maplibregl-popup-content a {
+  color: var(--color-blue-600);
+}
+
+.maplibregl-popup-content a:hover {
+  text-decoration: underline;
+}
+</style>

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -10,14 +10,14 @@ import {
 } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
 import {
-  ENABLED_LAYERS_STORAGE_KEY,
-  LAYER_REGISTRY,
-  LAYERS_QUERY_PARAM,
+  ACTIVE_FILTERS_STORAGE_KEY,
+  FILTER_QUERY_PARAM,
+  FILTER_REGISTRY,
   LEVEL_QUERY_PARAM,
   PANEL_COLLAPSED_STORAGE_KEY,
-  resolveEnabledLayers,
+  resolveActiveFilters,
   resolveLevel,
-  serializeEnabledLayers,
+  serializeFilters,
 } from "~/composables/mapLayers";
 import { webglSupport } from "~/composables/webglSupport";
 
@@ -33,6 +33,17 @@ useSeoMeta({
 
 const GARCHING_CENTER: [number, number] = [11.670099, 48.266921];
 const INITIAL_ZOOM = 17;
+// Opacity the non-matching map content fades to while a filter is active.
+const DIM = 0.2;
+// The combined POI layer that carries the toilet/shower icons (and other POIs we dim per-feature).
+const POI_LAYER = "indoor-pois";
+// Other indoor content faded as a whole while a filter is active.
+const DIM_TARGETS: ReadonlyArray<{ id: string; prop: string }> = [
+  { id: "indoor-pois", prop: "text-opacity" },
+  { id: "indoor-rooms", prop: "fill-opacity" },
+  { id: "poi-indoor", prop: "icon-opacity" },
+  { id: "poi-indoor", prop: "text-opacity" },
+];
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
@@ -41,11 +52,11 @@ const mapContainer = ref<HTMLElement | undefined>(undefined);
 const initialLoaded = ref(false);
 const currentZoom = ref(INITIAL_ZOOM);
 // Reassigned wholesale so the panel's `Set` prop changes identity.
-const enabledLayers = ref<Set<string>>(new Set(LAYER_REGISTRY.map((l) => l.id)));
+const activeFilters = ref<Set<string>>(new Set());
 const panelCollapsed = ref(false);
 
-// Style-layer ids whose markers open a popup.
-const allStyleLayerIds = LAYER_REGISTRY.flatMap((l) => l.styleLayerIds);
+// Original paint values captured before the first dim, so toggling a filter off restores them.
+const originalPaint = new Map<string, unknown>();
 
 /** Read a query value as a single string, distinguishing "absent" (null) from "present but empty" (""). */
 function queryString(key: string): string | null {
@@ -63,30 +74,57 @@ function setQueryParam(key: string, value: string | null): void {
   window.history.replaceState(window.history.state, "", url.toString());
 }
 
-function applyLayerVisibility(): void {
+/** The `indoor` values the active filters keep vibrant. */
+function vibrantIndoorValues(): string[] {
+  return FILTER_REGISTRY.filter((f) => activeFilters.value.has(f.id)).flatMap((f) => [
+    ...f.indoorValues,
+  ]);
+}
+
+function rememberPaint(m: MapLibreMap, id: string, prop: string): void {
+  const key = `${id}::${prop}`;
+  if (!originalPaint.has(key)) originalPaint.set(key, m.getPaintProperty(id, prop) ?? 1);
+}
+
+/** Highlight the active filters by dimming everything else; restore the original paint when none. */
+function applyFilterDim(): void {
   const m = map.value;
   if (!m) return;
-  for (const layer of LAYER_REGISTRY) {
-    const visibility = enabledLayers.value.has(layer.id) ? "visible" : "none";
-    for (const styleLayerId of layer.styleLayerIds) {
-      if (m.getLayer(styleLayerId)) m.setLayoutProperty(styleLayerId, "visibility", visibility);
-    }
+  const vibrant = vibrantIndoorValues();
+  const active = vibrant.length > 0;
+
+  // Fade the non-matching POI icons in place (a data-driven opacity keeps the matches vibrant).
+  if (m.getLayer(POI_LAYER)?.type === "symbol") {
+    rememberPaint(m, POI_LAYER, "icon-opacity");
+    m.setPaintProperty(
+      POI_LAYER,
+      "icon-opacity",
+      active
+        ? ["case", ["in", ["get", "indoor"], ["literal", vibrant]], 1, DIM]
+        : originalPaint.get(`${POI_LAYER}::icon-opacity`)
+    );
+  }
+
+  for (const { id, prop } of DIM_TARGETS) {
+    if (!m.getLayer(id)) continue;
+    rememberPaint(m, id, prop);
+    m.setPaintProperty(id, prop, active ? DIM : originalPaint.get(`${id}::${prop}`));
   }
 }
 
-function toggleLayer(id: string): void {
-  const next = new Set(enabledLayers.value);
+function toggleFilter(id: string): void {
+  const next = new Set(activeFilters.value);
   if (next.has(id)) next.delete(id);
   else next.add(id);
-  enabledLayers.value = next;
+  activeFilters.value = next;
 }
 
-watch(enabledLayers, (layers) => {
-  const serialized = serializeEnabledLayers(layers);
-  localStorage.setItem(ENABLED_LAYERS_STORAGE_KEY, serialized);
-  // Reflect the exact selection (empty too) so an all-off deep link survives a reload.
-  setQueryParam(LAYERS_QUERY_PARAM, serialized);
-  applyLayerVisibility();
+watch(activeFilters, (filters) => {
+  const serialized = serializeFilters(filters);
+  localStorage.setItem(ACTIVE_FILTERS_STORAGE_KEY, serialized);
+  // Drop the param when nothing is active (the default), so a bare /map URL stays clean.
+  setQueryParam(FILTER_QUERY_PARAM, serialized || null);
+  applyFilterDim();
 });
 
 watch(panelCollapsed, (collapsed) => {
@@ -140,6 +178,9 @@ function openPoiPopup(event: MapLayerMouseEvent): void {
   const m = map.value;
   const feature = event.features?.[0];
   if (!m || !feature) return;
+  // Only toilets and showers carry a popup; other POIs in the shared layer are not interactive.
+  const indoor = feature.properties?.indoor;
+  if (indoor !== "toilet" && indoor !== "shower") return;
 
   // Anchor on the marker's coordinates, not the click point.
   const [lng, lat] =
@@ -187,9 +228,8 @@ function initMap(): MapLibreMap {
     m.addControl(new FullscreenControl(), "top-right");
     m.addControl(floorControl, "top-right");
 
-    // Drop the legacy raster floor-plan overlays; the browse view shows only the vector indoor
-    // data. FloorControl's getLayer guards then skip them while still swapping the vector source
-    // per floor.
+    // Drop the legacy raster floor-plan overlays; they sit above the POIs and would hide them.
+    // FloorControl's getLayer guards then skip them while still swapping the vector source per floor.
     for (const layer of m.getStyle().layers) {
       if (!layer.id.startsWith("indoor-raster-floor-")) continue;
       const source = "source" in layer ? layer.source : undefined;
@@ -200,17 +240,15 @@ function initMap(): MapLibreMap {
     // Ground floor by default.
     floorControl.setLevel(resolveLevel(queryString(LEVEL_QUERY_PARAM)));
 
-    applyLayerVisibility();
+    applyFilterDim();
 
-    for (const styleLayerId of allStyleLayerIds) {
-      m.on("click", styleLayerId, openPoiPopup);
-      m.on("mouseenter", styleLayerId, () => {
-        m.getCanvas().style.cursor = "pointer";
-      });
-      m.on("mouseleave", styleLayerId, () => {
-        m.getCanvas().style.cursor = "";
-      });
-    }
+    m.on("click", POI_LAYER, openPoiPopup);
+    m.on("mouseenter", POI_LAYER, () => {
+      m.getCanvas().style.cursor = "pointer";
+    });
+    m.on("mouseleave", POI_LAYER, () => {
+      m.getCanvas().style.cursor = "";
+    });
   });
 
   floorControl.on("level-changed", (event: { level: number | null }) => {
@@ -222,9 +260,9 @@ function initMap(): MapLibreMap {
 
 onMounted(async () => {
   if (!webglSupport) return;
-  enabledLayers.value = resolveEnabledLayers({
-    urlParam: queryString(LAYERS_QUERY_PARAM),
-    stored: localStorage.getItem(ENABLED_LAYERS_STORAGE_KEY),
+  activeFilters.value = resolveActiveFilters({
+    urlParam: queryString(FILTER_QUERY_PARAM),
+    stored: localStorage.getItem(ACTIVE_FILTERS_STORAGE_KEY),
   });
   panelCollapsed.value = localStorage.getItem(PANEL_COLLAPSED_STORAGE_KEY) === "1";
   // <ClientOnly> mounts its slot after this hook fires, so wait for the container to exist.
@@ -247,11 +285,11 @@ onBeforeUnmount(() => {
         </div>
         <div id="map-browse" ref="mapContainer" class="h-full w-full" />
         <MapLayerPanel
-          :layers="LAYER_REGISTRY"
-          :enabled="enabledLayers"
+          :filters="FILTER_REGISTRY"
+          :active="activeFilters"
           :collapsed="panelCollapsed"
           :zoom="currentZoom"
-          @toggle="toggleLayer"
+          @toggle="toggleFilter"
           @update:collapsed="(v) => (panelCollapsed = v)"
         />
       </template>
@@ -263,7 +301,7 @@ onBeforeUnmount(() => {
 <i18n lang="yaml">
 de:
   title: Karte
-  description: Durchsuche die TUM-Karte und blende Ebenen wie Toiletten und Duschen ein.
+  description: Durchsuche die TUM-Karte und filtere nach Orten wie Toiletten und Duschen.
   edit_in_osm: In OpenStreetMap bearbeiten
   wheelchair_accessible: Rollstuhlgerecht
   poi:
@@ -276,7 +314,7 @@ de:
     unisex: Unisex
 en:
   title: Map
-  description: Browse the TUM map and toggle layers such as toilets and showers.
+  description: Browse the TUM map and filter for places such as toilets and showers.
   edit_in_osm: Edit in OpenStreetMap
   wheelchair_accessible: Wheelchair accessible
   poi:

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { until } from "@vueuse/core";
 import type { MapGeoJSONFeature, MapLayerMouseEvent } from "maplibre-gl";
 import {
   FullscreenControl,
@@ -30,20 +31,20 @@ useSeoMeta({
   description: () => t("description"),
 });
 
-// Garching is the densest indoor-mapped campus, so it best demonstrates the WC layer on first load.
 const GARCHING_CENTER: [number, number] = [11.670099, 48.266921];
 const INITIAL_ZOOM = 17;
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const poiPopup = shallowRef<Popup | undefined>(undefined);
+const mapContainer = ref<HTMLElement | undefined>(undefined);
 const initialLoaded = ref(false);
 const currentZoom = ref(INITIAL_ZOOM);
-// Reassigned (never mutated in place) so the panel's `Set` prop changes identity and re-renders.
+// Reassigned wholesale so the panel's `Set` prop changes identity.
 const enabledLayers = ref<Set<string>>(new Set(LAYER_REGISTRY.map((l) => l.id)));
 const panelCollapsed = ref(false);
 
-// Every style-layer id any overlay manages; also the layers whose markers open a popup.
+// Style-layer ids whose markers open a popup.
 const allStyleLayerIds = LAYER_REGISTRY.flatMap((l) => l.styleLayerIds);
 
 /** Read a query value as a single string, distinguishing "absent" (null) from "present but empty" (""). */
@@ -83,7 +84,7 @@ function toggleLayer(id: string): void {
 watch(enabledLayers, (layers) => {
   const serialized = serializeEnabledLayers(layers);
   localStorage.setItem(ENABLED_LAYERS_STORAGE_KEY, serialized);
-  // Always reflect the exact selection (empty included) so an "all off" deep link survives a reload.
+  // Reflect the exact selection (empty too) so an all-off deep link survives a reload.
   setQueryParam(LAYERS_QUERY_PARAM, serialized);
   applyLayerVisibility();
 });
@@ -101,8 +102,6 @@ function buildPopupContent(feature: MapGeoJSONFeature, lng: number, lat: number)
   const isShower = props.indoor === "shower";
 
   const root = document.createElement("div");
-  // Colours live in the `.maplibregl-popup-content` style rule below, not in nightwind-inverted
-  // utility classes, so the text stays dark on the popup's (always white) background in dark mode.
   root.className = "flex flex-col gap-1 text-sm";
 
   const title = document.createElement("p");
@@ -126,7 +125,7 @@ function buildPopupContent(feature: MapGeoJSONFeature, lng: number, lat: number)
     if (truthy(props.is_wheelchair_toilet)) addRow(t("wheelchair_accessible"));
   }
 
-  // Location-only deep link into the OSM editor (no element id is carried through the tiles).
+  // Location-only OSM edit link; no element id flows through the tiles.
   const edit = document.createElement("a");
   edit.href = `https://www.openstreetmap.org/edit#map=21/${lat.toFixed(7)}/${lng.toFixed(7)}`;
   edit.target = "_blank";
@@ -142,7 +141,7 @@ function openPoiPopup(event: MapLayerMouseEvent): void {
   const feature = event.features?.[0];
   if (!m || !feature) return;
 
-  // Anchor the popup (and the OSM edit link) on the marker's own coordinates, not the click point.
+  // Anchor on the marker's coordinates, not the click point.
   const [lng, lat] =
     feature.geometry.type === "Point"
       ? (feature.geometry.coordinates as [number, number])
@@ -156,10 +155,10 @@ function openPoiPopup(event: MapLayerMouseEvent): void {
 }
 
 function initMap(): MapLibreMap {
-  // Created here (not at setup) because its constructor touches `document`, which is absent on the server.
+  // Not at setup: its constructor touches `document`, absent on the server.
   const floorControl = new FloorControl();
   const m = new MapLibreMap({
-    container: "map-browse",
+    container: mapContainer.value as HTMLElement,
     // Reflect the viewport in the URL hash so the map state is deep-linkable.
     hash: true,
     canvasContextAttributes: { antialias: true, preserveDrawingBuffer: false },
@@ -175,7 +174,7 @@ function initMap(): MapLibreMap {
 
   m.on("load", () => {
     initialLoaded.value = true;
-    // The hash may have set a zoom before `load`, before any `zoom` event fired, so seed it here.
+    // Seed from the hash-set zoom; `load` can precede the first `zoom` event.
     currentZoom.value = m.getZoom();
     m.addControl(new NavigationControl({ showCompass: false }), "top-right");
     m.addControl(
@@ -187,7 +186,7 @@ function initMap(): MapLibreMap {
     );
     m.addControl(new FullscreenControl(), "top-right");
     m.addControl(floorControl, "top-right");
-    // Browse the ground floor by default, matching the tile source's default level.
+    // Ground floor by default.
     floorControl.setLevel(resolveLevel(queryString(LEVEL_QUERY_PARAM)));
 
     applyLayerVisibility();
@@ -210,13 +209,15 @@ function initMap(): MapLibreMap {
   return m;
 }
 
-onMounted(() => {
+onMounted(async () => {
   if (!webglSupport) return;
   enabledLayers.value = resolveEnabledLayers({
     urlParam: queryString(LAYERS_QUERY_PARAM),
     stored: localStorage.getItem(ENABLED_LAYERS_STORAGE_KEY),
   });
   panelCollapsed.value = localStorage.getItem(PANEL_COLLAPSED_STORAGE_KEY) === "1";
+  // <ClientOnly> mounts its slot after this hook fires, so wait for the container to exist.
+  await until(mapContainer).toBeTruthy();
   map.value = initMap();
 });
 
@@ -233,7 +234,7 @@ onBeforeUnmount(() => {
         <div v-if="!initialLoaded" class="absolute inset-0 z-10 flex items-center justify-center">
           <Spinner class="h-12 w-12 text-blue-500 dark:text-blue-400" />
         </div>
-        <div id="map-browse" class="h-full w-full" />
+        <div id="map-browse" ref="mapContainer" class="h-full w-full" />
         <MapLayerPanel
           :layers="LAYER_REGISTRY"
           :enabled="enabledLayers"
@@ -280,8 +281,7 @@ en:
 <style lang="postcss">
 @import "maplibre-gl/dist/maplibre-gl.css";
 
-/* The popup keeps MapLibre's white background in both themes, so pin dark text and a blue link
-   with raw CSS rather than nightwind-inverted utility classes on the elements. */
+/* Popup stays white in both themes; pin dark text + blue link so nightwind cannot invert them. */
 .maplibregl-popup-content {
   background: var(--color-white);
   color: var(--color-zinc-800);

--- a/webclient/test/mapLayers.test.ts
+++ b/webclient/test/mapLayers.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  LAYER_REGISTRY,
+  type LayerDef,
+  parseEnabledLayers,
+  parseLevel,
+  resolveEnabledLayers,
+  resolveLevel,
+  serializeEnabledLayers,
+} from "../app/composables/mapLayers";
+
+// A two-layer registry to exercise ordering, unknown-id rejection, and multi-select without
+// depending on the shipped registry only carrying WCs.
+const REGISTRY: readonly LayerDef[] = [
+  { id: "wcs", labelKey: "layers.wcs", icon: "M0", styleLayerIds: ["a", "b"], hintBelowZoom: 17 },
+  {
+    id: "elevators",
+    labelKey: "layers.elevators",
+    icon: "M1",
+    styleLayerIds: ["c"],
+    hintBelowZoom: 17,
+  },
+];
+
+describe("parseEnabledLayers", () => {
+  it("keeps known ids and drops unknown ones", () => {
+    expect(parseEnabledLayers("wcs,bogus,elevators", REGISTRY)).toEqual(
+      new Set(["wcs", "elevators"])
+    );
+  });
+
+  it("trims whitespace and de-duplicates", () => {
+    expect(parseEnabledLayers(" wcs , wcs ", REGISTRY)).toEqual(new Set(["wcs"]));
+  });
+
+  it("treats an empty, whitespace-only, or nullish value as no layers", () => {
+    for (const input of ["", "   ", null, undefined]) {
+      expect(parseEnabledLayers(input, REGISTRY)).toEqual(new Set());
+    }
+  });
+
+  it("recognises the shipped WCs layer by default", () => {
+    expect(parseEnabledLayers("wcs")).toEqual(new Set(["wcs"]));
+  });
+});
+
+describe("serializeEnabledLayers", () => {
+  it("emits ids in registry order regardless of input order", () => {
+    expect(serializeEnabledLayers(["elevators", "wcs"], REGISTRY)).toBe("wcs,elevators");
+  });
+
+  it("round-trips through parseEnabledLayers", () => {
+    const set = parseEnabledLayers("elevators,wcs", REGISTRY);
+    expect(parseEnabledLayers(serializeEnabledLayers(set, REGISTRY), REGISTRY)).toEqual(set);
+  });
+
+  it("serialises nothing for an empty selection", () => {
+    expect(serializeEnabledLayers([], REGISTRY)).toBe("");
+  });
+});
+
+describe("resolveEnabledLayers precedence (URL > localStorage > default)", () => {
+  it("uses the URL when present, ignoring localStorage", () => {
+    expect(
+      resolveEnabledLayers({ urlParam: "wcs", stored: "elevators", registry: REGISTRY })
+    ).toEqual(new Set(["wcs"]));
+  });
+
+  it("honours an explicit empty URL value as all-off, beating the default", () => {
+    expect(resolveEnabledLayers({ urlParam: "", stored: "wcs", registry: REGISTRY })).toEqual(
+      new Set()
+    );
+  });
+
+  it("falls back to localStorage when the URL is absent", () => {
+    expect(
+      resolveEnabledLayers({ urlParam: null, stored: "elevators", registry: REGISTRY })
+    ).toEqual(new Set(["elevators"]));
+  });
+
+  it("honours an explicit empty stored value as all-off", () => {
+    expect(resolveEnabledLayers({ urlParam: null, stored: "", registry: REGISTRY })).toEqual(
+      new Set()
+    );
+  });
+
+  it("defaults to every overlay on when neither URL nor localStorage is set", () => {
+    expect(resolveEnabledLayers({ urlParam: null, stored: null, registry: REGISTRY })).toEqual(
+      new Set(["wcs", "elevators"])
+    );
+  });
+
+  it("defaults to WCs on for the shipped registry", () => {
+    expect(resolveEnabledLayers({})).toEqual(new Set(LAYER_REGISTRY.map((l) => l.id)));
+  });
+});
+
+describe("parseLevel", () => {
+  it("parses known integer floors including negatives and ground", () => {
+    expect(parseLevel("0")).toBe(0);
+    expect(parseLevel("3")).toBe(3);
+    expect(parseLevel("-1")).toBe(-1);
+  });
+
+  it("tolerates a trailing .0 from the tile-source convention", () => {
+    expect(parseLevel("2.0")).toBe(2);
+  });
+
+  it("rejects out-of-range, fractional, non-numeric, and absent values", () => {
+    for (const input of ["7", "-2", "1.5", "abc", "", "  ", null, undefined]) {
+      expect(parseLevel(input)).toBeNull();
+    }
+  });
+});
+
+describe("resolveLevel", () => {
+  it("returns the parsed floor when valid", () => {
+    expect(resolveLevel("3")).toBe(3);
+    expect(resolveLevel("-1")).toBe(-1);
+  });
+
+  it("defaults to the ground floor when the value is unusable", () => {
+    for (const input of ["7", "abc", "", null, undefined]) {
+      expect(resolveLevel(input)).toBe(0);
+    }
+  });
+});

--- a/webclient/test/mapLayers.test.ts
+++ b/webclient/test/mapLayers.test.ts
@@ -1,97 +1,99 @@
 import { describe, expect, it } from "vitest";
 import {
-  LAYER_REGISTRY,
-  type LayerDef,
-  parseEnabledLayers,
+  FILTER_REGISTRY,
+  type FilterDef,
+  parseFilters,
   parseLevel,
-  resolveEnabledLayers,
+  resolveActiveFilters,
   resolveLevel,
-  serializeEnabledLayers,
+  serializeFilters,
 } from "../app/composables/mapLayers";
 
-// A two-layer registry to exercise ordering, unknown-id rejection, and multi-select without
+// A two-filter registry to exercise ordering, unknown-id rejection, and multi-select without
 // depending on the shipped registry only carrying WCs.
-const REGISTRY: readonly LayerDef[] = [
-  { id: "wcs", labelKey: "layers.wcs", icon: "M0", styleLayerIds: ["a", "b"], hintBelowZoom: 17 },
+const REGISTRY: readonly FilterDef[] = [
+  {
+    id: "wcs",
+    labelKey: "filters.wcs",
+    icon: "M0",
+    indoorValues: ["toilet", "shower"],
+    hintBelowZoom: 17,
+  },
   {
     id: "elevators",
-    labelKey: "layers.elevators",
+    labelKey: "filters.elevators",
     icon: "M1",
-    styleLayerIds: ["c"],
+    indoorValues: ["elevator"],
     hintBelowZoom: 17,
   },
 ];
 
-describe("parseEnabledLayers", () => {
+describe("parseFilters", () => {
   it("keeps known ids and drops unknown ones", () => {
-    expect(parseEnabledLayers("wcs,bogus,elevators", REGISTRY)).toEqual(
-      new Set(["wcs", "elevators"])
-    );
+    expect(parseFilters("wcs,bogus,elevators", REGISTRY)).toEqual(new Set(["wcs", "elevators"]));
   });
 
   it("trims whitespace and de-duplicates", () => {
-    expect(parseEnabledLayers(" wcs , wcs ", REGISTRY)).toEqual(new Set(["wcs"]));
+    expect(parseFilters(" wcs , wcs ", REGISTRY)).toEqual(new Set(["wcs"]));
   });
 
-  it("treats an empty, whitespace-only, or nullish value as no layers", () => {
+  it("treats an empty, whitespace-only, or nullish value as no filters", () => {
     for (const input of ["", "   ", null, undefined]) {
-      expect(parseEnabledLayers(input, REGISTRY)).toEqual(new Set());
+      expect(parseFilters(input, REGISTRY)).toEqual(new Set());
     }
   });
 
-  it("recognises the shipped WCs layer by default", () => {
-    expect(parseEnabledLayers("wcs")).toEqual(new Set(["wcs"]));
+  it("recognises the shipped WCs filter by default", () => {
+    expect(parseFilters("wcs")).toEqual(new Set(["wcs"]));
   });
 });
 
-describe("serializeEnabledLayers", () => {
+describe("serializeFilters", () => {
   it("emits ids in registry order regardless of input order", () => {
-    expect(serializeEnabledLayers(["elevators", "wcs"], REGISTRY)).toBe("wcs,elevators");
+    expect(serializeFilters(["elevators", "wcs"], REGISTRY)).toBe("wcs,elevators");
   });
 
-  it("round-trips through parseEnabledLayers", () => {
-    const set = parseEnabledLayers("elevators,wcs", REGISTRY);
-    expect(parseEnabledLayers(serializeEnabledLayers(set, REGISTRY), REGISTRY)).toEqual(set);
+  it("round-trips through parseFilters", () => {
+    const set = parseFilters("elevators,wcs", REGISTRY);
+    expect(parseFilters(serializeFilters(set, REGISTRY), REGISTRY)).toEqual(set);
   });
 
   it("serialises nothing for an empty selection", () => {
-    expect(serializeEnabledLayers([], REGISTRY)).toBe("");
+    expect(serializeFilters([], REGISTRY)).toBe("");
   });
 });
 
-describe("resolveEnabledLayers precedence (URL > localStorage > default)", () => {
+describe("resolveActiveFilters precedence (URL > localStorage > default)", () => {
   it("uses the URL when present, ignoring localStorage", () => {
     expect(
-      resolveEnabledLayers({ urlParam: "wcs", stored: "elevators", registry: REGISTRY })
+      resolveActiveFilters({ urlParam: "wcs", stored: "elevators", registry: REGISTRY })
     ).toEqual(new Set(["wcs"]));
   });
 
-  it("honours an explicit empty URL value as all-off, beating the default", () => {
-    expect(resolveEnabledLayers({ urlParam: "", stored: "wcs", registry: REGISTRY })).toEqual(
+  it("honours an explicit empty URL value as none active, beating localStorage", () => {
+    expect(resolveActiveFilters({ urlParam: "", stored: "wcs", registry: REGISTRY })).toEqual(
       new Set()
     );
   });
 
   it("falls back to localStorage when the URL is absent", () => {
     expect(
-      resolveEnabledLayers({ urlParam: null, stored: "elevators", registry: REGISTRY })
+      resolveActiveFilters({ urlParam: null, stored: "elevators", registry: REGISTRY })
     ).toEqual(new Set(["elevators"]));
   });
 
-  it("honours an explicit empty stored value as all-off", () => {
-    expect(resolveEnabledLayers({ urlParam: null, stored: "", registry: REGISTRY })).toEqual(
+  it("defaults to no filter active when neither URL nor localStorage is set", () => {
+    expect(resolveActiveFilters({ urlParam: null, stored: null, registry: REGISTRY })).toEqual(
       new Set()
     );
+    expect(resolveActiveFilters({})).toEqual(new Set());
   });
+});
 
-  it("defaults to every overlay on when neither URL nor localStorage is set", () => {
-    expect(resolveEnabledLayers({ urlParam: null, stored: null, registry: REGISTRY })).toEqual(
-      new Set(["wcs", "elevators"])
-    );
-  });
-
-  it("defaults to WCs on for the shipped registry", () => {
-    expect(resolveEnabledLayers({})).toEqual(new Set(LAYER_REGISTRY.map((l) => l.id)));
+describe("the shipped registry", () => {
+  it("highlights toilets and showers under the WCs filter", () => {
+    const wcs = FILTER_REGISTRY.find((f) => f.id === "wcs");
+    expect(wcs?.indoorValues).toEqual(["toilet", "shower"]);
   });
 });
 


### PR DESCRIPTION
Adds the `/map` browse page with a toggleable WCs (toilets + showers) layer — osm2pgsql node ingestion, split indoor style layers, and a typed layer registry. Closes #3156.