### PR TITLE
ci: run the map e2e spec in the ui-test matrix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -144,7 +144,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium]
-        subsystem: [main, search, navigation, details, calendar-about]
+        subsystem: [main, search, navigation, details, calendar-about, map]
 
     steps:
       - uses: BRAINSia/free-disk-space@7048ffbf50819342ac964ef3998a51c2564a8a75 # v2.1.3

--- a/webclient/app/components/AddProposalForm.vue
+++ b/webclient/app/components/AddProposalForm.vue
@@ -234,9 +234,11 @@ function displayNameOf(draft: AdditionDraft): string {
 
 type Addition = ReturnType<typeof buildAddition>;
 
-function validateAndBuild():
-  | { id: string; displayName: string; addition: NonNullable<Addition> }
-  | null {
+function validateAndBuild(): {
+  id: string;
+  displayName: string;
+  addition: NonNullable<Addition>;
+} | null {
   localError.value = "";
   const draft = editProposal.value.pendingAddition;
   const id = draft.id.trim();

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -8,7 +8,9 @@ import { wallTimeToRfc3339 } from "~/utils/datetime";
 
 type BuildingKind = components["schemas"]["BuildingKind"];
 // openapi-typescript marks everything readonly, but the builders below produce fresh literals destined for the writable EditRequest map.
-export type Addition = DeepWritable<components["schemas"]["LimitedHashMap_String_Addition"][string]>;
+export type Addition = DeepWritable<
+  components["schemas"]["LimitedHashMap_String_Addition"][string]
+>;
 
 const MAX_NAME_LEN = 200;
 const MAX_POI_KEY_LEN = 64;

--- a/webclient/app/composables/feedbackSubmission.ts
+++ b/webclient/app/composables/feedbackSubmission.ts
@@ -45,8 +45,7 @@ const MESSAGES = {
           "Vorschläge senden ist aktuell nicht möglich aufgrund von rate-limiting. Bitte versuche es später nochmal oder schreibe eine Mail.",
         feedback_not_configured:
           "Das Senden von Vorschlägen ist auf dem Server aktuell nicht konfiguriert.",
-        token_unexpected_status:
-          "Unerwarteter Status Code beim Abrufen eines Feedback Tokens: ",
+        token_unexpected_status: "Unerwarteter Status Code beim Abrufen eines Feedback Tokens: ",
         token_req_failed:
           "Unerwarteter Fehler beim Laden des Bearbeitungsformulars. Das Senden von Vorschlägen ist gerade vermutlich nicht möglich. Bitte schreibe stattdessen eine Mail.",
       },
@@ -66,8 +65,7 @@ const MESSAGES = {
         server_error: "Server Error",
         too_many_requests:
           "Sending proposals is currently not possible due to rate-limiting. Please try again in a while or send a mail.",
-        feedback_not_configured:
-          "Sending proposals is currently not configured on the server.",
+        feedback_not_configured: "Sending proposals is currently not configured on the server.",
         token_unexpected_status: "Unexpected status code when retrieving a feedback token",
         token_req_failed:
           "Unexpected error when loading the edit proposal form. Sending proposals is currently probably not possible. Please send a mail instead.",
@@ -82,9 +80,9 @@ export function useFeedbackSubmission() {
   i18n.mergeLocaleMessage("de", MESSAGES.de);
   i18n.mergeLocaleMessage("en", MESSAGES.en);
   const t = (key: string) => i18n.t(`feedbackSubmission.${key}`);
-  const { error: tokenError, token } = useFeedbackToken(
-    ((key: string) => t(key)) as ReturnType<typeof useI18n>["t"]
-  );
+  const { error: tokenError, token } = useFeedbackToken(((key: string) => t(key)) as ReturnType<
+    typeof useI18n
+  >["t"]);
   const runtimeConfig = useRuntimeConfig();
 
   const submitting = ref(false);

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -65,11 +65,19 @@ type OpacityValue = AllPaintProperties[OpacityProp];
 const PER_FEATURE_TARGETS = [
   { id: "indoor-pois", prop: "icon-opacity", type: "symbol" },
   { id: "indoor-rooms", prop: "fill-opacity", type: "fill" },
-] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
+] as const satisfies readonly {
+  readonly id: string;
+  readonly prop: OpacityProp;
+  readonly type: string;
+}[];
 // Indoor content with no per-feature meaning: dim wholesale while a filter is active.
 const FLAT_TARGETS = [
   { id: "indoor-pois", prop: "text-opacity", type: "symbol" },
-] as const satisfies readonly { readonly id: string; readonly prop: OpacityProp; readonly type: string }[];
+] as const satisfies readonly {
+  readonly id: string;
+  readonly prop: OpacityProp;
+  readonly type: string;
+}[];
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);


### PR DESCRIPTION
`tests/specs/map.ui.spec.ts` was added in #3217 and extended with the events-layer acceptance tests in #3227, but it was never added to the e2e `subsystem` matrix — so none of the /map tests (layer panel, WC popup, events toggle, `?events_window=` time window) actually run in CI. A matrix entry was part of the #3227 branch, but the squash-merge happened before that push landed.

Verified locally against current `main` (with the #3228 `setWorkerUrl` fix): the full spec passes 9/9 via `BASE_URL=… SKIP_WEBSERVER=1 pnpm test specs/map.ui.spec.ts --project=ui-tests-chromium`. The spec stubs the Martin basemap style, so it has no dependency on live tile data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)