### PR TITLE
docs(webclient): glossary and /map URL contract from #3162 grill

### DIFF
--- a/webclient/CONTEXT.md
+++ b/webclient/CONTEXT.md
@@ -1,58 +1,32 @@
 # Webclient
 
-The Nuxt 4 / Vue 3 frontend. Glossary for terms whose meaning is specific to NavigaTUM's UI vocabulary.
+Glossary for the Nuxt 4 / Vue 3 frontend.
 
 ## Language
 
-### Map surfaces
+**Browse map**: `/map`. Category-filtered, no entity identity.
+_Avoid_: "the map page".
 
-**Browse map**:
-The `/map` page. A Category-driven exploration surface, stateless about any one Entity. Owns the filter panel.
-_Avoid_: "the map page" - ambiguous against the Detail map.
+**Detail map**: `DetailsInteractiveMap` on `/{type}/{id}`. Anchored on one Entity's coords.
+_Avoid_: "interactive map" alone.
 
-**Detail map**:
-The `DetailsInteractiveMap` embedded on `/{type}/{id}`. Anchored on one Entity's `coords`.
-_Avoid_: "interactive map" alone - every map here is interactive.
+**Entity**: routable thing with a detail page (campus, site, area, building, joined building, room, virtual room, POI). Resolved via `entityPath()`.
+_Avoid_: "item", "result".
 
-### Search results
+**Category**: a class of Entities exposed as a Browse-map filter. Defined in `FILTER_REGISTRY` (`composables/mapLayers.ts`).
+_Avoid_: "type" - `type` is the API entity discriminator.
 
-**Entity**:
-A routable thing with a detail page; resolved via `entityPath()` (campus, site, area, building, joined building, room, virtual room, POI).
-_Avoid_: "item", "result" - both also cover non-routable hits.
+**Address result**: Nominatim hit in the `addresses` search section. Not an Entity (no id, no detail page).
 
-**Category**:
-A class of Entities exposed as a Browse-map filter. Defined in `FILTER_REGISTRY` (`composables/mapLayers.ts`).
-_Avoid_: "type" - `type` is the API entity discriminator, not the filter taxonomy.
+**Category bridge**: inline link on a detail page whose Entity has a Category → `/map?filter=<id>`.
 
-**Address result**:
-A Nominatim hit in the `addresses` search section. No NavigaTUM id, no detail page; only surfaced on `/navigate`.
-_Avoid_: treating it as an Entity.
+**Explore-here bridge**: inline link in a detail-page listing section (rooms-of-building, …) → `/map#zoom/lat/lng` from the parent's coords.
 
-### Detail ↔ Browse bridges
-
-The detail page never links to the Browse map as a page-level CTA. Three narrow inline-link exceptions exist, all modelled on the "via Transitous" pill in `DetailsNearbyTransportSection.vue`:
-
-**Category bridge**:
-Inline link on a detail page whose Entity belongs to a Category. Opens the Browse map with that filter applied; wording is Category-shaped ("Show all toilets on the map").
-
-**Explore-here bridge**:
-Inline link in a *listing* section of a detail page (rooms-of-building, buildings-of-area, …). Opens the Browse map framed on the parent Entity's coords.
-
-**Category shortcut**:
-Top entry in search results (`AppSearchBar` dropdown and `/search`) when a query token matches a Category's keyword list. Links to the Browse map with that filter applied. Keyword lists are intentionally broad - multilingual synonyms and common misspellings - so the shortcut fires on natural queries.
+**Category shortcut**: top entry in search results when a query token matches a Category's keyword list → `/map?filter=<id>`. Keyword lists are broad: synonyms + misspellings, both languages.
 
 ## Relationships
 
