### PR TITLE
feat(webclient): drop the fullscreen map control, enlarge the others

### DIFF
--- a/tests/specs/details.ui.spec.ts
+++ b/tests/specs/details.ui.spec.ts
@@ -25,7 +25,7 @@ test.describe("Details Page - Interactive Map", () => {
   test("should display interactive map with controls", async ({ page }) => {
     // The interactive map fetches its style from the production Martin
     // tileserver. When that endpoint is unavailable (intermittent 404s),
-    // MapLibre never fires `load`, so the navigation/fullscreen controls
+    // MapLibre never fires `load`, so the navigation controls
     // are never added and the test fails for an upstream reason. Stub the
     // style with a minimal valid maplibre style so the controls render
     // regardless of the upstream tileserver state.
@@ -48,9 +48,7 @@ test.describe("Details Page - Interactive Map", () => {
     await expect(mapCanvas).toHaveCount(1);
     await expect(mapCanvas).toBeVisible();
 
-    const fullScreenButton = page.getByRole("button", { name: "Enter fullscreen" });
-    await expect(fullScreenButton).toBeVisible();
-    await expect(fullScreenButton).toHaveCount(1);
+    await expect(page.getByRole("button", { name: "Enter fullscreen" })).toHaveCount(0);
 
     const zoomInButton = page.getByRole("button", { name: "Zoom in" });
     await expect(zoomInButton).toBeVisible();

--- a/webclient/app/assets/css/main.css
+++ b/webclient/app/assets/css/main.css
@@ -91,3 +91,20 @@ body {
     min-width: 0;
   }
 }
+
+/* MapLibre's 29px control buttons are too easy to miss; 48px is the minimum
+   recommended touch-target size. FloorControl.ts mirrors this value.
+   Scoped under .maplibregl-control-container to outrank maplibre-gl.css, which
+   the map components import after this sheet. The root's .maplibregl-map class
+   cannot serve as the scope: Vue class bindings on the container wipe
+   externally-added classes. */
+:root {
+  --map-ctrl-button-size: 48px;
+}
+.maplibregl-control-container .maplibregl-ctrl-group button {
+  width: var(--map-ctrl-button-size);
+  height: var(--map-ctrl-button-size);
+}
+.maplibregl-control-container .maplibregl-ctrl button .maplibregl-ctrl-icon {
+  background-size: contain;
+}

--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { until } from "@vueuse/core";
 import {
-  FullscreenControl,
   GeolocateControl,
   type IControl,
   Map as MapLibreMap,
@@ -118,9 +117,6 @@ function initMap(containerId: string): MapLibreMap {
   map.on("load", () => {
     initialLoaded.value = true;
 
-    const fullscreenCtl = new FullscreenControl();
-    map.addControl(fullscreenCtl, "top-right");
-
     // controls
     const controls: IControl[] = [];
     if (!isMobile.value) {
@@ -217,20 +213,6 @@ onMounted(async () => {
   > div {
     padding-bottom: 75%; /* 4:3 aspect ratio */
   }
-
-  &.maximize {
-    position: absolute;
-    top: 60px;
-    left: 0;
-    width: 100%;
-    height: calc(100vh - 60px);
-    z-index: 1000;
-
-    > div {
-      padding-bottom: 0;
-      height: 100%;
-    }
-  }
 }
 
 .marker {
@@ -321,7 +303,7 @@ onMounted(async () => {
 
     & #floor-list {
       display: inline-block;
-      width: calc(100% - 29px);
+      width: calc(100% - var(--map-ctrl-button-size));
     }
 
     & button {

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
-import { useResizeObserver } from "@vueuse/core";
 import type { GeoJSONSource } from "maplibre-gl";
-import {
-  FullscreenControl,
-  GeolocateControl,
-  Map as MapLibreMap,
-  Marker,
-  NavigationControl,
-} from "maplibre-gl";
+import { GeolocateControl, Map as MapLibreMap, Marker, NavigationControl } from "maplibre-gl";
 import type { components } from "~/api_types";
 import { useSharedGeolocation } from "~/composables/geolocation";
-import { useIsMobile } from "~/composables/useIsMobile";
 import { useWebglGuard } from "~/composables/webglSupport";
 import { zoomForLocationType } from "~/utils/map";
 import {
@@ -44,17 +36,10 @@ const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
-const fullscreenContainerEl = ref<HTMLElement | null>(null);
 const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
-// Maplibre bug: the map doesn't update to the new size when changing between
-// fullscreen in the mobile version.
-useResizeObserver(fullscreenContainerEl, () => {
-  map.value?.resize();
-});
 
 // Geolocation state
 const geolocationState = useSharedGeolocation();
-const isMobileQuery = useIsMobile();
 
 // Motis routing state
 const highlightedLegIndex = ref<number | null>(null);
@@ -133,48 +118,6 @@ function initMap(containerId: string): MapLibreMap {
   // succeeded.
   map.on("load", () => {
     map.addControl(new NavigationControl({}), "top-left");
-
-    // (Browser) Fullscreen is enabled only on mobile, on desktop the map
-    // is maximized instead. This is determined once to select the correct
-    // container to maximize, and then remains unchanged even if the browser
-    // is resized (not relevant for users but for developers).
-    const isMobile = isMobileQuery.value;
-    const fullscreenContainer = isMobile
-      ? document.getElementById("interactive-indoor-map")
-      : document.getElementById("interactive-indoor-map-container");
-    const fullscreenCtl = new FullscreenControl({
-      container: fullscreenContainer as HTMLElement,
-    });
-    // "Backup" the maplibregl default fullscreen handler
-    const defaultOnClickFullscreen = fullscreenCtl._onClickFullscreen;
-    fullscreenCtl._onClickFullscreen = () => {
-      if (isMobile) defaultOnClickFullscreen();
-      else {
-        if (fullscreenCtl._container.classList.contains("maximize")) {
-          fullscreenCtl._container.classList.remove("maximize");
-          document.body.classList.remove("overflow-y-hidden");
-          fullscreenCtl._fullscreenButton.classList.remove("maplibregl-ctrl-shrink");
-        } else {
-          fullscreenCtl._container.classList.add("maximize");
-          fullscreenCtl._fullscreenButton.classList.add("maplibregl-ctrl-shrink");
-          document.body.classList.add("overflow-y-hidden");
-          window.scrollTo({ top: 0, behavior: "auto" });
-        }
-
-        fullscreenCtl._fullscreen = fullscreenCtl._container.classList.contains("maximize");
-        fullscreenCtl._fullscreenButton.ariaLabel = fullscreenCtl._fullscreen
-          ? "Exit fullscreen"
-          : "Enter fullscreen";
-        fullscreenCtl._fullscreenButton.title = fullscreenCtl._fullscreen
-          ? "Exit fullscreen"
-          : "Enter fullscreen";
-        fullscreenCtl._map.resize();
-      }
-    };
-    map.addControl(fullscreenCtl);
-    if (isMobile) {
-      fullscreenContainerEl.value = fullscreenCtl._container;
-    }
 
     const location = new GeolocateControl({
       positionOptions: {
@@ -583,14 +526,6 @@ defineExpose({
 
   > div {
     padding-bottom: 0;
-  }
-
-  &.maximize {
-    position: absolute;
-    top: 60px;
-    left: 0;
-    height: calc(100vh - 150px);
-    z-index: 1000;
   }
 }
 

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
 import { mdiMapMarkerPlus } from "@mdi/js";
 import { until } from "@vueuse/core";
-import {
-  FullscreenControl,
-  GeolocateControl,
-  Map as MapLibreMap,
-  Marker,
-  NavigationControl,
-} from "maplibre-gl";
-import { useIsMobile } from "~/composables/useIsMobile";
+import { GeolocateControl, Map as MapLibreMap, Marker, NavigationControl } from "maplibre-gl";
 import { useWebglGuard } from "~/composables/webglSupport";
 
 interface Props {
@@ -32,7 +25,6 @@ const { t } = useI18n({ useScope: "local" });
 const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const mapContainer = ref<HTMLElement>();
-const isMobile = useIsMobile();
 const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 function createMarker(hueRotation = 120) {
@@ -63,10 +55,6 @@ function initMap() {
 
   mapInstance.on("load", () => {
     mapInstance.addControl(new NavigationControl({}), "top-left");
-    if (isMobile.value) {
-      const fullscreenCtl = new FullscreenControl({ container: mapContainer.value as HTMLElement });
-      mapInstance.addControl(fullscreenCtl);
-    }
     mapInstance.addControl(
       new GeolocateControl({
         positionOptions: { enableHighAccuracy: true },

--- a/webclient/app/components/LocationPickerModal.vue
+++ b/webclient/app/components/LocationPickerModal.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
 import { until } from "@vueuse/core";
-import {
-  FullscreenControl,
-  GeolocateControl,
-  Map as MapLibreMap,
-  Marker,
-  NavigationControl,
-} from "maplibre-gl";
+import { GeolocateControl, Map as MapLibreMap, Marker, NavigationControl } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
-import { useIsMobile } from "~/composables/useIsMobile";
 import { useWebglGuard } from "~/composables/webglSupport";
 
 interface LocationPickerProps {
@@ -35,7 +28,6 @@ const marker = ref<Marker | undefined>(undefined);
 const floorControl = ref<FloorControl>(new FloorControl());
 const mapContainer = ref<HTMLElement>();
 const isMapLoaded = ref(false);
-const isMobile = useIsMobile();
 const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 const coordinates = ref({
@@ -78,14 +70,6 @@ function initMap() {
 
     // Add navigation controls
     mapInstance.addControl(new NavigationControl({}), "top-left");
-
-    // Add fullscreen control for mobile
-    if (isMobile.value) {
-      const fullscreenCtl = new FullscreenControl({
-        container: mapContainer.value as HTMLElement,
-      });
-      mapInstance.addControl(fullscreenCtl);
-    }
 
     // Add location control
     const location = new GeolocateControl({
@@ -309,7 +293,7 @@ defineExpose({
 
       & #floor-list {
         display: inline-block;
-        width: calc(100% - 29px);
+        width: calc(100% - var(--map-ctrl-button-size));
       }
 
       & button {

--- a/webclient/app/composables/FloorControl.ts
+++ b/webclient/app/composables/FloorControl.ts
@@ -6,6 +6,9 @@ interface FloorLevel {
   readonly label: string;
 }
 
+// Mirrors `--map-ctrl-button-size` in assets/css/main.css.
+const CTRL_BUTTON_PX = 48;
+
 // All available floor levels globally
 export const FLOOR_LEVELS: readonly FloorLevel[] = [
   { id: 6, label: "6" },
@@ -214,9 +217,8 @@ export class FloorControl extends Evented implements IControl {
       document.querySelector(".maplibregl-ctrl-bottom-left")?.clientHeight || 0;
     const floorCtrlHeight = document.querySelector(".floor-ctrl")?.clientHeight || 0;
 
-    // The buttons have a height of 29px
     const availableHeight = mapHeight - topCtrlHeight - bottomCtrlHeight + floorCtrlHeight;
-    const requiredHeight = 29 * n;
+    const requiredHeight = CTRL_BUTTON_PX * n;
 
     // 3 or fewer buttons can always be displayed in reduced layout.
     // Also, if the control takes only a small amount of space, it is always open.
@@ -227,9 +229,9 @@ export class FloorControl extends Evented implements IControl {
     } else {
       this.container.classList.remove("reduced");
 
-      // 25px = 10px reserved for top/bottom margin + 5px between control groups
-      // 29px = additional height from the open/collapse button
-      if (availableHeight - (requiredHeight + 29) > 25) {
+      // 25px = 10px reserved for top/bottom margin + 5px between control groups;
+      // one extra button height for the open/collapse button.
+      if (availableHeight - (requiredHeight + CTRL_BUTTON_PX) > 25) {
         // Enough vertical space: auto-expand on larger devices unless the user has
         // explicitly collapsed the widget via the toggle button.
         this.container.classList.remove("horizontal");

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -6,13 +6,7 @@ import type {
   MapGeoJSONFeature,
   MapLayerMouseEvent,
 } from "maplibre-gl";
-import {
-  FullscreenControl,
-  GeolocateControl,
-  Map as MapLibreMap,
-  NavigationControl,
-  Popup,
-} from "maplibre-gl";
+import { GeolocateControl, Map as MapLibreMap, NavigationControl, Popup } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
 import {
   ACTIVE_FILTERS_STORAGE_KEY,
@@ -320,7 +314,6 @@ function initMap(): MapLibreMap {
       }),
       "top-right"
     );
-    m.addControl(new FullscreenControl(), "top-right");
     m.addControl(floorControl, "top-right");
 
     // Drop the legacy raster floor-plan overlays; they sit above the POIs and would hide them.


### PR DESCRIPTION
## What this does

- **Removes the fullscreen control from all five map surfaces** — `/map`, the details interactive map, the indoor map, and both location pickers. On the indoor map this also removes the desktop "maximize" reimplementation (`_onClickFullscreen` override, the `fullscreenContainerEl` resize-observer workaround, and the `.maximize` CSS in both IndoorMap and DetailsInteractiveMap, the latter of which was already dead).
- **Enlarges the remaining control buttons from 29px to 48px** (the minimum recommended touch-target size) with proportionally scaled icons, via a `--map-ctrl-button-size` override in `main.css`. The floor control inherits the size; its JS layout maths (`FloorControl.ts`) and the horizontal floor-list `calc()`s in DetailsInteractiveMap/LocationPickerModal follow the same value.

Two cascade subtleties the override has to respect, documented in the CSS comment:
- the map components import `maplibre-gl.css` after `main.css`, so the rule needs higher specificity than MapLibre's own;
- scoping under `.maplibregl-map` does not work — surfaces with dynamic Vue `:class` bindings on the map container (details, indoor) lose externally-added classes whenever Vue patches the attribute, so the rule scopes under the MapLibre-owned `.maplibregl-control-container` instead.

## Verification

- Measured 48×48 buttons on both `/map` and the details map in a real browser; screenshots confirm icons scale cleanly and the floor control grows to match; no fullscreen button anywhere.
- `map.ui.spec.ts` 10/10 and `details.ui.spec.ts` 24/24 locally (the latter now asserts the fullscreen button is absent).
- `pnpm type-check`, `pnpm run lint`, vitest 144/144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)