### PR TITLE
test(webclient): regression test for the maplibre-gl v6 worker URL

### DIFF
--- a/tests/specs/map.ui.spec.ts
+++ b/tests/specs/map.ui.spec.ts
@@ -41,6 +41,21 @@ async function stubBasemap(page: Page, style: object): Promise<void> {
 }
 
 test.describe("Browse map (/map)", () => {
+  // MapLibre GL v6 loads `maplibre-gl-worker.mjs` via `new URL('./...', import.meta.url)`,
+  // a pattern Vite/Rollup cannot statically detect; without an explicit `setWorkerUrl()` the
+  // asset is never emitted and the worker fetch 404s, leaving the map without tiles.
+  test("loads its WebWorker without a 404", async ({ page }) => {
+    const failures: string[] = [];
+    page.on("requestfailed", (req) => {
+      if (req.url().includes("maplibre-gl-worker")) failures.push(req.url());
+    });
+    await stubBasemap(page, EMPTY_STYLE);
+    await page.goto("/map", { waitUntil: "networkidle" });
+
+    await expect(page.getByRole("region", { name: "Map" })).toBeVisible();
+    expect(failures, `maplibre worker fetch failed: ${failures.join(", ")}`).toEqual([]);
+  });
+
   test("loads with the filter panel and no filter active by default", async ({ page }) => {
     await stubBasemap(page, EMPTY_STYLE);
     await page.goto("/map", { waitUntil: "networkidle" });

--- a/webclient/app/plugins/maplibre.client.ts
+++ b/webclient/app/plugins/maplibre.client.ts
@@ -1,0 +1,11 @@
+// MapLibre GL v6 loads its worker via `new URL('./maplibre-gl-worker.mjs', import.meta.url)`.
+// Bundlers (Vite/Rollup) do not statically pick this pattern up, so the worker file is never
+// emitted as an asset and the fetch 404s at runtime - the map renders the attribution but no
+// tiles. Pin the worker URL through Vite's `?url` import so the bundler emits the asset and
+// returns its public URL.
+import { setWorkerUrl } from "maplibre-gl";
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?url";
+
+export default defineNuxtPlugin(() => {
+  setWorkerUrl(maplibreWorkerUrl);
+});


### PR DESCRIPTION
Asserts no `requestfailed` event for `maplibre-gl-worker` during `/map` navigation. Verified: fails locally (`maplibre worker fetch failed: …/maplibre-gl-worker.mjs`) when the [PR #3228](https://github.com/TUM-Dev/NavigaTUM/pull/3228) plugin is absent, passes once it is in place. Stacks on #3228.