-- An Entity has at most one Detail map; belongs to zero or one Category.
-- A Browse-map filter selects by Category, never by Entity identity.
-- Category bridge gates on Category membership; Explore-here bridge gates on listed children.
-
-## Example dialogue
-
-> **Dev:** "Should 'Show on map' on a toilet search result open the Browse map or the Detail map?"
-> **Domain expert:** "Neither directly - the Detail map is one click away through the row's detail link. The Browse map link from a toilet would be a Category bridge: 'all toilets', not 'this toilet.'"
-
-## Flagged ambiguities
-
-- "map" was used ambiguously between the Browse map and the Detail map in #3162 - resolved: distinct surfaces, distinct intents (explore vs. inspect).
-- "Show on map" was used loosely - resolved: it is a Category or Explore-here bridge, never an entity-focus operation.
+- Entity ↔ Detail map: at most one.
+- Entity ↔ Category: zero or one.
+- Browse-map filter selects by Category, never by Entity.
+- Bridges and shortcut all use `DetailsNearbyTransportSection.vue`'s inline-pill pattern; no page-level CTAs.

--- a/webclient/CONTEXT.md
+++ b/webclient/CONTEXT.md
@@ -1,0 +1,58 @@
+# Webclient
+
+The Nuxt 4 / Vue 3 frontend. Glossary for terms whose meaning is specific to NavigaTUM's UI vocabulary.
+
+## Language
+
+### Map surfaces
+
+**Browse map**:
+The `/map` page. A Category-driven exploration surface, stateless about any one Entity. Owns the filter panel.
+_Avoid_: "the map page" — ambiguous against the Detail map.
+
+**Detail map**:
+The `DetailsInteractiveMap` embedded on `/{type}/{id}`. Anchored on one Entity's `coords`.
+_Avoid_: "interactive map" alone — every map here is interactive.
+
+### Search results
+
+**Entity**:
+A routable thing with a detail page; resolved via `entityPath()` (campus, site, area, building, joined building, room, virtual room, POI).
+_Avoid_: "item", "result" — both also cover non-routable hits.
+
+**Category**:
+A class of Entities exposed as a Browse-map filter. Defined in `FILTER_REGISTRY` (`composables/mapLayers.ts`).
+_Avoid_: "type" — `type` is the API entity discriminator, not the filter taxonomy.
+
+**Address result**:
+A Nominatim hit in the `addresses` search section. No NavigaTUM id, no detail page; only surfaced on `/navigate`.
+_Avoid_: treating it as an Entity.
+
+### Detail ↔ Browse bridges
+
+The detail page never links to the Browse map as a page-level CTA. Three narrow inline-link exceptions exist, all modelled on the "via Transitous" pill in `DetailsNearbyTransportSection.vue`:
+
+**Category bridge**:
+Inline link on a detail page whose Entity belongs to a Category. Opens the Browse map with that filter applied; wording is Category-shaped ("Show all toilets on the map").
+
+**Explore-here bridge**:
+Inline link in a *listing* section of a detail page (rooms-of-building, buildings-of-area, …). Opens the Browse map framed on the parent Entity's coords.
+
+**Category shortcut**:
+Top entry in search results (`AppSearchBar` dropdown and `/search`) when a query token matches a Category's keyword list. Links to the Browse map with that filter applied. Keyword lists are intentionally broad — multilingual synonyms and common misspellings — so the shortcut fires on natural queries.
+
+## Relationships
+
+- An Entity has at most one Detail map; belongs to zero or one Category.
+- A Browse-map filter selects by Category, never by Entity identity.
+- Category bridge gates on Category membership; Explore-here bridge gates on listed children.
+
+## Example dialogue
+
+> **Dev:** "Should 'Show on map' on a toilet search result open the Browse map or the Detail map?"
+> **Domain expert:** "Neither directly — the Detail map is one click away through the row's detail link. The Browse map link from a toilet would be a Category bridge: 'all toilets', not 'this toilet.'"
+
+## Flagged ambiguities
+
+- "map" was used ambiguously between the Browse map and the Detail map in #3162 — resolved: distinct surfaces, distinct intents (explore vs. inspect).
+- "Show on map" was used loosely — resolved: it is a Category or Explore-here bridge, never an entity-focus operation.

--- a/webclient/CONTEXT.md
+++ b/webclient/CONTEXT.md
@@ -8,21 +8,21 @@ The Nuxt 4 / Vue 3 frontend. Glossary for terms whose meaning is specific to Nav
 
 **Browse map**:
 The `/map` page. A Category-driven exploration surface, stateless about any one Entity. Owns the filter panel.
