### PR TITLE
fix(webclient): pin the maplibre-gl v6 worker URL via setWorkerUrl

### DIFF
--- a/webclient/app/plugins/maplibre.client.ts
+++ b/webclient/app/plugins/maplibre.client.ts
@@ -1,0 +1,11 @@
+// MapLibre GL v6 loads its worker via `new URL('./maplibre-gl-worker.mjs', import.meta.url)`.
+// Bundlers (Vite/Rollup) do not statically pick this pattern up, so the worker file is never
+// emitted as an asset and the fetch 404s at runtime - the map renders the attribution but no
+// tiles. Pin the worker URL through Vite's `?url` import so the bundler emits the asset and
+// returns its public URL.
+import { setWorkerUrl } from "maplibre-gl";
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?url";
+
+export default defineNuxtPlugin(() => {
+  setWorkerUrl(maplibreWorkerUrl);
+});


### PR DESCRIPTION
MapLibre v6 needs a one-time `setWorkerUrl()` call under bundlers - per the [v5→v6 migration guide](https://github.com/maplibre/maplibre-gl-js/blob/main/docs/guides/v5-to-v6-migration-guide.md#setworkerurl-is-bundler-only) and the [Vite snippet in Installation](https://github.com/maplibre/maplibre-gl-js/blob/main/docs/index.md) - otherwise the worker .mjs file is never emitted and `/map` renders the attribution but no tiles.