### PR TITLE
feat: add eat-api weekly mensa menus to canteen detail pages

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -50,6 +50,10 @@ jobs:
         continue-on-error: true # an outage leaves the previous hours in place => coverage degrades, build still works
         run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/studierendenwerk.py
         working-directory: data/external
+      - name: Download eat-api weekly canteen menus
+        continue-on-error: true # an outage leaves the previous menus in place => coverage degrades, build still works
+        run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/eat_api_menus.py
+        working-directory: data/external
       - name: Download UB-TUM library opening hours
         continue-on-error: true # an outage leaves the previous hours in place => coverage degrades, build still works
         run: PYTHONPATH=$PYTHONPATH:.. uv run python scrapers/ub_tum.py

--- a/data/compile.py
+++ b/data/compile.py
@@ -12,6 +12,7 @@ from pipeline_types import Entry
 from processors import (
     aliases,
     coords,
+    eat_api_menus,
     export,
     images,
     iris,
@@ -197,6 +198,10 @@ def _run_pipeline(
     # Expands lecture:/break: macros; fails the build on an unknown id or a schedule
     # that does not reduce to plain OSM.
     df = opening_hours.merge_opening_hours(df, schedules=schedules)
+
+    # Attach the current + next ISO week of eat-api menus next to opening hours so the room
+    # detail page can render them in the same column.
+    df = eat_api_menus.merge_mensa_menus(df)
 
     # Entries that only appear in comments/links CSVs (not in names.csv) were not created
     # at step 02, so they don't have NavigaTUM source. Prepend it now.

--- a/data/external/loaders/eat_api_menus.py
+++ b/data/external/loaders/eat_api_menus.py
@@ -1,0 +1,13 @@
+import dataframely as dy
+import polars as pl
+
+from external.models.common import RESULTS_PATH
+from external.schemas.eat_api_menus import EatApiMenuSchema
+
+EAT_API_MENUS_CSV = RESULTS_PATH / "eat_api_menus.csv"
+
+
+def load_eat_api_menus() -> dy.DataFrame[EatApiMenuSchema]:
+    """Load and validate the cached `eat_api_menus.csv` weekly canteen menus."""
+    df = pl.read_csv(EAT_API_MENUS_CSV, schema=EatApiMenuSchema.to_polars_schema())
+    return EatApiMenuSchema.validate(df)

--- a/data/external/schemas/eat_api_menus.py
+++ b/data/external/schemas/eat_api_menus.py
@@ -1,0 +1,65 @@
+import dataframely as dy
+import polars as pl
+
+from external.schemas._validators import is_http_url, is_iso_date
+
+# eat-api dish-type values are short German labels (e.g. `Pasta`, `Suppe`, `Studitopf`); a fixed
+# enumeration would silently drop new categories, so the schema only requires non-empty when present.
+
+
+class EatApiMenuSchema(dy.Schema):
+    """
+    Per-dish menu rows scraped from the TUM-Dev eat-api weekly canteen feeds.
+
+    eat-api publishes `{canteen}/{year}/{week}.json`, where each day carries an ordered list
+    of dishes. We flatten that nesting into one row per dish so the schema can enforce dish-level
+    rules; the processor re-nests them per canteen for the response payload. `prices_json` and
+    `labels_json` are pre-serialised JSON strings (object resp. array) so the CSV stays a flat
+    text file. Keyed by `(canteen_id, date, position)`; `position` is the dish's index within
+    the day's list and preserves the upstream serving order.
+    """
+
+    canteen_id = dy.String(nullable=False, primary_key=True)
+    date = dy.String(nullable=False, primary_key=True)
+    position = dy.Integer(nullable=False, primary_key=True, min=0)
+    name = dy.String(nullable=False)
+    dish_type = dy.String(nullable=True)
+    prices_json = dy.String(nullable=False)
+    labels_json = dy.String(nullable=False)
+    source_url = dy.String(nullable=False)
+    last_update = dy.String(nullable=False)
+
+    @dy.rule()
+    def name_non_empty(cls) -> pl.Expr:
+        """`name` must contain visible characters; an empty title is never a real dish."""
+        return pl.col("name").str.strip_chars().str.len_chars() > 0
+
+    @dy.rule()
+    def dish_type_non_empty_when_present(cls) -> pl.Expr:
+        """`dish_type`, when supplied, must contain visible characters."""
+        return pl.col("dish_type").is_null() | (pl.col("dish_type").str.strip_chars().str.len_chars() > 0)
+
+    @dy.rule()
+    def date_is_iso(cls) -> pl.Expr:
+        """`date` must be a `YYYY-MM-DD` calendar date."""
+        return is_iso_date("date")
+
+    @dy.rule()
+    def last_update_is_iso_date(cls) -> pl.Expr:
+        """`last_update` must be a `YYYY-MM-DD` date."""
+        return is_iso_date("last_update")
+
+    @dy.rule()
+    def source_url_is_http(cls) -> pl.Expr:
+        """`source_url` must be an absolute http(s) URL."""
+        return is_http_url("source_url")
+
+    @dy.rule()
+    def prices_json_is_object(cls) -> pl.Expr:
+        """`prices_json` must be a JSON object string (`{...}`), not a list or scalar."""
+        return pl.col("prices_json").str.starts_with("{") & pl.col("prices_json").str.ends_with("}")
+
+    @dy.rule()
+    def labels_json_is_array(cls) -> pl.Expr:
+        """`labels_json` must be a JSON array string (`[...]`), even when empty."""
+        return pl.col("labels_json").str.starts_with("[") & pl.col("labels_json").str.ends_with("]")

--- a/data/external/schemas/test_schemas_eat_api_menus.py
+++ b/data/external/schemas/test_schemas_eat_api_menus.py
@@ -1,0 +1,171 @@
+from datetime import date
+
+import dataframely as dy
+import polars as pl
+import pytest
+
+from external.schemas.eat_api_menus import EatApiMenuSchema
+from external.scrapers.eat_api_menus import _iso_weeks, _rows_for_week
+
+
+def _valid_row() -> dict[str, list[object]]:
+    """Build a single valid dish row in `EatApiMenuSchema` column order."""
+    return {
+        "canteen_id": ["mensa-garching"],
+        "date": ["2026-06-10"],
+        "position": [0],
+        "name": ["Pasta Emiliana"],
+        "dish_type": ["Pasta"],
+        "prices_json": ['{"students":{"base_price":1.0,"price_per_unit":0.9,"unit":"100g"}}'],
+        "labels_json": ['["GLUTEN","LACTOSE"]'],
+        "source_url": ["https://tum-dev.github.io/eat-api/#!/de/mensa-garching"],
+        "last_update": ["2026-06-05"],
+    }
+
+
+def _row_with(**overrides: object) -> pl.DataFrame:
+    """Build a one-row frame from the valid baseline, overriding named columns."""
+    row = _valid_row()
+    for key, value in overrides.items():
+        row[key] = [value]
+    return pl.DataFrame(row, schema=EatApiMenuSchema.to_polars_schema())
+
+
+def test_schema_accepts_minimal_valid_row() -> None:
+    """A row matching every rule must validate cleanly (positive control)."""
+    EatApiMenuSchema.validate(_row_with())
+
+
+def test_schema_accepts_null_dish_type() -> None:
+    """`dish_type` is upstream-optional and must accept null without complaint."""
+    EatApiMenuSchema.validate(_row_with(dish_type=None))
+
+
+def test_schema_rejects_empty_dish_type() -> None:
+    """A whitespace-only `dish_type` must be rejected; null is the only "absent" signal."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(dish_type="   "))
+
+
+def test_schema_rejects_empty_name() -> None:
+    """An empty `name` must be rejected; a dish without a title is never a real dish."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(name=""))
+
+
+def test_schema_rejects_negative_position() -> None:
+    """`position` is a 0-based index; negatives are never valid."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(position=-1))
+
+
+def test_schema_rejects_duplicate_primary_key() -> None:
+    """Two dishes with the same `(canteen_id, date, position)` would shadow each other."""
+    duplicated = pl.DataFrame(
+        {
+            "canteen_id": ["mensa-garching"] * 2,
+            "date": ["2026-06-10"] * 2,
+            "position": [0, 0],
+            "name": ["Pasta", "Suppe"],
+            "dish_type": ["Pasta", "Suppe"],
+            "prices_json": ["{}", "{}"],
+            "labels_json": ["[]", "[]"],
+            "source_url": ["https://x.tld"] * 2,
+            "last_update": ["2026-06-05"] * 2,
+        },
+        schema=EatApiMenuSchema.to_polars_schema(),
+    )
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(duplicated)
+
+
+@pytest.mark.parametrize("bad_date", ["2026/06/10", "10-06-2026", "2026-6-1", "not-a-date"])
+def test_schema_rejects_non_iso_date(bad_date: str) -> None:
+    """`date` must be a zero-padded `YYYY-MM-DD` calendar date."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(date=bad_date))
+
+
+@pytest.mark.parametrize("bad_prices", ["null", "[]", '"x"', "1.0"])
+def test_schema_rejects_non_object_prices_json(bad_prices: str) -> None:
+    """`prices_json` must be a JSON object string; the response model expects a per-role mapping."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(prices_json=bad_prices))
+
+
+@pytest.mark.parametrize("bad_labels", ["{}", "null", '"GLUTEN"', "1"])
+def test_schema_rejects_non_array_labels_json(bad_labels: str) -> None:
+    """`labels_json` must be a JSON array string, even when empty (`[]`)."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(labels_json=bad_labels))
+
+
+@pytest.mark.parametrize("url", ["www.example.tld", "ftp://example.tld", "/relative", ""])
+def test_schema_rejects_non_http_source_url(url: str) -> None:
+    """`source_url` must be an absolute http(s) URL."""
+    with pytest.raises(dy.exc.ValidationError):
+        EatApiMenuSchema.validate(_row_with(source_url=url))
+
+
+def test_iso_weeks_crosses_year_boundary() -> None:
+    """The week sequence must follow ISO calendar rules across a year change."""
+    # 2025-12-29 is ISO week 1 of 2026; the following Monday is week 2 of 2026.
+    weeks = _iso_weeks(date(2025, 12, 29), count=2)
+    assert weeks == [(2026, 1), (2026, 2)]
+
+
+def test_iso_weeks_returns_requested_count_in_order() -> None:
+    """The week sequence advances one ISO week at a time and never repeats."""
+    weeks = _iso_weeks(date(2026, 6, 10), count=3)
+    assert weeks == [(2026, 24), (2026, 25), (2026, 26)]
+
+
+def test_rows_for_week_flattens_dishes_preserving_order() -> None:
+    """Dishes flatten in upstream order; `position` is the source index within the day."""
+    payload = {
+        "days": [
+            {
+                "date": "2026-06-10",
+                "dishes": [
+                    {"name": "Suppe", "dish_type": "Suppe", "prices": {}, "labels": []},
+                    {"name": "Pasta", "dish_type": "Pasta", "prices": {}, "labels": ["GLUTEN"]},
+                ],
+            },
+            {
+                "date": "2026-06-11",
+                "dishes": [
+                    {"name": "Reisgericht", "prices": {"students": {"base_price": 2.0}}, "labels": []},
+                ],
+            },
+        ]
+    }
+    rows = _rows_for_week("mensa-garching", payload, last_update="2026-06-05")
+    assert [(row["date"], row["position"], row["name"]) for row in rows] == [
+        ("2026-06-10", 0, "Suppe"),
+        ("2026-06-10", 1, "Pasta"),
+        ("2026-06-11", 0, "Reisgericht"),
+    ]
+    # A dish without `dish_type` should round-trip as null.
+    assert rows[2]["dish_type"] is None
+
+
+def test_rows_for_week_skips_dishes_without_a_name() -> None:
+    """A blank `name` is never a real dish; we drop it rather than pollute the schema."""
+    payload = {
+        "days": [
+            {
+                "date": "2026-06-10",
+                "dishes": [
+                    {"name": "  ", "prices": {}, "labels": []},
+                    {"name": "Real Dish", "prices": {}, "labels": []},
+                ],
+            }
+        ]
+    }
+    rows = _rows_for_week("mensa-garching", payload, last_update="2026-06-05")
+    assert [row["name"] for row in rows] == ["Real Dish"]
+
+
+def test_rows_for_week_handles_missing_days_block() -> None:
+    """An eat-api response with no `days` (e.g. a closed-week stub) yields no rows, no error."""
+    assert _rows_for_week("mensa-garching", {}, last_update="2026-06-05") == []

--- a/data/external/schemas/test_schemas_eat_api_menus.py
+++ b/data/external/schemas/test_schemas_eat_api_menus.py
@@ -5,7 +5,11 @@ import polars as pl
 import pytest
 
 from external.schemas.eat_api_menus import EatApiMenuSchema
-from external.scrapers.eat_api_menus import _iso_weeks, _rows_for_week
+from external.scrapers.eat_api_menus import (
+    _EatApiWeek,
+    _iso_weeks,
+    _rows_for_week,
+)
 
 
 def _valid_row() -> dict[str, list[object]]:
@@ -122,7 +126,7 @@ def test_iso_weeks_returns_requested_count_in_order() -> None:
 
 def test_rows_for_week_flattens_dishes_preserving_order() -> None:
     """Dishes flatten in upstream order; `position` is the source index within the day."""
-    payload = {
+    payload: _EatApiWeek = {
         "days": [
             {
                 "date": "2026-06-10",
@@ -151,7 +155,7 @@ def test_rows_for_week_flattens_dishes_preserving_order() -> None:
 
 def test_rows_for_week_skips_dishes_without_a_name() -> None:
     """A blank `name` is never a real dish; we drop it rather than pollute the schema."""
-    payload = {
+    payload: _EatApiWeek = {
         "days": [
             {
                 "date": "2026-06-10",
@@ -168,4 +172,5 @@ def test_rows_for_week_skips_dishes_without_a_name() -> None:
 
 def test_rows_for_week_handles_missing_days_block() -> None:
     """An eat-api response with no `days` (e.g. a closed-week stub) yields no rows, no error."""
-    assert _rows_for_week("mensa-garching", {}, last_update="2026-06-05") == []
+    empty: _EatApiWeek = {"days": []}
+    assert _rows_for_week("mensa-garching", empty, last_update="2026-06-05") == []

--- a/data/external/scrapers/eat_api_menus.py
+++ b/data/external/scrapers/eat_api_menus.py
@@ -3,6 +3,7 @@ import logging
 from datetime import UTC, date, datetime, timedelta
 from email.utils import parsedate_to_datetime
 from pathlib import Path
+from typing import NotRequired, TypedDict
 
 import orjson
 import polars as pl
@@ -11,6 +12,37 @@ from utils import setup_logging
 
 from external.schemas.eat_api_menus import EatApiMenuSchema
 from external.scraping_utils import CACHE_PATH
+
+
+class _EatApiPrice(TypedDict, total=False):
+    """One role's price block as eat-api emits it; every key is upstream-optional."""
+
+    base_price: float
+    price_per_unit: float
+    unit: str
+
+
+class _EatApiDish(TypedDict):
+    """Single dish in eat-api's weekly JSON. `dish_type` is upstream-optional."""
+
+    name: str
+    dish_type: NotRequired[str | None]
+    prices: dict[str, _EatApiPrice]
+    labels: list[str]
+
+
+class _EatApiDay(TypedDict):
+    """One calendar day's dishes in eat-api's weekly JSON."""
+
+    date: str
+    dishes: list[_EatApiDish]
+
+
+class _EatApiWeek(TypedDict):
+    """Top-level weekly payload eat-api publishes per canteen."""
+
+    days: list[_EatApiDay]
+
 
 # eat-api stores one JSON per ISO week per canteen; we fetch the current and next ISO weeks so
 # a Friday visitor still sees Monday. Going further out yields stale 404s on most canteens.
@@ -52,7 +84,7 @@ def _last_modified_date(response: requests.Response, fallback: date) -> str:
     return fallback.isoformat()
 
 
-def _fetch_week(canteen_id: str, year: int, week: int) -> tuple[dict | None, str | None]:
+def _fetch_week(canteen_id: str, year: int, week: int) -> tuple[_EatApiWeek | None, str | None]:
     """
     Fetch one week's menu for a canteen. Returns `(payload, last_modified_iso)`.
 
@@ -69,7 +101,7 @@ def _fetch_week(canteen_id: str, year: int, week: int) -> tuple[dict | None, str
 
 def _rows_for_week(
     canteen_id: str,
-    payload: dict,
+    payload: _EatApiWeek,
     last_update: str,
 ) -> list[dict[str, object]]:
     """Flatten one week's payload into `EatApiMenuSchema` rows in serving order."""

--- a/data/external/scrapers/eat_api_menus.py
+++ b/data/external/scrapers/eat_api_menus.py
@@ -1,0 +1,135 @@
+import csv
+import logging
+from datetime import UTC, date, datetime, timedelta
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import orjson
+import polars as pl
+import requests
+from utils import setup_logging
+
+from external.schemas.eat_api_menus import EatApiMenuSchema
+from external.scraping_utils import CACHE_PATH
+
+# eat-api stores one JSON per ISO week per canteen; we fetch the current and next ISO weeks so
+# a Friday visitor still sees Monday. Going further out yields stale 404s on most canteens.
+_WEEKS_AHEAD = 1
+_WEEK_URL = "https://tum-dev.github.io/eat-api/{canteen_id}/{year}/{week:02d}.json"
+_MENU_URL = "https://tum-dev.github.io/eat-api/#!/de/{canteen_id}"
+
+# Same source file the processor consumes for the canteen-id -> NavigaTUM-id mapping. The
+# scraper only needs the `canteen_id` column, so we read it directly rather than importing
+# the processor and pulling in its dataframely dependency.
+_CANTEEN_MAPPING_CSV = Path(__file__).resolve().parents[2] / "sources" / "mensa_canteens.csv"
+
+_logger = logging.getLogger(__name__)
+
+
+def _mapped_canteen_ids() -> list[str]:
+    """Return the canteen ids the build is wired up to render menus for, in CSV order."""
+    with _CANTEEN_MAPPING_CSV.open() as f:
+        return [row["canteen_id"] for row in csv.DictReader(f)]
+
+
+def _iso_weeks(reference: date, count: int) -> list[tuple[int, int]]:
+    """Return `count` consecutive ISO `(year, week)` pairs starting at `reference`'s week."""
+    weeks: list[tuple[int, int]] = []
+    cursor = reference
+    while len(weeks) < count:
+        iso_year, iso_week, _ = cursor.isocalendar()
+        weeks.append((iso_year, iso_week))
+        # Step into next ISO week without depending on the calendar month.
+        cursor += timedelta(days=7)
+    return weeks
+
+
+def _last_modified_date(response: requests.Response, fallback: date) -> str:
+    """Return the response's `Last-Modified` as `YYYY-MM-DD`, falling back to `fallback`."""
+    header = response.headers.get("Last-Modified")
+    if header:
+        return parsedate_to_datetime(header).date().isoformat()
+    return fallback.isoformat()
+
+
+def _fetch_week(canteen_id: str, year: int, week: int) -> tuple[dict | None, str | None]:
+    """
+    Fetch one week's menu for a canteen. Returns `(payload, last_modified_iso)`.
+
+    A 404 means "no menu published for this week" - a real and common case for any canteen
+    that is closed - and is treated as empty data, not an error.
+    """
+    url = _WEEK_URL.format(canteen_id=canteen_id, year=year, week=week)
+    response = requests.get(url, timeout=30)
+    if response.status_code == 404:
+        return None, None
+    response.raise_for_status()
+    return response.json(), _last_modified_date(response, fallback=datetime.now(UTC).date())
+
+
+def _rows_for_week(
+    canteen_id: str,
+    payload: dict,
+    last_update: str,
+) -> list[dict[str, object]]:
+    """Flatten one week's payload into `EatApiMenuSchema` rows in serving order."""
+    rows: list[dict[str, object]] = []
+    for day in payload.get("days", []):
+        day_date = day.get("date")
+        if not day_date:
+            continue
+        for position, dish in enumerate(day.get("dishes", [])):
+            name = (dish.get("name") or "").strip()
+            if not name:
+                continue
+            rows.append(
+                {
+                    "canteen_id": canteen_id,
+                    "date": day_date,
+                    "position": position,
+                    "name": name,
+                    "dish_type": (dish.get("dish_type") or None),
+                    "prices_json": orjson.dumps(dish.get("prices") or {}).decode(),
+                    "labels_json": orjson.dumps(list(dish.get("labels") or [])).decode(),
+                    "source_url": _MENU_URL.format(canteen_id=canteen_id),
+                    "last_update": last_update,
+                }
+            )
+    return rows
+
+
+def scrape_eat_api_menus(*, today: date | None = None) -> None:
+    """
+    Write `eat_api_menus.csv` with the current and upcoming ISO week of menus per mapped canteen.
+
+    Iterates the canteen ids in `mensa_canteens.csv`, since publishing a menu for a canteen
+    NavigaTUM does not render would only widen the snapshot without benefit. Refuses to
+    overwrite an existing CSV with an empty roster, so an upstream outage leaves stale (but
+    correct) data in place rather than wiping coverage.
+    """
+    today = today or datetime.now(UTC).date()
+    canteen_ids = _mapped_canteen_ids()
+    weeks = _iso_weeks(today, count=1 + _WEEKS_AHEAD)
+
+    all_rows: list[dict[str, object]] = []
+    for canteen_id in canteen_ids:
+        for year, week in weeks:
+            payload, last_update = _fetch_week(canteen_id, year, week)
+            if payload is None or last_update is None:
+                _logger.info("no menu published for canteen %s in %s-W%02d", canteen_id, year, week)
+                continue
+            all_rows.extend(_rows_for_week(canteen_id, payload, last_update))
+
+    if not all_rows:
+        raise RuntimeError("eat-api returned no menus across the mapped canteens - refusing to overwrite the roster")
+
+    df = pl.DataFrame(all_rows, schema=EatApiMenuSchema.to_polars_schema()).sort(["canteen_id", "date", "position"])
+    EatApiMenuSchema.validate(df)
+    df.write_csv(CACHE_PATH / "eat_api_menus.csv")
+    _logger.info("Scraped %d dish rows across %d canteens", df.height, len(canteen_ids))
+
+
+if __name__ == "__main__":
+    setup_logging()
+    CACHE_PATH.mkdir(exist_ok=True)
+    scrape_eat_api_menus()

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1682,6 +1682,15 @@ components:
         maps:
           $ref: '#/components/schemas/MapsResponse'
           description: Print or overlay maps for said location
+        mensa_menu:
+          oneOf:
+            - type: "null"
+            - $ref: '#/components/schemas/MensaMenuResponse'
+              description: |-
+                Weekly canteen menu sourced from the eat-api feed.
+
+                Present for the canteens listed in `data/sources/mensa_canteens.csv`; the snapshot
+                covers the current and next ISO week. Omitted for every other entry.
         name:
           type: string
           description: The name of the entry in a human-readable form
@@ -2103,6 +2112,139 @@ components:
           oneOf:
             - type: "null"
             - $ref: '#/components/schemas/RoomfinderMapResponse'
+    MensaMenuDayResponse:
+      type: object
+      description: One day in a [`MensaMenuResponse`].
+      required:
+        - date
+        - dishes
+      properties:
+        date:
+          type: string
+          description: '`YYYY-MM-DD` calendar date of the day.'
+          examples:
+            - "2026-06-10"
+        dishes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MensaMenuDishResponse'
+          description: Dishes served on this day, in the upstream serving order.
+    MensaMenuDishResponse:
+      type: object
+      description: One dish on one day of a [`MensaMenuResponse`].
+      required:
+        - name
+        - prices
+        - labels
+      properties:
+        dish_type:
+          type:
+            - string
+            - "null"
+          description: |-
+            Short category label upstream uses to group the dish (`Pasta`, `Suppe`, `Studitopf`, ...).
+
+            Omitted when upstream did not classify the dish.
+          examples:
+            - Pasta
+        labels:
+          type: array
+          items:
+            type: string
+          description: |-
+            Allergen and ingredient labels in upstream's enum form (e.g. `GLUTEN`, `LACTOSE`).
+
+            The client maps them to localized text via its own label dictionary so prices and
+            labels stay in sync without a server round-trip on language change.
+          examples:
+            - - GLUTEN
+              - LACTOSE
+        name:
+          type: string
+          description: Dish title in the upstream language (German).
+          examples:
+            - Pasta Emiliana mit (Vorder-)Schinken und Erbsen
+        prices:
+          $ref: '#/components/schemas/MensaMenuPricesResponse'
+          description: Prices keyed by role. A role is omitted when upstream priced the dish only for some.
+    MensaMenuPriceResponse:
+      type: object
+      description: |-
+        One role's price for a dish.
+
+        `price_per_unit` and `unit` are upstream-optional because flat-rate dishes (e.g. a fixed
+        `1.00 €` Studitopf) carry only a `base_price`.
+      required:
+        - base_price
+      properties:
+        base_price:
+          type: number
+          format: double
+          description: Flat amount in Euros charged before any unit upcharge.
+          examples:
+            - 1.0
+        price_per_unit:
+          type:
+            - number
+            - "null"
+          format: double
+          description: Additional amount in Euros charged per `unit` (e.g. per 100g).
+          examples:
+            - 0.9
+        unit:
+          type:
+            - string
+            - "null"
+          description: Unit the `price_per_unit` is charged against (e.g. `100g`).
+          examples:
+            - 100g
+    MensaMenuPricesResponse:
+      type: object
+      description: |-
+        Per-role price block for a [`MensaMenuDishResponse`].
+
+        Each field is `None` when upstream did not price the dish for that role.
+      properties:
+        guests:
+          oneOf:
+            - type: "null"
+            - $ref: '#/components/schemas/MensaMenuPriceResponse'
+        staff:
+          oneOf:
+            - type: "null"
+            - $ref: '#/components/schemas/MensaMenuPriceResponse'
+        students:
+          oneOf:
+            - type: "null"
+            - $ref: '#/components/schemas/MensaMenuPriceResponse'
+    MensaMenuResponse:
+      type: object
+      description: |-
+        Weekly canteen menu sourced from the TUM-Dev eat-api feed.
+
+        `days` is calendar-ordered and covers the current ISO week plus the next, so a Friday
+        visitor still sees Monday. Closed days are simply absent rather than represented as
+        empty entries.
+      required:
+        - source_url
+        - last_update
+        - days
+      properties:
+        days:
+          type: array
+          items:
+            $ref: '#/components/schemas/MensaMenuDayResponse'
+          description: Per-day dish lists in calendar order; only days with at least one dish are present.
+        last_update:
+          type: string
+          description: '`YYYY-MM-DD` date the feed snapshot was last confirmed (the upstream `Last-Modified`).'
+          examples:
+            - "2026-06-05"
+        source_url:
+          type: string
+          description: Where the menu was sourced from; shown as the "source" link on the card.
+          examples:
+            - https://tum-dev.github.io/eat-api/#!/de/mensa-garching
     ModeResponse:
       type: string
       enum:

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2151,14 +2151,14 @@ components:
           type: array
           items:
             type: string
+            examples:
+              - - GLUTEN
+                - LACTOSE
           description: |-
             Allergen and ingredient labels in upstream's enum form (e.g. `GLUTEN`, `LACTOSE`).
 
             The client maps them to localized text via its own label dictionary so prices and
             labels stay in sync without a server round-trip on language change.
-          examples:
-            - - GLUTEN
-              - LACTOSE
         name:
           type: string
           description: Dish title in the upstream language (German).
@@ -2182,7 +2182,7 @@ components:
           format: double
           description: Flat amount in Euros charged before any unit upcharge.
           examples:
-            - 1.0
+            - 1
         price_per_unit:
           type:
             - number

--- a/data/processors/df_utils.py
+++ b/data/processors/df_utils.py
@@ -308,6 +308,8 @@ def unflatten_row(row: FlatRow) -> Entry:
         result["roomfinder_data"] = orjson.loads(roomfinder_json)
     if opening_hours_json := row.get("opening_hours_json"):
         result["opening_hours"] = orjson.loads(opening_hours_json)
+    if mensa_menus_json := row.get("mensa_menus_json"):
+        result["mensa_menu"] = orjson.loads(mensa_menus_json)
 
     if arch_name := row.get("arch_name"):
         result["arch_name"] = arch_name

--- a/data/processors/eat_api_menus.py
+++ b/data/processors/eat_api_menus.py
@@ -28,7 +28,7 @@ def _load_stored_menus() -> pl.DataFrame:
         return pl.DataFrame(schema=EatApiMenuSchema.to_polars_schema())
 
 
-def _build_payload(rows: list[dict]) -> dict:
+def _build_payload(rows: list[dict[str, object]]) -> dict[str, object]:
     """
     Re-nest a sorted slice of dish rows for one canteen into a `MenuResponse`-shaped payload.
 
@@ -36,19 +36,21 @@ def _build_payload(rows: list[dict]) -> dict:
     order. `source_url`/`last_update` are taken from the latest row, mirroring opening-hours
     behaviour when several scraper snapshots land in the same build.
     """
-    days: list[dict] = []
-    current_day: dict | None = None
+    days: list[dict[str, object]] = []
+    current_day: dict[str, object] | None = None
     for row in rows:
         if current_day is None or current_day["date"] != row["date"]:
             current_day = {"date": row["date"], "dishes": []}
             days.append(current_day)
-        dish: dict = {
+        dish: dict[str, object] = {
             "name": row["name"],
-            "prices": orjson.loads(row["prices_json"]),
-            "labels": orjson.loads(row["labels_json"]),
+            "prices": orjson.loads(str(row["prices_json"])),
+            "labels": orjson.loads(str(row["labels_json"])),
         }
         if row["dish_type"]:
             dish["dish_type"] = row["dish_type"]
+        # `current_day["dishes"]` was built as a list above; help mypy see that.
+        assert isinstance(current_day["dishes"], list)
         current_day["dishes"].append(dish)
     return {
         "source_url": rows[-1]["source_url"],

--- a/data/processors/eat_api_menus.py
+++ b/data/processors/eat_api_menus.py
@@ -1,0 +1,102 @@
+import logging
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import orjson
+import polars as pl
+from external.freshness import warn_if_stale
+from external.loaders.eat_api_menus import load_eat_api_menus
+from external.schemas.eat_api_menus import EatApiMenuSchema
+
+_logger = logging.getLogger(__name__)
+
+SOURCES_PATH = Path(__file__).parent.parent / "sources"
+CANTEEN_MAPPING_CSV = SOURCES_PATH / "mensa_canteens.csv"
+_MAPPING_SCHEMA = {"canteen_id": pl.Utf8(), "id": pl.Utf8()}
+
+
+def _load_mapping() -> pl.DataFrame:
+    """Load the hand-authored canteen-id -> NavigaTUM entry-id mapping."""
+    return pl.read_csv(CANTEEN_MAPPING_CSV, schema=_MAPPING_SCHEMA)
+
+
+def _load_stored_menus() -> pl.DataFrame:
+    try:
+        return load_eat_api_menus()
+    except FileNotFoundError:
+        _logger.warning("No stored eat-api menu feed yet; no mensa menus will be attached this build")
+        return pl.DataFrame(schema=EatApiMenuSchema.to_polars_schema())
+
+
+def _build_payload(rows: list[dict]) -> dict:
+    """
+    Re-nest a sorted slice of dish rows for one canteen into a `MenuResponse`-shaped payload.
+
+    `rows` must already be sorted by `(date, position)` so days and dishes appear in serving
+    order. `source_url`/`last_update` are taken from the latest row, mirroring opening-hours
+    behaviour when several scraper snapshots land in the same build.
+    """
+    days: list[dict] = []
+    current_day: dict | None = None
+    for row in rows:
+        if current_day is None or current_day["date"] != row["date"]:
+            current_day = {"date": row["date"], "dishes": []}
+            days.append(current_day)
+        dish: dict = {
+            "name": row["name"],
+            "prices": orjson.loads(row["prices_json"]),
+            "labels": orjson.loads(row["labels_json"]),
+        }
+        if row["dish_type"]:
+            dish["dish_type"] = row["dish_type"]
+        current_day["dishes"].append(dish)
+    return {
+        "source_url": rows[-1]["source_url"],
+        "last_update": rows[-1]["last_update"],
+        "days": days,
+    }
+
+
+def merge_mensa_menus(
+    df: pl.DataFrame,
+    *,
+    menus: pl.DataFrame | None = None,
+    mapping: pl.DataFrame | None = None,
+    today: date | None = None,
+) -> pl.DataFrame:
+    """
+    Attach scraped eat-api menus to their entries as a `mensa_menus_json` payload.
+
+    Canteens are matched to entries via the hand-authored `mensa_canteens.csv`. A mapped
+    canteen absent from the feed is logged (mapping drift or an upstream rename); an
+    unmapped canteen is ignored. Emits a build-time staleness warning per feed snapshot.
+    `menus`/`mapping`/`today` are injectable for tests.
+    """
+    menus = _load_stored_menus() if menus is None else menus
+    mapping = _load_mapping() if mapping is None else mapping
+    today = today or datetime.now(UTC).date()
+
+    joined = mapping.join(menus, on="canteen_id", how="left")
+    missing_ids = joined.filter(pl.col("name").is_null()).select("canteen_id").unique().to_series().to_list()
+    for canteen_id in missing_ids:
+        _logger.warning("mensa mapping references canteen %r absent from the eat-api menu feed", canteen_id)
+    joined = joined.filter(pl.col("name").is_not_null())
+    if joined.is_empty():
+        return df
+
+    unknown = set(joined["id"]) - set(df["id"])
+    if unknown:
+        raise ValueError(f"eat-api menus reference unknown entry id(s): {sorted(unknown)}")
+
+    for row in joined.select("source_url", "last_update").unique().iter_rows(named=True):
+        warn_if_stale(date.fromisoformat(row["last_update"]), today=today, source=row["source_url"])
+
+    joined = joined.sort(["id", "date", "position"])
+    payloads: list[dict[str, str]] = []
+    for entry_id, group in joined.group_by("id", maintain_order=True):
+        rows = group.iter_rows(named=True)
+        payload = _build_payload(list(rows))
+        payloads.append({"id": entry_id[0], "mensa_menus_json": orjson.dumps(payload).decode()})
+
+    encoded = pl.DataFrame(payloads, schema={"id": pl.Utf8(), "mensa_menus_json": pl.Utf8()})
+    return df.join(encoded, on="id", how="left")

--- a/data/processors/test_eat_api_menus.py
+++ b/data/processors/test_eat_api_menus.py
@@ -1,0 +1,130 @@
+import logging
+from datetime import date
+
+import orjson
+import polars as pl
+import pytest
+from external.schemas.eat_api_menus import EatApiMenuSchema
+
+from processors.eat_api_menus import merge_mensa_menus
+
+_TODAY = date(2026, 6, 10)
+_SOURCE = "https://tum-dev.github.io/eat-api/#!/de/mensa-garching"
+
+
+def _menus(**overrides: list[object]) -> pl.DataFrame:
+    """Build a two-day, two-dish menu feed matching `EatApiMenuSchema`."""
+    base: dict[str, list[object]] = {
+        "canteen_id": ["mensa-garching", "mensa-garching", "mensa-garching"],
+        "date": ["2026-06-10", "2026-06-10", "2026-06-11"],
+        "position": [0, 1, 0],
+        "name": ["Suppe", "Pasta", "Reisgericht"],
+        "dish_type": ["Suppe", "Pasta", None],
+        "prices_json": [
+            "{}",
+            '{"students":{"base_price":1.0,"price_per_unit":0.9,"unit":"100g"}}',
+            "{}",
+        ],
+        "labels_json": ["[]", '["GLUTEN","LACTOSE"]', "[]"],
+        "source_url": [_SOURCE, _SOURCE, _SOURCE],
+        "last_update": ["2026-06-05", "2026-06-05", "2026-06-05"],
+    }
+    return pl.DataFrame({**base, **overrides}, schema=EatApiMenuSchema.to_polars_schema())
+
+
+def _mapping(canteen_ids: list[str], ids: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"canteen_id": canteen_ids, "id": ids}, schema={"canteen_id": pl.Utf8(), "id": pl.Utf8()})
+
+
+def _entries(ids: list[str]) -> pl.DataFrame:
+    return pl.DataFrame({"id": ids, "type": ["building"] * len(ids)})
+
+
+def test_attaches_menu_payload_to_mapped_entry() -> None:
+    """A mapped canteen yields a serialized `MenuResponse`-shaped payload on its NavigaTUM id."""
+    entries = _entries(["5304", "0001"])
+    merged = merge_mensa_menus(
+        entries,
+        menus=_menus(),
+        mapping=_mapping(["mensa-garching"], ["5304"]),
+        today=_TODAY,
+    )
+    by_id = dict(zip(merged["id"], merged["mensa_menus_json"], strict=True))
+    assert by_id["0001"] is None
+    payload = orjson.loads(by_id["5304"])
+    assert payload["source_url"] == _SOURCE
+    assert payload["last_update"] == "2026-06-05"
+    assert [day["date"] for day in payload["days"]] == ["2026-06-10", "2026-06-11"]
+    monday_dishes = payload["days"][0]["dishes"]
+    assert [dish["name"] for dish in monday_dishes] == ["Suppe", "Pasta"]
+    pasta = monday_dishes[1]
+    assert pasta["dish_type"] == "Pasta"
+    assert pasta["prices"]["students"]["price_per_unit"] == 0.9
+    assert pasta["labels"] == ["GLUTEN", "LACTOSE"]
+
+
+def test_omits_dish_type_when_upstream_null() -> None:
+    """`dish_type` is skipped on dishes where upstream did not supply it; null bloats the payload."""
+    entries = _entries(["5304"])
+    merged = merge_mensa_menus(
+        entries,
+        menus=_menus(),
+        mapping=_mapping(["mensa-garching"], ["5304"]),
+        today=_TODAY,
+    )
+    payload = orjson.loads(merged["mensa_menus_json"][0])
+    tuesday = payload["days"][1]["dishes"][0]
+    assert "dish_type" not in tuesday
+
+
+def test_warns_when_mapping_targets_canteen_absent_from_feed(caplog: pytest.LogCaptureFixture) -> None:
+    """A mapping entry with no matching feed canteen is logged and produces no payload."""
+    entries = _entries(["5304", "9999"])
+    with caplog.at_level(logging.WARNING):
+        merged = merge_mensa_menus(
+            entries,
+            menus=_menus(),
+            mapping=_mapping(["mensa-garching", "mensa-gone"], ["5304", "9999"]),
+            today=_TODAY,
+        )
+    by_id = dict(zip(merged["id"], merged["mensa_menus_json"], strict=True))
+    assert by_id["5304"] is not None
+    assert by_id["9999"] is None
+    assert "mensa-gone" in caplog.text
+
+
+def test_warns_when_feed_is_stale(caplog: pytest.LogCaptureFixture) -> None:
+    """A feed snapshot older than the staleness window is flagged at build time."""
+    entries = _entries(["5304"])
+    with caplog.at_level(logging.WARNING):
+        merge_mensa_menus(
+            entries,
+            menus=_menus(last_update=["2025-01-01", "2025-01-01", "2025-01-01"]),
+            mapping=_mapping(["mensa-garching"], ["5304"]),
+            today=_TODAY,
+        )
+    assert "stale" in caplog.text
+
+
+def test_returns_unchanged_frame_when_no_canteens_match() -> None:
+    """An empty join must not introduce a `mensa_menus_json` column on unrelated builds."""
+    entries = _entries(["0001"])
+    merged = merge_mensa_menus(
+        entries,
+        menus=_menus(),
+        mapping=_mapping(["mensa-elsewhere"], ["9999"]),
+        today=_TODAY,
+    )
+    assert "mensa_menus_json" not in merged.columns
+
+
+def test_fails_when_payload_targets_unknown_entry_id() -> None:
+    """A mapping pointing at an id absent from the entries frame is a build-time error."""
+    entries = _entries(["0001"])
+    with pytest.raises(ValueError, match="unknown entry id"):
+        merge_mensa_menus(
+            entries,
+            menus=_menus(),
+            mapping=_mapping(["mensa-garching"], ["5304"]),
+            today=_TODAY,
+        )

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -170,6 +170,11 @@ struct LocationDetailsResponse {
     ///
     /// Omitted for entries without a known schedule (most rooms).
     opening_hours: Option<OpeningHoursResponse>,
+    /// Weekly canteen menu sourced from the eat-api feed.
+    ///
+    /// Present for the canteens listed in `data/sources/mensa_canteens.csv`; the snapshot
+    /// covers the current and next ISO week. Omitted for every other entry.
+    mensa_menu: Option<MensaMenuResponse>,
 }
 
 /// Opening hours of a location.
@@ -199,6 +204,84 @@ struct OpeningHoursResponse {
     /// several (e.g. a separate lending desk).
     #[schema(examples("Ausleihe"))]
     service: Option<String>,
+}
+
+/// Weekly canteen menu sourced from the TUM-Dev eat-api feed.
+///
+/// `days` is calendar-ordered and covers the current ISO week plus the next, so a Friday
+/// visitor still sees Monday. Closed days are simply absent rather than represented as
+/// empty entries.
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct MensaMenuResponse {
+    /// Where the menu was sourced from; shown as the "source" link on the card.
+    #[schema(examples("https://tum-dev.github.io/eat-api/#!/de/mensa-garching"))]
+    source_url: String,
+    /// `YYYY-MM-DD` date the feed snapshot was last confirmed (the upstream `Last-Modified`).
+    #[schema(examples("2026-06-05"))]
+    last_update: String,
+    /// Per-day dish lists in calendar order; only days with at least one dish are present.
+    days: Vec<MensaMenuDayResponse>,
+}
+
+/// One day in a [`MensaMenuResponse`].
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct MensaMenuDayResponse {
+    /// `YYYY-MM-DD` calendar date of the day.
+    #[schema(examples("2026-06-10"))]
+    date: String,
+    /// Dishes served on this day, in the upstream serving order.
+    dishes: Vec<MensaMenuDishResponse>,
+}
+
+/// One dish on one day of a [`MensaMenuResponse`].
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct MensaMenuDishResponse {
+    /// Dish title in the upstream language (German).
+    #[schema(examples("Pasta Emiliana mit (Vorder-)Schinken und Erbsen"))]
+    name: String,
+    /// Short category label upstream uses to group the dish (`Pasta`, `Suppe`, `Studitopf`, ...).
+    ///
+    /// Omitted when upstream did not classify the dish.
+    #[schema(examples("Pasta"))]
+    dish_type: Option<String>,
+    /// Prices keyed by role. A role is omitted when upstream priced the dish only for some.
+    prices: MensaMenuPricesResponse,
+    /// Allergen and ingredient labels in upstream's enum form (e.g. `GLUTEN`, `LACTOSE`).
+    ///
+    /// The client maps them to localized text via its own label dictionary so prices and
+    /// labels stay in sync without a server round-trip on language change.
+    #[schema(examples(json!(["GLUTEN", "LACTOSE"])))]
+    labels: Vec<String>,
+}
+
+/// Per-role price block for a [`MensaMenuDishResponse`].
+///
+/// Each field is `None` when upstream did not price the dish for that role.
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct MensaMenuPricesResponse {
+    students: Option<MensaMenuPriceResponse>,
+    staff: Option<MensaMenuPriceResponse>,
+    guests: Option<MensaMenuPriceResponse>,
+}
+
+/// One role's price for a dish.
+///
+/// `price_per_unit` and `unit` are upstream-optional because flat-rate dishes (e.g. a fixed
+/// `1.00 €` Studitopf) carry only a `base_price`.
+#[serde_with::skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
+struct MensaMenuPriceResponse {
+    /// Flat amount in Euros charged before any unit upcharge.
+    #[schema(examples(1.0))]
+    base_price: f64,
+    /// Additional amount in Euros charged per `unit` (e.g. per 100g).
+    #[schema(examples(0.9))]
+    price_per_unit: Option<f64>,
+    /// Unit the `price_per_unit` is charged against (e.g. `100g`).
+    #[schema(examples("100g"))]
+    unit: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, utoipa::ToSchema)]

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -888,6 +888,7 @@ export type components = {
       readonly imgs?: readonly components["schemas"]["ImageInfoResponse"][] | null;
       /** @description Print or overlay maps for said location */
       readonly maps: components["schemas"]["MapsResponse"];
+      readonly mensa_menu?: null | components["schemas"]["MensaMenuResponse"];
       /**
        * @description The name of the entry in a human-readable form
        * @example 5606.EG.036 (Büro Fachschaft Mathe Physik Informatik Chemie / MPIC)
@@ -1180,6 +1181,100 @@ export type components = {
       readonly default: components["schemas"]["DefaultMapsResponse"];
       readonly overlays?: null | components["schemas"]["OverlayMapsResponse"];
       readonly roomfinder?: null | components["schemas"]["RoomfinderMapResponse"];
+    };
+    /** @description One day in a [`MensaMenuResponse`]. */
+    readonly MensaMenuDayResponse: {
+      /**
+       * @description `YYYY-MM-DD` calendar date of the day.
+       * @example 2026-06-10
+       */
+      readonly date: string;
+      /** @description Dishes served on this day, in the upstream serving order. */
+      readonly dishes: readonly components["schemas"]["MensaMenuDishResponse"][];
+    };
+    /** @description One dish on one day of a [`MensaMenuResponse`]. */
+    readonly MensaMenuDishResponse: {
+      /**
+       * @description Short category label upstream uses to group the dish (`Pasta`, `Suppe`, `Studitopf`, ...).
+       *
+       *     Omitted when upstream did not classify the dish.
+       * @example Pasta
+       */
+      readonly dish_type?: string | null;
+      /**
+       * @description Allergen and ingredient labels in upstream's enum form (e.g. `GLUTEN`, `LACTOSE`).
+       *
+       *     The client maps them to localized text via its own label dictionary so prices and
+       *     labels stay in sync without a server round-trip on language change.
+       * @example [
+       *       "GLUTEN",
+       *       "LACTOSE"
+       *     ]
+       */
+      readonly labels: readonly string[];
+      /**
+       * @description Dish title in the upstream language (German).
+       * @example Pasta Emiliana mit (Vorder-)Schinken und Erbsen
+       */
+      readonly name: string;
+      /** @description Prices keyed by role. A role is omitted when upstream priced the dish only for some. */
+      readonly prices: components["schemas"]["MensaMenuPricesResponse"];
+    };
+    /**
+     * @description One role's price for a dish.
+     *
+     *     `price_per_unit` and `unit` are upstream-optional because flat-rate dishes (e.g. a fixed
+     *     `1.00 €` Studitopf) carry only a `base_price`.
+     */
+    readonly MensaMenuPriceResponse: {
+      /**
+       * Format: double
+       * @description Flat amount in Euros charged before any unit upcharge.
+       * @example 1
+       */
+      readonly base_price: number;
+      /**
+       * Format: double
+       * @description Additional amount in Euros charged per `unit` (e.g. per 100g).
+       * @example 0.9
+       */
+      readonly price_per_unit?: number | null;
+      /**
+       * @description Unit the `price_per_unit` is charged against (e.g. `100g`).
+       * @example 100g
+       */
+      readonly unit?: string | null;
+    };
+    /**
+     * @description Per-role price block for a [`MensaMenuDishResponse`].
+     *
+     *     Each field is `None` when upstream did not price the dish for that role.
+     */
+    readonly MensaMenuPricesResponse: {
+      readonly guests?: null | components["schemas"]["MensaMenuPriceResponse"];
+      readonly staff?: null | components["schemas"]["MensaMenuPriceResponse"];
+      readonly students?: null | components["schemas"]["MensaMenuPriceResponse"];
+    };
+    /**
+     * @description Weekly canteen menu sourced from the TUM-Dev eat-api feed.
+     *
+     *     `days` is calendar-ordered and covers the current ISO week plus the next, so a Friday
+     *     visitor still sees Monday. Closed days are simply absent rather than represented as
+     *     empty entries.
+     */
+    readonly MensaMenuResponse: {
+      /** @description Per-day dish lists in calendar order; only days with at least one dish are present. */
+      readonly days: readonly components["schemas"]["MensaMenuDayResponse"][];
+      /**
+       * @description `YYYY-MM-DD` date the feed snapshot was last confirmed (the upstream `Last-Modified`).
+       * @example 2026-06-05
+       */
+      readonly last_update: string;
+      /**
+       * @description Where the menu was sourced from; shown as the "source" link on the card.
+       * @example https://tum-dev.github.io/eat-api/#!/de/mensa-garching
+       */
+      readonly source_url: string;
     };
     /** @enum {string} */
     readonly ModeResponse:

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1206,10 +1206,6 @@ export type components = {
        *
        *     The client maps them to localized text via its own label dictionary so prices and
        *     labels stay in sync without a server round-trip on language change.
-       * @example [
-       *       "GLUTEN",
-       *       "LACTOSE"
-       *     ]
        */
       readonly labels: readonly string[];
       /**

--- a/webclient/app/components/AddProposalForm.vue
+++ b/webclient/app/components/AddProposalForm.vue
@@ -234,9 +234,11 @@ function displayNameOf(draft: AdditionDraft): string {
 
 type Addition = ReturnType<typeof buildAddition>;
 
-function validateAndBuild():
-  | { id: string; displayName: string; addition: NonNullable<Addition> }
-  | null {
+function validateAndBuild(): {
+  id: string;
+  displayName: string;
+  addition: NonNullable<Addition>;
+} | null {
   localError.value = "";
   const draft = editProposal.value.pendingAddition;
   const id = draft.id.trim();

--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -257,6 +257,10 @@ const actions = computed<DetailAction[]>(() => [
           v-if="data.opening_hours"
           :opening-hours="data.opening_hours"
         />
+        <LazyDetailsMensaMenuCard
+          v-if="data.mensa_menu"
+          :menu="data.mensa_menu"
+        />
         <LazyDetailsNearbyTransportSection :id="data.id"/>
         <LazyDetailsIrisCoverageCard
           v-if="data.props.iris_coverage_building_ids?.length"

--- a/webclient/app/components/DetailsMensaMenuCard.vue
+++ b/webclient/app/components/DetailsMensaMenuCard.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import { mdiChevronDown, mdiOpenInNew, mdiSilverwareForkKnife } from "@mdi/js";
+import { useToggle } from "@vueuse/core";
+import type { components } from "~/api_types";
+import { type EatApiLocale, labelText } from "~/utils/eatApiLabels";
+
+type MenuResponse = components["schemas"]["MensaMenuResponse"];
+type MenuDay = components["schemas"]["MensaMenuDayResponse"];
+type MenuDish = components["schemas"]["MensaMenuDishResponse"];
+type MenuPrice = components["schemas"]["MensaMenuPriceResponse"];
+type RoleKey = keyof MenuDish["prices"];
+
+const props = defineProps<{
+  readonly menu: MenuResponse;
+}>();
+
+const { t, locale } = useI18n({ useScope: "local" });
+const [expanded, toggleExpanded] = useToggle(false);
+
+// The eat-api `date` is a plain `YYYY-MM-DD` string in Munich's local time, so we compare
+// against the visitor's local day rather than walking a Date through UTC.
+const todayIso = computed(() => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+});
+
+const todayDay = computed<MenuDay | null>(
+  () => props.menu.days.find((day) => day.date === todayIso.value) ?? null
+);
+
+// Today renders inline above the chevron, so the expanded block lists everything after.
+const futureDays = computed<readonly MenuDay[]>(() =>
+  props.menu.days.filter((day) => day.date > todayIso.value)
+);
+
+// First future day surfaces in the collapsed view when today is closed; visitors should not
+// have to expand to find out what tomorrow looks like.
+const headlineDay = computed<MenuDay | null>(() => todayDay.value ?? futureDays.value[0] ?? null);
+const headlineIsToday = computed<boolean>(() => headlineDay.value === todayDay.value);
+
+// When today _is_ the headline, the expandable block holds the remaining days; when today is
+// closed and tomorrow is the headline, we skip showing it again in the expanded block.
+const remainingDays = computed<readonly MenuDay[]>(() =>
+  headlineIsToday.value ? futureDays.value : futureDays.value.slice(1)
+);
+
+const labelLocale = computed<EatApiLocale>(() => (locale.value === "de" ? "de" : "en"));
+
+// Roles render in a fixed order so dishes compare visually across rows.
+const ROLES = ["students", "staff", "guests"] as const satisfies readonly RoleKey[];
+
+const euroFormatter = computed(
+  () =>
+    new Intl.NumberFormat(locale.value === "de" ? "de-DE" : "en-GB", {
+      style: "currency",
+      currency: "EUR",
+    })
+);
+
+function formatPrice(price: MenuPrice): string {
+  const base = euroFormatter.value.format(price.base_price);
+  if (price.price_per_unit && price.unit) {
+    // Per-unit dishes (e.g. 100g self-service) carry a non-zero `price_per_unit`; render both
+    // so visitors see the headline number and the per-unit charge that drives the final total.
+    const perUnit = euroFormatter.value.format(price.price_per_unit);
+    return t("price_with_unit", { base, perUnit, unit: price.unit });
+  }
+  return base;
+}
+
+function formatDayLabel(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  if (!year || !month || !day) return iso;
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString(locale.value === "de" ? "de-DE" : "en-GB", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+const lastUpdated = computed(() => {
+  const [year, month, day] = props.menu.last_update.split("-").map(Number);
+  if (!year || !month || !day) return props.menu.last_update;
+  return new Date(year, month - 1, day).toLocaleDateString(
+    locale.value === "de" ? "de-DE" : "en-GB",
+    {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }
+  );
+});
+</script>
+
+<template>
+  <section class="flex flex-col gap-3 print:!hidden">
+    <div class="flex flex-row items-baseline justify-between gap-2">
+      <p class="text-zinc-800 dark:text-zinc-100 text-lg font-semibold">{{ t("title") }}</p>
+      <Btn :to="menu.source_url" variant="link" size="text-xs gap-1 rounded">
+        {{ t("source") }}
+        <MdiIcon :path="mdiOpenInNew" :size="14" class="my-auto" aria-hidden="true" />
+      </Btn>
+    </div>
+
+    <div class="bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 rounded-sm border">
+      <div v-if="headlineDay" class="border-zinc-200 dark:border-zinc-700 border-b p-3">
+        <p class="text-zinc-800 dark:text-zinc-100 mb-2 flex items-center gap-1.5 font-medium">
+          <MdiIcon :path="mdiSilverwareForkKnife" :size="16" class="shrink-0" aria-hidden="true" />
+          <span>
+            {{ headlineIsToday ? t("today") : t("next_open", { day: formatDayLabel(headlineDay.date) }) }}
+          </span>
+        </p>
+        <ul class="flex flex-col gap-2.5">
+          <li v-for="(dish, index) in headlineDay.dishes" :key="index" class="flex flex-col gap-1">
+            <div class="flex flex-row items-baseline justify-between gap-3">
+              <p class="text-zinc-800 dark:text-zinc-100 text-sm font-medium">{{ dish.name }}</p>
+              <p v-if="dish.dish_type" class="text-zinc-500 dark:text-zinc-400 shrink-0 text-xs">
+                {{ dish.dish_type }}
+              </p>
+            </div>
+            <ul class="text-zinc-600 dark:text-zinc-300 flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
+              <template v-for="role in ROLES" :key="role">
+                <li v-if="dish.prices[role]">
+                  <span class="text-zinc-500 dark:text-zinc-400">{{ t(`role.${role}`) }}:</span>
+                  {{ formatPrice(dish.prices[role]!) }}
+                </li>
+              </template>
+            </ul>
+            <ul v-if="dish.labels.length" class="flex flex-wrap gap-1">
+              <li
+                v-for="code in dish.labels"
+                :key="code"
+                :title="labelText(code, labelLocale)"
+                class="bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 rounded px-1.5 py-0.5 text-[10px] tracking-wide uppercase"
+              >
+                {{ labelText(code, labelLocale) }}
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <p v-else class="text-zinc-500 dark:text-zinc-400 p-3 text-sm">{{ t("no_menu") }}</p>
+
+      <button
+        v-if="remainingDays.length"
+        type="button"
+        class="focusable flex w-full items-center gap-3 p-3 text-left"
+        :aria-expanded="expanded"
+        @click="toggleExpanded()"
+      >
+        <span class="text-zinc-800 dark:text-zinc-100 font-medium">
+          {{ expanded ? t("hide_week") : t("show_week", remainingDays.length) }}
+        </span>
+        <span class="flex-1" />
+        <MdiIcon
+          :path="mdiChevronDown"
+          :size="18"
+          class="text-zinc-500 dark:text-zinc-400 shrink-0 transition-transform"
+          :class="{ 'rotate-180': expanded }"
+          aria-hidden="true"
+        />
+      </button>
+      <div
+        v-if="expanded"
+        class="border-zinc-200 dark:border-zinc-700 flex flex-col gap-4 border-t p-3"
+      >
+        <div v-for="day in remainingDays" :key="day.date" class="flex flex-col gap-2.5">
+          <p class="text-zinc-700 dark:text-zinc-200 font-medium">{{ formatDayLabel(day.date) }}</p>
+          <ul class="flex flex-col gap-2.5">
+            <li v-for="(dish, index) in day.dishes" :key="index" class="flex flex-col gap-1">
+              <div class="flex flex-row items-baseline justify-between gap-3">
+                <p class="text-zinc-800 dark:text-zinc-100 text-sm font-medium">{{ dish.name }}</p>
+                <p v-if="dish.dish_type" class="text-zinc-500 dark:text-zinc-400 shrink-0 text-xs">
+                  {{ dish.dish_type }}
+                </p>
+              </div>
+              <ul class="text-zinc-600 dark:text-zinc-300 flex flex-wrap gap-x-3 gap-y-0.5 text-xs">
+                <template v-for="role in ROLES" :key="role">
+                  <li v-if="dish.prices[role]">
+                    <span class="text-zinc-500 dark:text-zinc-400">{{ t(`role.${role}`) }}:</span>
+                    {{ formatPrice(dish.prices[role]!) }}
+                  </li>
+                </template>
+              </ul>
+              <ul v-if="dish.labels.length" class="flex flex-wrap gap-1">
+                <li
+                  v-for="code in dish.labels"
+                  :key="code"
+                  :title="labelText(code, labelLocale)"
+                  class="bg-zinc-200 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200 rounded px-1.5 py-0.5 text-[10px] tracking-wide uppercase"
+                >
+                  {{ labelText(code, labelLocale) }}
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <small class="text-zinc-500 dark:text-zinc-400">
+      {{ t("last_updated", { date: lastUpdated }) }}
+    </small>
+  </section>
+</template>
+
+<i18n lang="yaml">
+de:
+  title: Speisekarte
+  source: Quelle
+  today: Heute
+  next_open: "Nächste Öffnung: {day}"
+  no_menu: Diese Woche kein Speiseplan online.
+  show_week: "noch ein weiterer Tag | noch {count} weitere Tage"
+  hide_week: Weitere Tage ausblenden
+  last_updated: "zuletzt aktualisiert am {date}"
+  price_with_unit: "{base} + {perUnit}/{unit}"
+  role:
+    students: Studierende
+    staff: Bedienstete
+    guests: Gäste
+en:
+  title: Menu
+  source: Source
+  today: Today
+  next_open: "Next opening: {day}"
+  no_menu: No menu published for this week.
+  show_week: "one more day | {count} more days"
+  hide_week: Hide additional days
+  last_updated: "last updated on {date}"
+  price_with_unit: "{base} + {perUnit}/{unit}"
+  role:
+    students: Students
+    staff: Staff
+    guests: Guests
+</i18n>

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -8,7 +8,9 @@ import { wallTimeToRfc3339 } from "~/utils/datetime";
 
 type BuildingKind = components["schemas"]["BuildingKind"];
 // openapi-typescript marks everything readonly, but the builders below produce fresh literals destined for the writable EditRequest map.
-export type Addition = DeepWritable<components["schemas"]["LimitedHashMap_String_Addition"][string]>;
+export type Addition = DeepWritable<
+  components["schemas"]["LimitedHashMap_String_Addition"][string]
+>;
 
 const MAX_NAME_LEN = 200;
 const MAX_POI_KEY_LEN = 64;

--- a/webclient/app/composables/feedbackSubmission.ts
+++ b/webclient/app/composables/feedbackSubmission.ts
@@ -45,8 +45,7 @@ const MESSAGES = {
           "Vorschläge senden ist aktuell nicht möglich aufgrund von rate-limiting. Bitte versuche es später nochmal oder schreibe eine Mail.",
         feedback_not_configured:
           "Das Senden von Vorschlägen ist auf dem Server aktuell nicht konfiguriert.",
-        token_unexpected_status:
-          "Unerwarteter Status Code beim Abrufen eines Feedback Tokens: ",
+        token_unexpected_status: "Unerwarteter Status Code beim Abrufen eines Feedback Tokens: ",
         token_req_failed:
           "Unerwarteter Fehler beim Laden des Bearbeitungsformulars. Das Senden von Vorschlägen ist gerade vermutlich nicht möglich. Bitte schreibe stattdessen eine Mail.",
       },
@@ -66,8 +65,7 @@ const MESSAGES = {
         server_error: "Server Error",
         too_many_requests:
           "Sending proposals is currently not possible due to rate-limiting. Please try again in a while or send a mail.",
-        feedback_not_configured:
-          "Sending proposals is currently not configured on the server.",
+        feedback_not_configured: "Sending proposals is currently not configured on the server.",
         token_unexpected_status: "Unexpected status code when retrieving a feedback token",
         token_req_failed:
           "Unexpected error when loading the edit proposal form. Sending proposals is currently probably not possible. Please send a mail instead.",
@@ -82,9 +80,9 @@ export function useFeedbackSubmission() {
   i18n.mergeLocaleMessage("de", MESSAGES.de);
   i18n.mergeLocaleMessage("en", MESSAGES.en);
   const t = (key: string) => i18n.t(`feedbackSubmission.${key}`);
-  const { error: tokenError, token } = useFeedbackToken(
-    ((key: string) => t(key)) as ReturnType<typeof useI18n>["t"]
-  );
+  const { error: tokenError, token } = useFeedbackToken(((key: string) => t(key)) as ReturnType<
+    typeof useI18n
+  >["t"]);
   const runtimeConfig = useRuntimeConfig();
 
   const submitting = ref(false);

--- a/webclient/app/data/eat_api_labels.json
+++ b/webclient/app/data/eat_api_labels.json
@@ -1,0 +1,143 @@
+[
+  {
+    "enum_name": "GLUTEN",
+    "text": { "DE": "Gluten", "EN": "gluten-containing cereals" },
+    "abbreviation": "Gl"
+  },
+  { "enum_name": "WHEAT", "text": { "DE": "Weizen", "EN": "wheat" }, "abbreviation": "GlW" },
+  { "enum_name": "RYE", "text": { "DE": "Roggen", "EN": "rye" }, "abbreviation": "GlR" },
+  { "enum_name": "BARLEY", "text": { "DE": "Gerste", "EN": "barley" }, "abbreviation": "GlG" },
+  { "enum_name": "OAT", "text": { "DE": "Hafer", "EN": "oat" }, "abbreviation": "GlH" },
+  { "enum_name": "SPELT", "text": { "DE": "Dinkel", "EN": "spelt" }, "abbreviation": "GlD" },
+  {
+    "enum_name": "HYBRIDS",
+    "text": { "DE": "Hybridstämme", "EN": "hybrid strains" },
+    "abbreviation": "GlHy"
+  },
+  {
+    "enum_name": "SHELLFISH",
+    "text": { "DE": "Krebstiere", "EN": "shellfish" },
+    "abbreviation": "Kr"
+  },
+  { "enum_name": "CHICKEN_EGGS", "text": { "DE": "Eier", "EN": "egg" }, "abbreviation": "Ei" },
+  { "enum_name": "FISH", "text": { "DE": "Fisch", "EN": "fish" }, "abbreviation": "Fi" },
+  { "enum_name": "PEANUTS", "text": { "DE": "Erdnüsse", "EN": "peanut" }, "abbreviation": "Er" },
+  { "enum_name": "SOY", "text": { "DE": "Soja", "EN": "soy" }, "abbreviation": "So" },
+  { "enum_name": "MILK", "text": { "DE": "Milch", "EN": "milk" }, "abbreviation": "Mi" },
+  { "enum_name": "LACTOSE", "text": { "DE": "Laktose", "EN": "lactose" }, "abbreviation": "La" },
+  { "enum_name": "ALMONDS", "text": { "DE": "Mandeln", "EN": "almonds" }, "abbreviation": "ScM" },
+  {
+    "enum_name": "HAZELNUTS",
+    "text": { "DE": "Haselnüsse", "EN": "hazelnuts" },
+    "abbreviation": "ScH"
+  },
+  { "enum_name": "WALNUTS", "text": { "DE": "Walnüsse", "EN": "walnuts" }, "abbreviation": "ScW" },
+  {
+    "enum_name": "CASHEWS",
+    "text": { "DE": "Cashewnüsse", "EN": "cashews" },
+    "abbreviation": "ScC"
+  },
+  { "enum_name": "PECAN", "text": { "DE": "Pekannüsse", "EN": "pecans" }, "abbreviation": "ScP" },
+  {
+    "enum_name": "PISTACHIOS",
+    "text": { "DE": "Pistazien", "EN": "pistachios" },
+    "abbreviation": "ScPi"
+  },
+  {
+    "enum_name": "MACADAMIA",
+    "text": { "DE": "Macadamianüsse", "EN": "macadamias" },
+    "abbreviation": "ScMa"
+  },
+  { "enum_name": "CELERY", "text": { "DE": "Sellerie", "EN": "celery" }, "abbreviation": "Sl" },
+  { "enum_name": "MUSTARD", "text": { "DE": "Senf", "EN": "mustard" }, "abbreviation": "Sf" },
+  { "enum_name": "SESAME", "text": { "DE": "Sesam", "EN": "sesame" }, "abbreviation": "Se" },
+  {
+    "enum_name": "SULPHURS",
+    "text": { "DE": "Schwefeldioxid", "EN": "sulphurs" },
+    "abbreviation": "Su"
+  },
+  { "enum_name": "SULFITES", "text": { "DE": "Sulfite", "EN": "sulfites" }, "abbreviation": "Sw" },
+  { "enum_name": "LUPIN", "text": { "DE": "Lupine", "EN": "lupin" }, "abbreviation": "Lu" },
+  {
+    "enum_name": "MOLLUSCS",
+    "text": { "DE": "Weichtiere", "EN": "molluscs" },
+    "abbreviation": "Wt"
+  },
+  {
+    "enum_name": "SHELL_FRUITS",
+    "text": { "DE": "Schalenfrüchte", "EN": "shell fruits" },
+    "abbreviation": "Sc"
+  },
+  {
+    "enum_name": "BAVARIA",
+    "text": { "DE": "Zertifizierte Qualität Bayern", "EN": "Certified quality Bavaria" },
+    "abbreviation": "GQB"
+  },
+  {
+    "enum_name": "MSC",
+    "text": { "DE": "Marine Stewardship Council", "EN": "Marine Stewardship Council" },
+    "abbreviation": "MSC"
+  },
+  {
+    "enum_name": "DYESTUFF",
+    "text": { "DE": "Farbstoffe", "EN": "dyestuff" },
+    "abbreviation": "1"
+  },
+  {
+    "enum_name": "PRESERVATIVES",
+    "text": { "DE": "Konservierungsstoffe", "EN": "preservatives" },
+    "abbreviation": "2"
+  },
+  {
+    "enum_name": "ANTIOXIDANTS",
+    "text": { "DE": "Antioxidantien", "EN": "antioxidants" },
+    "abbreviation": "3"
+  },
+  {
+    "enum_name": "FLAVOR_ENHANCER",
+    "text": { "DE": "Geschmacksverstärker", "EN": "flavor enhancer" },
+    "abbreviation": "4"
+  },
+  { "enum_name": "WAXED", "text": { "DE": "Gewachst", "EN": "waxed" }, "abbreviation": "5" },
+  {
+    "enum_name": "PHOSPHATES",
+    "text": { "DE": "Phosphate", "EN": "phosphates" },
+    "abbreviation": "6"
+  },
+  {
+    "enum_name": "SWEETENERS",
+    "text": { "DE": "Süßungsmittel", "EN": "sweeteners" },
+    "abbreviation": "7"
+  },
+  {
+    "enum_name": "PHENYLALANINE",
+    "text": { "DE": "Phenylalanin", "EN": "with a source of phenylalanine" },
+    "abbreviation": "8"
+  },
+  {
+    "enum_name": "COCOA_CONTAINING_GREASE",
+    "text": { "DE": "Kakaohaltiges Fett", "EN": "cocoa-containing grease" },
+    "abbreviation": "9"
+  },
+  { "enum_name": "GELATIN", "text": { "DE": "Gelatine", "EN": "gelatin" }, "abbreviation": "Ge" },
+  { "enum_name": "ALCOHOL", "text": { "DE": "Alkohol", "EN": "alcohol" }, "abbreviation": "Al" },
+  { "enum_name": "PORK", "text": { "DE": "Schweinefleisch", "EN": "pork" }, "abbreviation": "S" },
+  { "enum_name": "BEEF", "text": { "DE": "Rinderfleisch", "EN": "beef" }, "abbreviation": "R" },
+  { "enum_name": "VEAL", "text": { "DE": "Kalbsfleisch", "EN": "veal" }, "abbreviation": "Ka" },
+  {
+    "enum_name": "WILD_MEAT",
+    "text": { "DE": "Wildfleisch", "EN": "wild meat" },
+    "abbreviation": "Wi"
+  },
+  { "enum_name": "LAMB", "text": { "DE": "Lammfleisch", "EN": "lamb" }, "abbreviation": "Lm" },
+  { "enum_name": "GARLIC", "text": { "DE": "Knoblauch", "EN": "garlic" }, "abbreviation": "Kn" },
+  { "enum_name": "POULTRY", "text": { "DE": "Geflügel", "EN": "poultry" }, "abbreviation": "Ge" },
+  { "enum_name": "CEREAL", "text": { "DE": "Getreide", "EN": "cereal" }, "abbreviation": "Ce" },
+  { "enum_name": "MEAT", "text": { "DE": "Fleisch", "EN": "meat" }, "abbreviation": "F" },
+  { "enum_name": "VEGAN", "text": { "DE": "Vegan", "EN": "vegan" }, "abbreviation": "Vn" },
+  {
+    "enum_name": "VEGETARIAN",
+    "text": { "DE": "Vegetarisch", "EN": "vegetarian" },
+    "abbreviation": "Vg"
+  }
+]

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -65,11 +65,19 @@ type OpacityValue = AllPaintProperties[OpacityProp];
 const PER_FEATURE_TARGETS = [
   { id: "indoor-pois", prop: "icon-opacity", type: "symbol" },
   { id: "indoor-rooms", prop: "fill-opacity", type: "fill" },
-] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
+] as const satisfies readonly {
+  readonly id: string;
+  readonly prop: OpacityProp;
+  readonly type: string;
+}[];
 // Indoor content with no per-feature meaning: dim wholesale while a filter is active.
 const FLAT_TARGETS = [
   { id: "indoor-pois", prop: "text-opacity", type: "symbol" },
-] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
+] as const satisfies readonly {
+  readonly id: string;
+  readonly prop: OpacityProp;
+  readonly type: string;
+}[];
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);

--- a/webclient/app/utils/eatApiLabels.ts
+++ b/webclient/app/utils/eatApiLabels.ts
@@ -1,0 +1,33 @@
+// Allergen, ingredient, and certification labels emitted by the TUM-Dev eat-api in their
+// `enum_name` form. The JSON next to this module mirrors `enums/labels.json` from
+// `https://tum-dev.github.io/eat-api/` verbatim so a refresh is a literal file copy rather
+// than a hand-merge. Vite inlines the JSON at build time, so visitors do not pay a
+// 3rd-party round-trip (which would also need the privacy disclosure).
+//
+// Unknown codes degrade gracefully to their raw upstream form.
+
+import labelsJson from "~/data/eat_api_labels.json";
+
+interface RawLabel {
+  readonly enum_name: string;
+  readonly text: { readonly DE: string; readonly EN: string };
+  readonly abbreviation: string;
+}
+
+export type EatApiLocale = "de" | "en";
+
+const BY_CODE: ReadonlyMap<string, RawLabel> = new Map(
+  (labelsJson as readonly RawLabel[]).map((label) => [label.enum_name, label])
+);
+
+/** Resolve a label code to its localized text, falling back to the raw code when unknown. */
+export function labelText(code: string, locale: EatApiLocale): string {
+  const entry = BY_CODE.get(code);
+  if (!entry) return code;
+  return locale === "de" ? entry.text.DE : entry.text.EN;
+}
+
+/** Resolve a label code to upstream's short abbreviation, or the raw code when unknown. */
+export function labelAbbreviation(code: string): string {
+  return BY_CODE.get(code)?.abbreviation ?? code;
+}


### PR DESCRIPTION
Test plan: `uv run pytest data/external/schemas/test_schemas_eat_api_menus.py data/processors/test_eat_api_menus.py`.