### PR TITLE
fix(map): restore the search bar on the /map page

### DIFF
--- a/webclient/app/layouts/browse-map.vue
+++ b/webclient/app/layouts/browse-map.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { useEditProposal } from "~/composables/editProposal";
+import { useFeedback } from "~/composables/feedback";
+
+const feedback = useFeedback();
+const editProposal = useEditProposal();
+const searchBarFocused = ref(false);
+
+const i18nHead = useLocaleHead({ dir: true, seo: true });
+useHead({
+  htmlAttrs: {
+    lang: i18nHead.value.htmlAttrs?.lang || "en",
+  },
+  link: [...(i18nHead.value.link || [])],
+  meta: [...(i18nHead.value.meta || [])],
+});
+
+const { t } = useI18n({ useScope: "local" });
+</script>
+
+<template>
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-30 focus:rounded focus:bg-blue-600 dark:focus:bg-blue-300 focus:px-4 focus:py-2 focus:text-white dark:focus:text-black focus:shadow-md focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-offset-2"
+  >
+    {{ t("skip_to_content") }}
+  </a>
+  <AppNavHeader>
+    <AppSearchBar v-model:search-bar-focused="searchBarFocused" />
+  </AppNavHeader>
+
+  <main id="main-content" tabindex="-1" class="mx-auto mt-[60px] min-h-[calc(100vh-150px)] transition-opacity">
+    <slot />
+  </main>
+
+  <AppFooter />
+  <ClientOnly>
+    <LazyFeedbackModal v-if="feedback.open" />
+    <LazyAddProposalModal v-if="editProposal.addOpen" />
+  </ClientOnly>
+</template>
+
+<i18n lang="yaml">
+de:
+  skip_to_content: Zum Hauptinhalt springen
+en:
+  skip_to_content: Skip to main content
+</i18n>

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -37,7 +37,7 @@ import {
 import { useEventPopup } from "~/composables/useEventMarkers";
 import { useWebglGuard } from "~/composables/webglSupport";
 
-definePageMeta({ layout: "navigation" });
+definePageMeta({ layout: "browse-map" });
 
 const { t } = useI18n({ useScope: "local" });
 const route = useRoute();


### PR DESCRIPTION
The shared `navigation` layout left `AppNavHeader`'s slot empty, so the /map page rendered without the global search bar; split off a dedicated `browse-map` layout that fills the slot with `AppSearchBar` and keep `/navigate` on the slot-less `navigation` layout (its own from/to inputs don't want a second search input on top).