-_Avoid_: "the map page" — ambiguous against the Detail map.
+_Avoid_: "the map page" - ambiguous against the Detail map.
 
 **Detail map**:
 The `DetailsInteractiveMap` embedded on `/{type}/{id}`. Anchored on one Entity's `coords`.
-_Avoid_: "interactive map" alone — every map here is interactive.
+_Avoid_: "interactive map" alone - every map here is interactive.
 
 ### Search results
 
 **Entity**:
 A routable thing with a detail page; resolved via `entityPath()` (campus, site, area, building, joined building, room, virtual room, POI).
-_Avoid_: "item", "result" — both also cover non-routable hits.
+_Avoid_: "item", "result" - both also cover non-routable hits.
 
 **Category**:
 A class of Entities exposed as a Browse-map filter. Defined in `FILTER_REGISTRY` (`composables/mapLayers.ts`).
-_Avoid_: "type" — `type` is the API entity discriminator, not the filter taxonomy.
+_Avoid_: "type" - `type` is the API entity discriminator, not the filter taxonomy.
 
 **Address result**:
 A Nominatim hit in the `addresses` search section. No NavigaTUM id, no detail page; only surfaced on `/navigate`.
@@ -39,7 +39,7 @@ Inline link on a detail page whose Entity belongs to a Category. Opens the Brows
 Inline link in a *listing* section of a detail page (rooms-of-building, buildings-of-area, …). Opens the Browse map framed on the parent Entity's coords.
 
 **Category shortcut**:
-Top entry in search results (`AppSearchBar` dropdown and `/search`) when a query token matches a Category's keyword list. Links to the Browse map with that filter applied. Keyword lists are intentionally broad — multilingual synonyms and common misspellings — so the shortcut fires on natural queries.
+Top entry in search results (`AppSearchBar` dropdown and `/search`) when a query token matches a Category's keyword list. Links to the Browse map with that filter applied. Keyword lists are intentionally broad - multilingual synonyms and common misspellings - so the shortcut fires on natural queries.
 
 ## Relationships
 
@@ -50,9 +50,9 @@ Top entry in search results (`AppSearchBar` dropdown and `/search`) when a query
 ## Example dialogue
 
 > **Dev:** "Should 'Show on map' on a toilet search result open the Browse map or the Detail map?"
-> **Domain expert:** "Neither directly — the Detail map is one click away through the row's detail link. The Browse map link from a toilet would be a Category bridge: 'all toilets', not 'this toilet.'"
+> **Domain expert:** "Neither directly - the Detail map is one click away through the row's detail link. The Browse map link from a toilet would be a Category bridge: 'all toilets', not 'this toilet.'"
 
 ## Flagged ambiguities
 
-- "map" was used ambiguously between the Browse map and the Detail map in #3162 — resolved: distinct surfaces, distinct intents (explore vs. inspect).
-- "Show on map" was used loosely — resolved: it is a Category or Explore-here bridge, never an entity-focus operation.
+- "map" was used ambiguously between the Browse map and the Detail map in #3162 - resolved: distinct surfaces, distinct intents (explore vs. inspect).
+- "Show on map" was used loosely - resolved: it is a Category or Explore-here bridge, never an entity-focus operation.

--- a/webclient/docs/adr/0001-browse-map-url-contract.md
+++ b/webclient/docs/adr/0001-browse-map-url-contract.md
@@ -1,15 +1,3 @@
 # `/map` URL contract: viewport + filter, no identity
 
-The Browse map's URL is **MapLibre `#zoom/lat/lng` hash + `?filter=` + `?level=`** - no `focus_id`, no entity identity. Bridges from search and detail pages encode the parent Entity's `coords` directly in the hash, so links are resolvable client-side from data the source page already has. Identity is the detail page's job (`/{type}/{id}`); the Browse map stays a stateless explore surface.
-
-## Considered options
-
-- **Coords-only** (chosen). No new contract; no API call on Browse-map load; sidesteps the OSM-POI-has-no-NavigaTUM-id problem because we never claim identity here.
-- **`?focus=<id>`**. Adds a server round-trip and a loading state to a page that is currently zero-API-call, and forces an id-space decision (NavigaTUM / OSM / event). Layerable later as an additive enhancement if highlights become wanted.
-- **Hybrid hash + `?focus=`**. Two contracts, marginal benefit while no highlight exists.
-
-## Consequences
-
-- All Browse-map links from elsewhere carry zero identity.
-- A future "highlight this entity" feature is an additive change, not a breaking redesign.
-- POI markers stay coordinate-anchored OSM features.
+`/map` is `#zoom/lat/lng` (MapLibre hash) + `?filter=` + `?level=`. No `focus_id`, no entity id. `/map` is the stateless explore surface; identity belongs to `/{type}/{id}`. Bridges from detail pages already encode the parent Entity's coords client-side, so `/map` makes no API call on load. A `?focus=<id>` resolving to a NavigaTUM id can be added later additively if highlights become wanted - POI markers carry their NavigaTUM id via the OSM `ref:tum` tag, not yet propagated through `style.lua` into the MVT.

