### PR TITLE
ci: reduce crates.io and Docker Hub network flakes

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -52,6 +52,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Pre-pull buildkit image with retry
+        # setup-buildx-action launches a docker-container builder that pulls
+        # moby/buildkit:buildx-stable-1 from Docker Hub once, without retry.
+        # When registry-1.docker.io rate-limits or times out, the whole build
+        # fails before we ever invoke cargo. Pre-pulling with retry isolates
+        # that transient failure mode from the actual build.
+        run: |
+          attempt=1
+          until docker pull moby/buildkit:buildx-stable-1; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::docker pull moby/buildkit failed after $attempt attempts"
+              exit 1
+            fi
+            echo "::warning::buildkit pull attempt $attempt failed, retrying in 15s"
+            sleep 15
+            attempt=$((attempt + 1))
+          done
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -180,12 +180,18 @@ jobs:
         run: cargo build
         env:
           CARGO_INCREMENTAL: 0
+          CARGO_NET_RETRY: 10
+          # See server/Dockerfile for context — HTTP/2 framing errors against
+          # crates.io are the dominant CI flake.
+          CARGO_HTTP_MULTIPLEXING: false
 
       - name: Run | Start server in background
         working-directory: server
         run: cargo run &
         env:
           CARGO_INCREMENTAL: 0
+          CARGO_NET_RETRY: 10
+          CARGO_HTTP_MULTIPLEXING: false
           SKIP_MS_SETUP: true
           SKIP_DB_SETUP: true
           POSTGRES_USER: postgres

--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -48,9 +48,15 @@ jobs:
       - run: cargo test --no-run --locked
         env:
           CARGO_INCREMENTAL: 0
+          CARGO_NET_RETRY: 10
+          # See server/Dockerfile — disabling HTTP/2 multiplexing avoids the
+          # framing-layer flake when cargo refreshes the registry.
+          CARGO_HTTP_MULTIPLEXING: false
       - run: cargo test -- --nocapture --quiet
         env:
           CARGO_INCREMENTAL: 0
+          CARGO_NET_RETRY: 10
+          CARGO_HTTP_MULTIPLEXING: false
   linting:
     runs-on: ubuntu-latest
     permissions:
@@ -67,6 +73,8 @@ jobs:
       - run: cargo clippy -- -D warnings
         env:
           CARGO_INCREMENTAL: 0
+          CARGO_NET_RETRY: 10
+          CARGO_HTTP_MULTIPLEXING: false
   build:
     uses: ./.github/workflows/_docker-build.yml
     with:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -57,6 +57,11 @@ ENV     CARGO_INCREMENTAL=0
 # eof while reading"), failing the whole image build. Cargo's default of 3
 # retries is not enough under that flakiness, so retry harder.
 ENV     CARGO_NET_RETRY=10
+# HTTP/2 multiplexing pools many crate downloads onto a single connection, so a
+# single libcurl framing error (CURLE_HTTP2 / "Send failure: Connection reset by
+# peer") tears down every in-flight transfer and CARGO_NET_RETRY can't recover.
+# Forcing HTTP/1.1 trades parallelism for one independent connection per crate.
+ENV     CARGO_HTTP_MULTIPLEXING=false
 # added in the build
 ARG     GIT_COMMIT_SHA=development
 ENV     GIT_COMMIT_SHA=${GIT_COMMIT_SHA}

--- a/webclient/app/components/LectureResultContent.vue
+++ b/webclient/app/components/LectureResultContent.vue
@@ -19,7 +19,11 @@ const title = computed(() => lectureTitle(props.item, localeKey.value));
 const meta = computed(() => {
   const event = firstUpcoming(props.item);
   if (!event) return null;
-  return { when: formatUpcoming(event, localeKey.value), room: event.room_name, startAt: event.start_at };
+  return {
+    when: formatUpcoming(event, localeKey.value),
+    room: event.room_name,
+    startAt: event.start_at,
+  };
 });
 </script>
 

--- a/webclient/app/composables/searchDropdownNav.ts
+++ b/webclient/app/composables/searchDropdownNav.ts
@@ -5,8 +5,8 @@ import {
   collapsedHighlightTarget,
   collapsedUpwardHighlightTarget,
   findLectureHeaderIndex,
-  type ResultsSectionFacet,
   type LectureNavController,
+  type ResultsSectionFacet,
   toggleLectureFromMouse,
   type VisibleSearchEntry,
 } from "~/utils/lectureRow";

--- a/webclient/app/utils/lectureRow.ts
+++ b/webclient/app/utils/lectureRow.ts
@@ -122,7 +122,11 @@ export function useLectureRowExpansion(initial = false): LectureRowExpansion {
 export const LECTURE_EVENT_NAV_CAP = 3;
 
 export type VisibleSearchEntry =
-  | { readonly kind: "result"; readonly sectionFacet: ResultsSectionFacet; readonly entry: SearchResultEntry }
+  | {
+      readonly kind: "result";
+      readonly sectionFacet: ResultsSectionFacet;
+      readonly entry: SearchResultEntry;
+    }
   | {
       readonly kind: "event";
       readonly lectureId: string;


### PR DESCRIPTION
## Summary

Recent PRs show two distinct CI flake patterns that turn otherwise-green branches red:

1. **crates.io HTTP/2 framing errors** during `cargo build` — seen on #3220 (autofix update-openapi) and #3217 (e2e server docker build). Cargo's HTTP/2 multiplexing pools many crate downloads onto one connection; one libcurl framing error tears them all down and `CARGO_NET_RETRY` can't recover. `CARGO_HTTP_MULTIPLEXING=false` forces HTTP/1.1 with one connection per crate so the existing retries actually do their job.
2. **Docker Hub timeouts pulling `moby/buildkit:buildx-stable-1`** — seen on #3220 webclient build. `docker/setup-buildx-action` pulls the buildkit image once with no retry. Pre-pulling it with the same retry loop already used for `docker compose pull` isolates that flake from the build.

Both are paid for in seconds, not minutes.

## Coverage

- `server/Dockerfile` — already had `CARGO_NET_RETRY=10` with a comment alluding to this exact failure mode. Now also disables HTTP/2 multiplexing.
- `.github/workflows/autofix.yml` — `update-openapi` job (the bare-runner `cargo build`).
- `.github/workflows/server-cicd.yml` — `tests` and `linting` jobs.
- `.github/workflows/_docker-build.yml` — adds the buildkit pre-pull retry.

## Test plan

- [ ] After merge, watch the next ~10 PR CI runs to confirm the crates.io HTTP/2 error disappears.
- [ ] Confirm webclient & server image builds still succeed (cache mounts still work).
- [ ] Watch for a buildkit-pull retry message in any CI run to confirm the new step kicks in when Docker Hub flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)