### PR TITLE
chore(webclient): upgrade maplibre-gl to v6.0.0-14 beta

### DIFF
--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -12,7 +12,7 @@ import {
 import type { components } from "~/api_types";
 import { FloorControl } from "~/composables/FloorControl";
 import { useIsMobile } from "~/composables/useIsMobile";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 import { zoomForLocationType } from "~/utils/map";
 
 const props = defineProps<{
@@ -28,6 +28,7 @@ const marker = shallowRef<Marker | undefined>(undefined);
 const floorControl = shallowRef<FloorControl>(new FloorControl());
 const mapContainer = ref<HTMLElement>();
 const isMobile = useIsMobile();
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 const zoom = computed<number>(() => zoomForLocationType(props.type));
 
 const { t } = useI18n({ useScope: "local" });
@@ -43,7 +44,7 @@ const initialLoaded = ref(false);
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 
 function loadInteractiveMap() {
-  if (!webglSupport) return;
+  if (!webglSupport.value) return;
 
   const doMapUpdate = () => {
     // The map might or might not be initialized depending on the type
@@ -115,6 +116,7 @@ function initMap(containerId: string): MapLibreMap {
     validateStyle: import.meta.env.DEV,
     maplibreLogo: true,
   });
+  attachWebglGuard(map);
 
   // Each source / style change causes the map to get
   // into "loading" state, so map.loaded() is not reliable

--- a/webclient/app/components/EventPreviewMap.vue
+++ b/webclient/app/components/EventPreviewMap.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Map as MapLibreMap, Marker } from "maplibre-gl";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 
 export interface EventPreviewPopup {
   readonly name: string;
@@ -30,6 +30,7 @@ const marker = shallowRef<Marker | undefined>(undefined);
 const markerImg = shallowRef<HTMLImageElement | undefined>(undefined);
 const loaded = ref(false);
 const markerPos = shallowRef<{ x: number; y: number } | null>(null);
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 function createMarkerElement(): HTMLElement {
   const el = document.createElement("div");
@@ -86,7 +87,7 @@ function applyPadding(): void {
 }
 
 onMounted(() => {
-  if (!webglSupport || !mapContainer.value) return;
+  if (!webglSupport.value || !mapContainer.value) return;
   const instance = new MapLibreMap({
     container: mapContainer.value,
     style: "https://nav.tum.de/martin/style/navigatum-basemap.json",
@@ -95,6 +96,7 @@ onMounted(() => {
     attributionControl: false,
     validateStyle: import.meta.env.DEV,
   });
+  attachWebglGuard(instance);
   map.value = instance;
   instance.on("load", () => {
     loaded.value = true;

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -11,7 +11,7 @@ import {
 import type { components } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
 import { useIsMobile } from "~/composables/useIsMobile";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 import { zoomForLocationType } from "~/utils/map";
 import {
   calculateItineraryBounds,
@@ -45,6 +45,7 @@ const marker = shallowRef<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
 const fullscreenContainerEl = ref<HTMLElement | null>(null);
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 // Maplibre bug: the map doesn't update to the new size when changing between
 // fullscreen in the mobile version.
 useResizeObserver(fullscreenContainerEl, () => {
@@ -60,7 +61,7 @@ const highlightedLegIndex = ref<number | null>(null);
 const zoom = computed<number>(() => zoomForLocationType(props.type));
 
 onMounted(async () => {
-  if (!webglSupport) return;
+  if (!webglSupport.value) return;
 
   const doMapUpdate = async () => {
     // The map might or might not be initialized depending on the type
@@ -124,6 +125,7 @@ function initMap(containerId: string): MapLibreMap {
     center: [11.670099, 48.266921],
     zoom: zoom.value,
   });
+  attachWebglGuard(map);
 
   // Each source / style change causes the map to get
   // into "loading" state, so map.loaded() is not reliable

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -9,7 +9,7 @@ import {
   NavigationControl,
 } from "maplibre-gl";
 import { useIsMobile } from "~/composables/useIsMobile";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 
 interface Props {
   initialLat: number;
@@ -33,6 +33,7 @@ const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const mapContainer = ref<HTMLElement>();
 const isMobile = useIsMobile();
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 function createMarker(hueRotation = 120) {
   const markerDiv = document.createElement("div");
@@ -49,7 +50,7 @@ function createMarker(hueRotation = 120) {
 }
 
 function initMap() {
-  if (!webglSupport || !mapContainer.value) return;
+  if (!webglSupport.value || !mapContainer.value) return;
   const mapInstance = new MapLibreMap({
     container: mapContainer.value,
     hash: false,
@@ -58,6 +59,7 @@ function initMap() {
     center: [props.initialLon, props.initialLat],
     zoom: props.zoom,
   });
+  attachWebglGuard(mapInstance);
 
   mapInstance.on("load", () => {
     mapInstance.addControl(new NavigationControl({}), "top-left");

--- a/webclient/app/components/LocationPickerModal.vue
+++ b/webclient/app/components/LocationPickerModal.vue
@@ -9,7 +9,7 @@ import {
 } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
 import { useIsMobile } from "~/composables/useIsMobile";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 
 interface LocationPickerProps {
   initialLat: number;
@@ -36,6 +36,7 @@ const floorControl = ref<FloorControl>(new FloorControl());
 const mapContainer = ref<HTMLElement>();
 const isMapLoaded = ref(false);
 const isMobile = useIsMobile();
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 const coordinates = ref({
   lat: props.initialLat,
@@ -57,7 +58,7 @@ function createMarker(hueRotation = 120) {
 }
 
 function initMap() {
-  if (!webglSupport || !mapContainer.value) return;
+  if (!webglSupport.value || !mapContainer.value) return;
 
   const mapInstance = new MapLibreMap({
     container: mapContainer.value,
@@ -70,6 +71,7 @@ function initMap() {
     center: [coordinates.value.lon, coordinates.value.lat],
     zoom: props.zoom,
   });
+  attachWebglGuard(mapInstance);
 
   mapInstance.on("load", () => {
     isMapLoaded.value = true;

--- a/webclient/app/components/MapGLNotSupported.vue
+++ b/webclient/app/components/MapGLNotSupported.vue
@@ -24,12 +24,12 @@ const { t } = useI18n({ useScope: "local" });
 <i18n lang="yaml">
 de:
   no_webgl:
-    detailed_message: Es tut uns leid, aber es scheint, dass Ihr Browser WebGL nicht unterstützt, eine Technologie zum Rendern von 3D-Grafiken im Web.
-    webgl_required: WebGL ist erforderlich, um diese Karte anzuzeigen.
+    detailed_message: Es tut uns leid, aber es scheint, dass Ihr Browser WebGL 2 nicht unterstützt, eine Technologie zum Rendern von 3D-Grafiken im Web.
+    webgl_required: WebGL 2 ist erforderlich, um diese Karte anzuzeigen.
     read_more: Mehr erfahren
 en:
   no_webgl:
-    detailed_message: We are sorry, but it seems that your browser does not support WebGL, a technology for rendering 3D graphics on the web.
-    webgl_required: WebGL is required to display this map.
+    detailed_message: We are sorry, but it seems that your browser does not support WebGL 2, a technology for rendering 3D graphics on the web.
+    webgl_required: WebGL 2 is required to display this map.
     read_more: Read more
 </i18n>

--- a/webclient/app/composables/webglSupport.ts
+++ b/webclient/app/composables/webglSupport.ts
@@ -1,15 +1,28 @@
-function supportsWebgl(): boolean {
-  if (import.meta.server) return false;
-  try {
-    const canvas = document.createElement("canvas");
-    return (
-      Boolean(window.WebGLRenderingContext) &&
-      Boolean(canvas.getContext("webgl") || canvas.getContext("experimental-webgl"))
-    );
-  } catch (e) {
-    console.error("cannot construct webglcontext (needed to render the map) because", e);
-    return false;
-  }
+// MapLibre GL v6 surfaces unavailable GPU contexts (no WebGL2 etc.) through the map's `error`
+// event as a `GPUInitializationError`, instead of letting consumers probe support up-front. We
+// keep an optimistic ref, attach to a constructed map, and flip the ref on the first such error
+// so the calling component can render the not-supported fallback.
+import { GPUInitializationError, type Map as MapLibreMap } from "maplibre-gl";
+
+export interface WebglGuard {
+  /** Optimistic; flips to false once a `GPUInitializationError` is observed on the map. */
+  readonly supported: Readonly<Ref<boolean>>;
+  /** Wire up the guard against a freshly-constructed map. Safe to call once per map. */
+  attach(map: MapLibreMap): void;
 }
 
-export const webglSupport: boolean = supportsWebgl();
+export function useWebglGuard(): WebglGuard {
+  const supported = ref(true);
+  return {
+    supported,
+    attach(map) {
+      const onError = (event: { error: unknown }): void => {
+        if (event.error instanceof GPUInitializationError) {
+          supported.value = false;
+          map.off("error", onError);
+        }
+      };
+      map.on("error", onError);
+    },
+  };
+}

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { until } from "@vueuse/core";
-import type { MapGeoJSONFeature, MapLayerMouseEvent } from "maplibre-gl";
+import type { AllPaintProperties, MapGeoJSONFeature, MapLayerMouseEvent } from "maplibre-gl";
 import {
   FullscreenControl,
   GeolocateControl,
@@ -19,7 +19,7 @@ import {
   resolveLevel,
   serializeFilters,
 } from "~/composables/mapLayers";
-import { webglSupport } from "~/composables/webglSupport";
+import { useWebglGuard } from "~/composables/webglSupport";
 
 definePageMeta({ layout: "navigation" });
 
@@ -40,19 +40,28 @@ const BASEMAP_SCRIM = "rgba(255, 255, 255, 0.45)";
 const SCRIM_LAYER = "filter-basemap-dim";
 // The combined POI layer whose markers open a popup.
 const POI_LAYER = "indoor-pois";
+// MapLibre v6 tightened {set,get}PaintProperty signatures: the property name must be a literal
+// key of AllPaintProperties, and the value matches that key's spec. The three opacity props
+// below all resolve to DataDrivenPropertyValueSpecification<number>.
+type OpacityProp = "icon-opacity" | "fill-opacity" | "text-opacity";
+type OpacityValue = AllPaintProperties[OpacityProp];
+
 // Indoor layers carrying an `indoor` field: keep the filter's values vibrant, dim the rest
 // per-feature (so e.g. the toilet room fill stays its bathroom colour while other rooms fade).
 const PER_FEATURE_TARGETS = [
   { id: "indoor-pois", prop: "icon-opacity", type: "symbol" },
   { id: "indoor-rooms", prop: "fill-opacity", type: "fill" },
-] as const;
+] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
 // Indoor content with no per-feature meaning: dim wholesale while a filter is active.
-const FLAT_TARGETS = [{ id: "indoor-pois", prop: "text-opacity", type: "symbol" }] as const;
+const FLAT_TARGETS = [
+  { id: "indoor-pois", prop: "text-opacity", type: "symbol" },
+] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const poiPopup = shallowRef<Popup | undefined>(undefined);
 const mapContainer = ref<HTMLElement | undefined>(undefined);
+const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 const initialLoaded = ref(false);
 const currentZoom = ref(INITIAL_ZOOM);
 // Reassigned wholesale so the panel's `Set` prop changes identity.
@@ -60,7 +69,7 @@ const activeFilters = ref<Set<string>>(new Set());
 const panelCollapsed = ref(false);
 
 // Original paint values captured before the first dim, so toggling a filter off restores them.
-const originalPaint = new Map<string, unknown>();
+const originalPaint = new Map<string, OpacityValue | undefined>();
 
 /** Read a query value as a single string, distinguishing "absent" (null) from "present but empty" (""). */
 function queryString(key: string): string | null {
@@ -85,7 +94,7 @@ function vibrantIndoorValues(): string[] {
   ]);
 }
 
-function rememberPaint(m: MapLibreMap, id: string, prop: string): void {
+function rememberPaint(m: MapLibreMap, id: string, prop: OpacityProp): void {
   const key = `${id}::${prop}`;
   if (!originalPaint.has(key)) originalPaint.set(key, m.getPaintProperty(id, prop) ?? 1);
 }
@@ -118,11 +127,15 @@ function applyFilterDim(): void {
     if (m.getLayer(id)?.type !== type) continue;
     rememberPaint(m, id, prop);
     const original = originalPaint.get(`${id}::${prop}`);
+    // The case-expression branch must be a concrete expression/literal — v6 rejects the legacy
+    // `{ stops: ... }` form here. Our basemap publishes these as plain numbers, so fall back to 1
+    // when the original is anything else.
+    const vibrantValue = typeof original === "number" ? original : 1;
     m.setPaintProperty(
       id,
       prop,
       active
-        ? ["case", ["in", ["get", "indoor"], ["literal", vibrant]], original ?? 1, DIM]
+        ? ["case", ["in", ["get", "indoor"], ["literal", vibrant]], vibrantValue, DIM]
         : original
     );
   }
@@ -229,6 +242,7 @@ function initMap(): MapLibreMap {
     zoom: INITIAL_ZOOM,
     validateStyle: import.meta.env.DEV,
   });
+  attachWebglGuard(m);
 
   m.on("zoom", () => {
     currentZoom.value = m.getZoom();
@@ -280,7 +294,7 @@ function initMap(): MapLibreMap {
 }
 
 onMounted(async () => {
-  if (!webglSupport) return;
+  if (!webglSupport.value) return;
   activeFilters.value = resolveActiveFilters({
     urlParam: queryString(FILTER_QUERY_PARAM),
     stored: localStorage.getItem(ACTIVE_FILTERS_STORAGE_KEY),

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -127,7 +127,7 @@ function applyFilterDim(): void {
     if (m.getLayer(id)?.type !== type) continue;
     rememberPaint(m, id, prop);
     const original = originalPaint.get(`${id}::${prop}`);
-    // The case-expression branch must be a concrete expression/literal — v6 rejects the legacy
+    // The case-expression branch must be a concrete expression/literal - v6 rejects the legacy
     // `{ stops: ... }` form here. Our basemap publishes these as plain numbers, so fall back to 1
     // when the original is anything else.
     const vibrantValue = typeof original === "number" ? original : 1;

--- a/webclient/package.json
+++ b/webclient/package.json
@@ -29,7 +29,7 @@
 		"@vueuse/nuxt": "14.3.0",
 		"@vueuse/router": "14.3.0",
 		"better-sqlite3": "12.10.0",
-		"maplibre-gl": "5.24.0",
+		"maplibre-gl": "6.0.0-14",
 		"nuxt": "4.4.8",
 		"opening_hours": "^3.13.0",
 		"prom-client": "^15.1.3",

--- a/webclient/pnpm-lock.yaml
+++ b/webclient/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: 12.10.0
         version: 12.10.0
       maplibre-gl:
-        specifier: 5.24.0
-        version: 5.24.0
+        specifier: 6.0.0-14
+        version: 6.0.0-14
       nuxt:
         specifier: 4.4.8
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@biomejs/biome@2.4.16)(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.16(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
@@ -1059,11 +1059,11 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.5':
-    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
   '@mapbox/whoots-js@3.1.0':
     resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
@@ -1072,8 +1072,8 @@ packages:
   '@maplibre/geojson-vt@6.1.0':
     resolution: {integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.9.0':
-    resolution: {integrity: sha512-7pvjgwioEtnCXRgfPgoJGlFg1jY0rBXNoPmMR8uAcqd6m6d3LjKMSc1gzaQiRMvDMh6wje6z7FEejTE6JuFtiA==}
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
     hasBin: true
 
   '@maplibre/mlt@1.1.11':
@@ -4186,8 +4186,8 @@ packages:
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
-  maplibre-gl@5.24.0:
-    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+  maplibre-gl@6.0.0-14:
+    resolution: {integrity: sha512-QcFYp1rMA7dMBoIoNbj0ngOAWZsbf6j53hLSyL4CRcef89Qpo4tANszEirQ1CGwGuxGZM/+hqOIHuqI5ZzVHHQ==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   markdown-table@3.0.4:
@@ -4670,10 +4670,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pbf@4.0.2:
-    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
-    hasBin: true
 
   pbf@5.1.0:
     resolution: {integrity: sha512-Wv0yo0+uZepnoNEKsquhar1F18LogB8oeEikIhUXG16udbiXG7JecHGySwoo6kuMgjmbQYzdrTZlO+/K9t8eZg==}
@@ -6774,13 +6770,13 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
+  '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.5':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.2
+      pbf: 5.1.0
 
   '@mapbox/whoots-js@3.1.0': {}
 
@@ -6788,10 +6784,10 @@ snapshots:
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@24.9.0':
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
-      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/unitbezier': 1.0.0
       json-stringify-pretty-compact: 4.0.0
       minimist: 1.2.8
       quickselect: 3.0.0
@@ -10011,16 +10007,15 @@ snapshots:
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
-  maplibre-gl@5.24.0:
+  maplibre-gl@6.0.0-14:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
       '@mapbox/whoots-js': 3.1.0
       '@maplibre/geojson-vt': 6.1.0
-      '@maplibre/maplibre-gl-style-spec': 24.9.0
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
       '@maplibre/mlt': 1.1.11
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -10028,7 +10023,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.2
+      pbf: 5.1.0
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0
@@ -10990,10 +10985,6 @@ snapshots:
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
-
-  pbf@4.0.2:
-    dependencies:
-      resolve-protobuf-schema: 2.1.0
 
   pbf@5.1.0:
     dependencies:


### PR DESCRIPTION
Adapts the webclient to maplibre-gl v6 (ESM-only, WebGL2-mandatory, stricter paint-property typings) by swapping the synchronous WebGL1 probe for a `useWebglGuard()` composable that flips on the map's `GPUInitializationError`, narrowing the indoor-dim paint types in `/map`, and updating the not-supported copy to name WebGL 2 explicitly.