--- a/webclient/docs/adr/0001-browse-map-url-contract.md
+++ b/webclient/docs/adr/0001-browse-map-url-contract.md
@@ -1,6 +1,6 @@
 # `/map` URL contract: viewport + filter, no identity
 
-The Browse map's URL is **MapLibre `#zoom/lat/lng` hash + `?filter=` + `?level=`** — no `focus_id`, no entity identity. Bridges from search and detail pages encode the parent Entity's `coords` directly in the hash, so links are resolvable client-side from data the source page already has. Identity is the detail page's job (`/{type}/{id}`); the Browse map stays a stateless explore surface.
+The Browse map's URL is **MapLibre `#zoom/lat/lng` hash + `?filter=` + `?level=`** - no `focus_id`, no entity identity. Bridges from search and detail pages encode the parent Entity's `coords` directly in the hash, so links are resolvable client-side from data the source page already has. Identity is the detail page's job (`/{type}/{id}`); the Browse map stays a stateless explore surface.
 
 ## Considered options
 

--- a/webclient/docs/adr/0001-browse-map-url-contract.md
+++ b/webclient/docs/adr/0001-browse-map-url-contract.md
@@ -1,0 +1,15 @@
+# `/map` URL contract: viewport + filter, no identity
+
+The Browse map's URL is **MapLibre `#zoom/lat/lng` hash + `?filter=` + `?level=`** — no `focus_id`, no entity identity. Bridges from search and detail pages encode the parent Entity's `coords` directly in the hash, so links are resolvable client-side from data the source page already has. Identity is the detail page's job (`/{type}/{id}`); the Browse map stays a stateless explore surface.
+
+## Considered options
+
+- **Coords-only** (chosen). No new contract; no API call on Browse-map load; sidesteps the OSM-POI-has-no-NavigaTUM-id problem because we never claim identity here.
+- **`?focus=<id>`**. Adds a server round-trip and a loading state to a page that is currently zero-API-call, and forces an id-space decision (NavigaTUM / OSM / event). Layerable later as an additive enhancement if highlights become wanted.
+- **Hybrid hash + `?focus=`**. Two contracts, marginal benefit while no highlight exists.
+
+## Consequences
+
+- All Browse-map links from elsewhere carry zero identity.
+- A future "highlight this entity" feature is an additive change, not a breaking redesign.
+- POI markers stay coordinate-anchored OSM features.


### PR DESCRIPTION
## Summary

- Adds `webclient/CONTEXT.md` — glossary for Browse map vs. Detail map, Entity, Category, Address result, and the three bridge types (Category bridge, Explore-here bridge, Category shortcut).
- Adds `webclient/docs/adr/0001-browse-map-url-contract.md` — records that `/map`'s URL contract is `viewport + ?filter= + ?level=`, no entity identity. Sidesteps the OSM-POI-has-no-NavigaTUM-id problem because the surface never claims identity.

Closes the design portion of #3162. Implementation slices follow in #3234 (search Category shortcut) and #3235 (detail-page bridges).

## Test plan

- [ ] Read `webclient/CONTEXT.md` cold and verify each term is one-glance distinguishable from its avoid-list aliases.
- [ ] Read ADR 0001 against the existing `/map` implementation in `webclient/app/pages/map.vue` and confirm the URL contract matches what already ships.
- [ ] Cross-check the bridge typology against the two follow-up issues (#3234, #3235) — every claim in the issues should trace back to a term in CONTEXT.md.