### PR TITLE
docs(webclient): rewrite the about pages to match today's data sources

### DIFF
--- a/webclient/content/about/ueber-uns.md
+++ b/webclient/content/about/ueber-uns.md
@@ -5,52 +5,36 @@ description: NavigaTUM ist ein von Studierenden für Studierende entwickeltes Op
 
 # Über NavigaTUM
 
-NavigaTUM ist ein von Studierenden für Studierende entwickeltes Tool, um sich bei der [TUM](https://tum.de) zurechtzufinden.
-Du kannst gerne selbst mitmachen, [der Code ist Open Source verfügbar](https://github.com/TUM-Dev/navigatum) und wir freuen uns über neue Mitwirkende.
+NavigaTUM hilft dir, Räume, Gebäude und Standorte der [TUM](https://tum.de) zu finden - vom Stammgelände über Garching und Weihenstephan bis Heilbronn und Straubing.
+Das Projekt wird von Studierenden für Studierende entwickelt, ist [Open Source](https://github.com/TUM-Dev/NavigaTUM) und kommt ohne Login, ohne Werbung und ohne Tracking aus.
+Hinter dem Projekt steht keine offizielle Stelle der TUM, sondern eine Gruppe Freiwilliger des [OpenSource @ TUM e.V.](https://tum.dev) - und vielleicht bald auch du.
 
-## Datenquellen
+## Woher die Daten kommen
 
-Die Daten in NavigaTUM sollten möglichst umfangreich, aktuell und hilfreich sein.
-Deswegen verwendet NavigaTUM neben eigenen Daten auch Daten aus externen Quellen,
-insbesondere [TUMonline](https://campus.tum.de) und dem
-TUM [Roomfinder](https://portal.mytum.de/campus/roomfinder).
+Gute Navigation steht und fällt mit guten Daten, deswegen kombinieren wir mehrere Quellen.
+Die Grundlage bilden die Gebäude, Räume, Organisationen und Kalendereinträge aus [TUMonline](https://campus.tum.de).
+Wir übernehmen diese Daten regelmäßig automatisiert, strukturieren sie aber teilweise um (zum Beispiel bei Gebäudekomplexen) und korrigieren Fehler.
+Den alten TUM Roomfinder haben wir abgelöst; seine Lagepläne und Raum-Metadaten leben bei uns als archivierter Datenbestand weiter.
+Vieles pflegen wir außerdem von Hand nach, oft auf Basis von Hinweisen aus der Community: Koordinaten, Namen, das Suchranking, Öffnungszeiten mit Quellenangabe je Eintrag und einige selbst gezeichnete Lagepläne.
 
-Eine Übersicht woher welche Daten stammen findest du hier:
+Das Rückgrat unserer Karte ist [OpenStreetMap](https://www.openstreetmap.org).
+Gebäudeumrisse, Innenraumdaten, Points of Interest und viele Öffnungszeiten stammen aus OSM - und das ist keine Einbahnstraße: Was wir vor Ort verbessern, tragen wir in OSM ein, sodass auch alle anderen Karten davon profitieren.
+Kartendaten © OpenStreetMap-Mitwirkende.
 
-- **Standorte:** Die Standorte wurden von NavigaTUM selbst gesammelt und gruppiert aus der Liste von Gebäuden. Zusätzlich Quellen:
-  - [Offizielle Standortübersicht der TUM](https://www.tum.de/die-tum/die-universitaet/standorte)
-  - [Standortübersicht der MPI](https://mpi.fs.tum.de/neu-an-der-tum/standorte/)
-- **Gebäude:** Die Liste an Gebäude stammt aus der gesammelten Liste von Gebäuden in TUMonline, sowie der Gebäudeauswahl im Roomfinder. Allerdings verwendet NavigaTUM zum Teil andere Namen oder eine andere Struktur (z.B. bei Gebäudekomplexen). Weitere Informationen zu den Gebäuden wurden evtl. übernommen aus:
-  - Für alle: [Open Street Map](https://www.openstreetmap.org)
-  - Stammgelände: [Karte Stammgelände](https://portal.mytum.de/campus/stammgelaende/TUM_Campus_Muenchen_klein)
-  - Klinkikum rechts der Isar (MRI):
-    - [Karte MRI](https://portal.mytum.de/campus/rechts_der_isar/mri)
-    - [MRI Lageplan I](https://www.mri.tum.de/lageplaene-und-wegweiser)
-    - [MRI Lageplan II](http://www.imi-muenchen.de/fileadmin/user_upload/pdf/MRI_Lageplan.pdf)
-    - [Anfahrt Frauenklinik](http://www.frauenklinik.med.tum.de/inhalt/anfahrt)
-    - [Wegweiser für Patienten](https://www.mri.tum.de/sites/default/files/seiten/wegweiser_patienten_ambulant_20200312_web.pdf)
-  - Olympia: [Karte Olympiapark](https://portal.mytum.de/campus/olympiapark/olympiapark)
-  - Pasing: [Standort Pasing](https://www.bgu.tum.de/gb/ueber-uns/standort-muenchen-pasing/)
-  - Heilbronn:
-    - [Bildungscampus Heilbronn](https://bildungscampus.hn/ueber-uns/leben-am-campus)
-    - [TUM Heilbronn](https://www.wi.tum.de/tum-campus-heilbronn/welcome-tum-campus-heilbronn/)
-  - Straubing:
-    - [Campus Straubing](https://www.cs.tum.de/campus-straubing/campus/?lang=en)
-    - [Anfahrt und Lageplan Straubing](https://www.cs.tum.de/campus-straubing/anfahrt-und-lageplan/)
-    - [Karte Straubing](https://www.cs.tum.de/wp-content/uploads/2020/01/200127_TUM_Plan_Straubing_WEB.png)
-  - Wissenschaftszentrum Weihenstephan:
-    - [Lageplan Lehrräume](https://www.wzw.tum.de/fileadmin/lageplan/SoLS-Plan-Lehrraume.jpg)
-    - [Campusplan Weihenstephan](https://www.gm.wzw.tum.de/en/campusplan-stand-oktober-2019/)
-    - [Versuchsstationen](https://www.wzw.tum.de/?id=239)
-  - Garching:
-    - [Karte Garching I](https://portal.mytum.de/campus/garching/TUM_Campus_Garching_web)
-    - [Karte Garching II](https://www.forschung-garching.tum.de/fileadmin/w00btp/www/00_Startseite_normal/161015_KarteGarchingKomplett_RGB.pdf)
-    - [Gebäudeplan MW](https://www.mw.tum.de/fileadmin/w00btx/mw/Fakultaet/Anfahrt/Lageplan_Gebaeude_MW.pdf)
-    - [Gebäudeplan Physik](https://www.ph.tum.de/about/visit/TUM_Physik_Orientierungsplan.pdf)
-    - [Gebäudeplan Chemie](https://www.ch.tum.de/fileadmin/tuchfak/www/Lageplan/Infoblatt_2020-06.pdf)
-- **Räume:** Die Räume wurden großteils aus TUMonline übernommen und ggf. mit Informationen aus dem Roomfinder ergänzt. Ausnahmen sind spezielle Räume oder Bereiche wie Teilbibliotheken.
-  - [Teilbibliotheken](https://www.ub.tum.de/teilbibliotheken)
-- **Bilder:** Die Bilder wurden unabhängig der sonstigen Daten gesammelt und den Einträgen zugeordnet.
-- **Öffentliche Verkehrsmittel:** Stationen und Fahrpläne stammen vom MVV
-  - [Stationen](https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/opendata/index.html)
-  - [Fahrpläne](https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/homepage-services/index.html)
+Einige Inhalte sind live.
+Haltestellen in Campusnähe und die Abfahrten auf den Detailseiten kommen vom community-betriebenen ÖPNV-Routing-Projekt [Transitous](https://transitous.org), die aktuelle Verfügbarkeit von Lernräumen von [IRIS](https://iris.asta.tum.de), der Lernraum-Anzeige der Studentischen Vertretung.
+Die Speisepläne und Öffnungszeiten der Mensen liefert die [eat-api](https://github.com/TUM-Dev/eat-api), aufbereitet aus den Daten des Studierendenwerks München Oberbayern; die Informationen zu den Teilbibliotheken stammen von der [TUM Universitätsbibliothek](https://www.ub.tum.de/teilbibliotheken).
+
+## Bilder
+
+Die Fotos von Gebäuden und Räumen stammen von Mitgliedern der Community.
+Zu jedem Bild speichern wir, wer es aufgenommen hat und unter welcher Lizenz es steht (zum Beispiel CC0 oder CC BY) - die Angaben kannst du dir direkt am Bild anzeigen lassen.
+Du warst mit der Kamera unterwegs? Über den Bearbeiten-Knopf auf jeder Detailseite kannst du eigene Fotos beisteuern.
+
+## Mitmachen
+
+NavigaTUM lebt davon, dass Leute Fehler melden und Lücken füllen.
+Der einfachste Weg ist das Feedback-Formular auf jeder Seite - daraus entsteht ein öffentliches Issue [auf GitHub](https://github.com/TUM-Dev/NavigaTUM/issues), dessen Bearbeitung du nachverfolgen kannst.
+Falsche Koordinaten oder Namen kannst du direkt auf der Detailseite bearbeiten und fehlende Einträge [vorschlagen](/propose).
+Wer lieber an der Karte arbeitet, trägt fehlende Details direkt in [OpenStreetMap](https://www.openstreetmap.org) ein - sie erscheinen automatisch auch bei uns.
+Und falls du mitentwickeln willst: [Der Code ist Open Source](https://github.com/TUM-Dev/NavigaTUM) und wir freuen uns über neue Mitwirkende.

--- a/webclient/content/about/ueber-uns.md
+++ b/webclient/content/about/ueber-uns.md
@@ -45,10 +45,12 @@ Du warst mit der Kamera unterwegs?
 ## Mitmachen
 
 NavigaTUM lebt davon, dass Leute Fehler melden und Lücken füllen.
-Der einfachste Weg ist das Feedback-Formular auf jeder Seite.
-Daraus entsteht ein öffentliches Issue [auf GitHub](https://github.com/TUM-Dev/NavigaTUM/issues), dessen Bearbeitung du nachverfolgen kannst.
-Falsche Koordinaten oder Namen kannst du direkt auf der Detailseite bearbeiten.
+Am meisten hilfst du uns mit direkten Korrekturen.
+Falsche Koordinaten oder Namen kannst du auf jeder Detailseite bearbeiten.
 Fehlende Einträge kannst du [vorschlagen](/propose).
+Aus deinem Vorschlag wird automatisch ein Pull Request, den wir oft direkt übernehmen können.
+Für alles andere gibt es das Feedback-Formular auf jeder Seite.
+Daraus entsteht ein öffentliches Issue [auf GitHub](https://github.com/TUM-Dev/NavigaTUM/issues), dessen Bearbeitung du nachverfolgen kannst.
 Wer lieber an der Karte arbeitet, trägt fehlende Details direkt in [OpenStreetMap](https://www.openstreetmap.org) ein.
 Sie erscheinen automatisch auch bei uns.
 Und der Code ist [Open Source](https://github.com/TUM-Dev/NavigaTUM) - wir freuen uns über neue Mitwirkende.

--- a/webclient/content/about/ueber-uns.md
+++ b/webclient/content/about/ueber-uns.md
@@ -5,36 +5,50 @@ description: NavigaTUM ist ein von Studierenden für Studierende entwickeltes Op
 
 # Über NavigaTUM
 
-NavigaTUM hilft dir, Räume, Gebäude und Standorte der [TUM](https://tum.de) zu finden - vom Stammgelände über Garching und Weihenstephan bis Heilbronn und Straubing.
-Das Projekt wird von Studierenden für Studierende entwickelt, ist [Open Source](https://github.com/TUM-Dev/NavigaTUM) und kommt ohne Login, ohne Werbung und ohne Tracking aus.
-Hinter dem Projekt steht keine offizielle Stelle der TUM, sondern eine Gruppe Freiwilliger des [OpenSource @ TUM e.V.](https://tum.dev) - und vielleicht bald auch du.
+NavigaTUM hilft dir, Räume, Gebäude und Standorte der [TUM](https://tum.de) zu finden - in München, Garching, Weihenstephan, Heilbronn und Straubing.
+Das Projekt ist [Open Source](https://github.com/TUM-Dev/NavigaTUM) und wird von Studierenden für Studierende entwickelt.
+Es funktioniert ohne Login, ohne Werbung und ohne Tracking.
+Dahinter steht keine offizielle Stelle der TUM, sondern eine Gruppe Freiwilliger des [OpenSource @ TUM e.V.](https://tum.dev) - und vielleicht bald auch du.
 
 ## Woher die Daten kommen
 
-Gute Navigation steht und fällt mit guten Daten, deswegen kombinieren wir mehrere Quellen.
-Die Grundlage bilden die Gebäude, Räume, Organisationen und Kalendereinträge aus [TUMonline](https://campus.tum.de).
-Wir übernehmen diese Daten regelmäßig automatisiert, strukturieren sie aber teilweise um (zum Beispiel bei Gebäudekomplexen) und korrigieren Fehler.
-Den alten TUM Roomfinder haben wir abgelöst; seine Lagepläne und Raum-Metadaten leben bei uns als archivierter Datenbestand weiter.
-Vieles pflegen wir außerdem von Hand nach, oft auf Basis von Hinweisen aus der Community: Koordinaten, Namen, das Suchranking, Öffnungszeiten mit Quellenangabe je Eintrag und einige selbst gezeichnete Lagepläne.
+Gute Navigation steht und fällt mit guten Daten.
+Deswegen kombinieren wir mehrere Quellen.
+Die Grundlage liefert [TUMonline](https://campus.tum.de): Gebäude, Räume, Organisationen und Kalendereinträge.
+Wir übernehmen diese Daten regelmäßig automatisiert.
+Dabei strukturieren wir sie teilweise um (etwa bei Gebäudekomplexen) und korrigieren Fehler.
+Den alten TUM Roomfinder haben wir abgelöst.
+Seine Lagepläne und Raum-Metadaten leben bei uns als Archivbestand weiter.
+Vieles pflegen wir von Hand nach: Koordinaten, Namen, das Suchranking, Öffnungszeiten mit Quellenangabe je Eintrag und einige selbst gezeichnete Lagepläne.
+Hinweise aus der Community helfen dabei oft.
 
 Das Rückgrat unserer Karte ist [OpenStreetMap](https://www.openstreetmap.org).
-Gebäudeumrisse, Innenraumdaten, Points of Interest und viele Öffnungszeiten stammen aus OSM - und das ist keine Einbahnstraße: Was wir vor Ort verbessern, tragen wir in OSM ein, sodass auch alle anderen Karten davon profitieren.
+Gebäudeumrisse, Innenraumdaten, Points of Interest und viele Öffnungszeiten stammen aus OSM.
+Das ist keine Einbahnstraße: Was wir vor Ort verbessern, tragen wir in OSM ein.
+Davon profitieren auch alle anderen Karten.
 Kartendaten © OpenStreetMap-Mitwirkende.
 
 Einige Inhalte sind live.
-Haltestellen in Campusnähe und die Abfahrten auf den Detailseiten kommen vom community-betriebenen ÖPNV-Routing-Projekt [Transitous](https://transitous.org), die aktuelle Verfügbarkeit von Lernräumen von [IRIS](https://iris.asta.tum.de), der Lernraum-Anzeige der Studentischen Vertretung.
-Die Speisepläne und Öffnungszeiten der Mensen liefert die [eat-api](https://github.com/TUM-Dev/eat-api), aufbereitet aus den Daten des Studierendenwerks München Oberbayern; die Informationen zu den Teilbibliotheken stammen von der [TUM Universitätsbibliothek](https://www.ub.tum.de/teilbibliotheken).
+Haltestellen und Abfahrten kommen vom community-betriebenen ÖPNV-Projekt [Transitous](https://transitous.org).
+Die aktuelle Lernraum-Verfügbarkeit liefert [IRIS](https://iris.asta.tum.de), die Lernraum-Anzeige der Studentischen Vertretung.
+Speisepläne und Mensa-Öffnungszeiten kommen von der [eat-api](https://github.com/TUM-Dev/eat-api), aufbereitet aus den Daten des Studierendenwerks.
+Die Informationen zu den Teilbibliotheken stammen von der [TUM Universitätsbibliothek](https://www.ub.tum.de/teilbibliotheken).
 
 ## Bilder
 
-Die Fotos von Gebäuden und Räumen stammen von Mitgliedern der Community.
-Zu jedem Bild speichern wir, wer es aufgenommen hat und unter welcher Lizenz es steht (zum Beispiel CC0 oder CC BY) - die Angaben kannst du dir direkt am Bild anzeigen lassen.
-Du warst mit der Kamera unterwegs? Über den Bearbeiten-Knopf auf jeder Detailseite kannst du eigene Fotos beisteuern.
+Die Fotos von Gebäuden und Räumen stammen aus der Community.
+Zu jedem Bild speichern wir, wer es aufgenommen hat und unter welcher Lizenz es steht (zum Beispiel CC0 oder CC BY).
+Beides kannst du dir direkt am Bild anzeigen lassen.
+Du warst mit der Kamera unterwegs?
+Über den Bearbeiten-Knopf auf jeder Detailseite kannst du eigene Fotos beisteuern.
 
 ## Mitmachen
 
 NavigaTUM lebt davon, dass Leute Fehler melden und Lücken füllen.
-Der einfachste Weg ist das Feedback-Formular auf jeder Seite - daraus entsteht ein öffentliches Issue [auf GitHub](https://github.com/TUM-Dev/NavigaTUM/issues), dessen Bearbeitung du nachverfolgen kannst.
-Falsche Koordinaten oder Namen kannst du direkt auf der Detailseite bearbeiten und fehlende Einträge [vorschlagen](/propose).
-Wer lieber an der Karte arbeitet, trägt fehlende Details direkt in [OpenStreetMap](https://www.openstreetmap.org) ein - sie erscheinen automatisch auch bei uns.
-Und falls du mitentwickeln willst: [Der Code ist Open Source](https://github.com/TUM-Dev/NavigaTUM) und wir freuen uns über neue Mitwirkende.
+Der einfachste Weg ist das Feedback-Formular auf jeder Seite.
+Daraus entsteht ein öffentliches Issue [auf GitHub](https://github.com/TUM-Dev/NavigaTUM/issues), dessen Bearbeitung du nachverfolgen kannst.
+Falsche Koordinaten oder Namen kannst du direkt auf der Detailseite bearbeiten.
+Fehlende Einträge kannst du [vorschlagen](/propose).
+Wer lieber an der Karte arbeitet, trägt fehlende Details direkt in [OpenStreetMap](https://www.openstreetmap.org) ein.
+Sie erscheinen automatisch auch bei uns.
+Und der Code ist [Open Source](https://github.com/TUM-Dev/NavigaTUM) - wir freuen uns über neue Mitwirkende.

--- a/webclient/content/en/about/about-us.md
+++ b/webclient/content/en/about/about-us.md
@@ -5,36 +5,50 @@ description: NavigaTUM is an open-source tool developed by students for students
 
 # About NavigaTUM
 
-NavigaTUM helps you find rooms, buildings, and locations at [TUM](https://tum.de) - from the main campus in Munich to Garching, Weihenstephan, Heilbronn, and Straubing.
-The project is developed by students for students, is [open source](https://github.com/TUM-Dev/NavigaTUM), and works without a login, without ads, and without tracking.
+NavigaTUM helps you find rooms, buildings, and locations at [TUM](https://tum.de) - in Munich, Garching, Weihenstephan, Heilbronn, and Straubing.
+The project is [open source](https://github.com/TUM-Dev/NavigaTUM) and developed by students for students.
+It works without a login, without ads, and without tracking.
 It is not run by an official TUM department, but by a group of volunteers at [OpenSource @ TUM e.V.](https://tum.dev) - and maybe soon by you.
 
 ## Where the data comes from
 
-Good navigation lives and dies with good data, so we combine several sources.
-The foundation are the buildings, rooms, organisations, and calendar entries from [TUMonline](https://campus.tum.de).
-We import this data regularly and automatically, but partially restructure it (for example for building complexes) and fix errors.
-We replaced the old TUM Roomfinder; its site plans and room metadata live on in NavigaTUM as an archived dataset.
-On top of that, we curate a lot by hand, often based on hints from the community: coordinates, names, the search ranking, opening hours with a source reference per entry, and some hand-drawn site plans.
+Good navigation lives and dies with good data.
+That is why we combine several sources.
+The foundation comes from [TUMonline](https://campus.tum.de): buildings, rooms, organisations, and calendar entries.
+We import this data regularly and automatically.
+Along the way, we partially restructure it (for example for building complexes) and fix errors.
+We replaced the old TUM Roomfinder.
+Its site plans and room metadata live on in NavigaTUM as an archived dataset.
+A lot is curated by hand: coordinates, names, the search ranking, opening hours with a source reference per entry, and some hand-drawn site plans.
+Hints from the community often help with that.
 
 The backbone of our map is [OpenStreetMap](https://www.openstreetmap.org).
-Building outlines, indoor data, points of interest, and many opening hours come from OSM - and it is not a one-way street: improvements we make on the ground go back into OSM, so every other map benefits too.
+Building outlines, indoor data, points of interest, and many opening hours come from OSM.
+It is not a one-way street: improvements we make on the ground go back into OSM.
+Every other map benefits from that too.
 Map data © OpenStreetMap contributors.
 
 Some content is live.
-Public transport stops near the campuses and the departures on detail pages come from the community-run public transport routing project [Transitous](https://transitous.org), and the current availability of study rooms from [IRIS](https://iris.asta.tum.de), the student council's study room display.
-The menus and opening hours of the canteens are provided by the [eat-api](https://github.com/TUM-Dev/eat-api), derived from the data of the Studierendenwerk München Oberbayern; the information about the branch libraries comes from the [TUM University Library](https://www.ub.tum.de/en/branch-libraries).
+Public transport stops and departures come from the community-run project [Transitous](https://transitous.org).
+The current study room availability is provided by [IRIS](https://iris.asta.tum.de), the student council's study room display.
+Menus and canteen opening hours come from the [eat-api](https://github.com/TUM-Dev/eat-api), derived from the data of the Studierendenwerk.
+The information about the branch libraries comes from the [TUM University Library](https://www.ub.tum.de/en/branch-libraries).
 
 ## Images
 
-The photos of buildings and rooms come from members of the community.
-For every image, we record who took it and under which license it is published (for example CC0 or CC BY) - you can view this attribution directly on the image.
-Been out with your camera? You can contribute your own photos via the edit button on every detail page.
+The photos of buildings and rooms come from the community.
+For every image, we record who took it and under which license it is published (for example CC0 or CC BY).
+You can view both directly on the image.
+Been out with your camera?
+You can contribute your own photos via the edit button on every detail page.
 
 ## How to contribute
 
 NavigaTUM thrives on people reporting errors and filling gaps.
-The easiest way is the feedback form on every page - it creates a public issue [on GitHub](https://github.com/TUM-Dev/NavigaTUM/issues) whose progress you can follow.
-You can fix wrong coordinates or names directly on the detail page and [propose](/en/propose) missing entries.
-If you prefer working on the map, add missing details directly to [OpenStreetMap](https://www.openstreetmap.org) - they automatically show up here as well.
-And if you want to help build NavigaTUM itself: [the code is open source](https://github.com/TUM-Dev/NavigaTUM) and we are happy to welcome new contributors.
+The easiest way is the feedback form on every page.
+It creates a public issue [on GitHub](https://github.com/TUM-Dev/NavigaTUM/issues) whose progress you can follow.
+You can fix wrong coordinates or names directly on the detail page.
+Missing entries can be [proposed](/en/propose).
+If you prefer working on the map, add missing details directly to [OpenStreetMap](https://www.openstreetmap.org).
+They automatically show up here as well.
+And the code is [open source](https://github.com/TUM-Dev/NavigaTUM) - we are happy to welcome new contributors.

--- a/webclient/content/en/about/about-us.md
+++ b/webclient/content/en/about/about-us.md
@@ -45,10 +45,12 @@ You can contribute your own photos via the edit button on every detail page.
 ## How to contribute
 
 NavigaTUM thrives on people reporting errors and filling gaps.
-The easiest way is the feedback form on every page.
-It creates a public issue [on GitHub](https://github.com/TUM-Dev/NavigaTUM/issues) whose progress you can follow.
-You can fix wrong coordinates or names directly on the detail page.
+Direct corrections help us the most.
+You can fix wrong coordinates or names on every detail page.
 Missing entries can be [proposed](/en/propose).
+Your proposal automatically becomes a pull request, which we can often merge as-is.
+For everything else, there is the feedback form on every page.
+It creates a public issue [on GitHub](https://github.com/TUM-Dev/NavigaTUM/issues) whose progress you can follow.
 If you prefer working on the map, add missing details directly to [OpenStreetMap](https://www.openstreetmap.org).
 They automatically show up here as well.
 And the code is [open source](https://github.com/TUM-Dev/NavigaTUM) - we are happy to welcome new contributors.

--- a/webclient/content/en/about/about-us.md
+++ b/webclient/content/en/about/about-us.md
@@ -5,51 +5,36 @@ description: NavigaTUM is an open-source tool developed by students for students
 
 # About NavigaTUM
 
-NavigaTUM is a tool developed by students for students, to help you get around at [TUM](https://tum.de).
-Feel free to contribute, [the code is open source](https://github.com/TUM-Dev/navigatum) and we are open to new contributors.
+NavigaTUM helps you find rooms, buildings, and locations at [TUM](https://tum.de) - from the main campus in Munich to Garching, Weihenstephan, Heilbronn, and Straubing.
+The project is developed by students for students, is [open source](https://github.com/TUM-Dev/NavigaTUM), and works without a login, without ads, and without tracking.
+It is not run by an official TUM department, but by a group of volunteers at [OpenSource @ TUM e.V.](https://tum.dev) - and maybe soon by you.
 
-## Data Sources
+## Where the data comes from
 
-The data used in NavigaTUM should be as complete, up-to-date and helpful as possible.
-For this reason it uses besides its own data information from externen sources, especially [TUMonline](https://campus.tum.de) and the
-TUM [Roomfinder](https://portal.mytum.de/campus/roomfinder).
+Good navigation lives and dies with good data, so we combine several sources.
+The foundation are the buildings, rooms, organisations, and calendar entries from [TUMonline](https://campus.tum.de).
+We import this data regularly and automatically, but partially restructure it (for example for building complexes) and fix errors.
+We replaced the old TUM Roomfinder; its site plans and room metadata live on in NavigaTUM as an archived dataset.
+On top of that, we curate a lot by hand, often based on hints from the community: coordinates, names, the search ranking, opening hours with a source reference per entry, and some hand-drawn site plans.
 
-You can find an overview where which data comes here:
+The backbone of our map is [OpenStreetMap](https://www.openstreetmap.org).
+Building outlines, indoor data, points of interest, and many opening hours come from OSM - and it is not a one-way street: improvements we make on the ground go back into OSM, so every other map benefits too.
+Map data © OpenStreetMap contributors.
 
-- **Sites/Areas:** The sites/areas have been collected by NavigaTUM based on the list of buildings. Additional sources are:
-  - [Official Locations overview of TUM](https://www.tum.de/en/about-tum/our-university/locations)
-  - [Locations overview by MPI](https://mpi.fs.tum.de/en/entering-tum/locations//)
-- **Buildings:** The list of buildings was derived from the collected list of buildings in TUMonline and the buildings selection in the Roomfinder. However, sometimes their names or structure was changed (e.g. for complex buildings). Additional information about buildings may have been included from:
-  - For all: [Open Street Map](https://www.openstreetmap.org)
-  - Stammgelände: [Map of Stammgelände](https://portal.mytum.de/campus/stammgelaende/TUM_Campus_Muenchen_klein)
-  - Klinkikum rechts der Isar (MRI):
-    - [Map of MRI](https://portal.mytum.de/campus/rechts_der_isar/mri)
-    - [MRI Lageplan I](https://www.mri.tum.de/lageplaene-und-wegweiser)
-    - [MRI Lageplan II](http://www.imi-muenchen.de/fileadmin/user_upload/pdf/MRI_Lageplan.pdf)
-    - [Anfahrt Frauenklinik](http://www.frauenklinik.med.tum.de/inhalt/anfahrt)
-    - [Wegweiser für Patienten](https://www.mri.tum.de/sites/default/files/seiten/wegweiser_patienten_ambulant_20200312_web.pdf)
-  - Olympia: [Map of Olympiapark](https://portal.mytum.de/campus/olympiapark/olympiapark)
-  - Pasing: [Standort Pasing](https://www.bgu.tum.de/gb/ueber-uns/standort-muenchen-pasing/)
-  - Heilbronn:
-    - [Bildungscampus Heilbronn](https://bildungscampus.hn/ueber-uns/leben-am-campus)
-    - [TUM Heilbronn](https://www.wi.tum.de/tum-campus-heilbronn/welcome-tum-campus-heilbronn/)
-  - Straubing:
-    - [Campus Straubing](https://www.cs.tum.de/campus-straubing/campus/?lang=en)
-    - [Anfahrt und Lageplan Straubing](https://www.cs.tum.de/campus-straubing/anfahrt-und-lageplan/)
-    - [Map of Straubing](https://www.cs.tum.de/wp-content/uploads/2020/01/200127_TUM_Plan_Straubing_WEB.png)
-  - Wissenschaftszentrum Weihenstephan:
-    - [Lageplan Lehrräume](https://www.wzw.tum.de/fileadmin/lageplan/SoLS-Plan-Lehrraume.jpg)
-    - [Campusplan Weihenstephan](https://www.gm.wzw.tum.de/en/campusplan-stand-oktober-2019/)
-    - [Versuchsstationen](https://www.wzw.tum.de/?id=239)
-  - Garching:
-    - [Map of Garching I](https://portal.mytum.de/campus/garching/TUM_Campus_Garching_web)
-    - [Map of Garching II](https://www.forschung-garching.tum.de/fileadmin/w00btp/www/00_Startseite_normal/161015_KarteGarchingKomplett_RGB.pdf)
-    - [Building map MW](https://www.mw.tum.de/fileadmin/w00btx/mw/Fakultaet/Anfahrt/Lageplan_Gebaeude_MW.pdf)
-    - [Building map Physics](https://www.ph.tum.de/about/visit/TUM_Physik_Orientierungsplan.pdf)
-    - [Building map Chemistry](https://www.ch.tum.de/fileadmin/tuchfak/www/Lageplan/Infoblatt_2020-06.pdf)
-- **Rooms:** The rooms were mainly taken from TUMonline and extended with information from the Roomfinder. Exceptions are special rooms or spaces such as branch libraries.
-  - [Branch Libraries](https://www.ub.tum.de/en/branch-libraries)
-- **Images:** All images were collected independently and assigned to the entries.
-- **Public transport:** Station locations and departure data is taken from the MVV
-  - [Station Data](https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/opendata/index.html)
-  - [Departure Data](https://www.mvv-muenchen.de/fahrplanauskunft/fuer-entwickler/homepage-services/index.html)
+Some content is live.
+Public transport stops near the campuses and the departures on detail pages come from the community-run public transport routing project [Transitous](https://transitous.org), and the current availability of study rooms from [IRIS](https://iris.asta.tum.de), the student council's study room display.
+The menus and opening hours of the canteens are provided by the [eat-api](https://github.com/TUM-Dev/eat-api), derived from the data of the Studierendenwerk München Oberbayern; the information about the branch libraries comes from the [TUM University Library](https://www.ub.tum.de/en/branch-libraries).
+
+## Images
+
+The photos of buildings and rooms come from members of the community.
+For every image, we record who took it and under which license it is published (for example CC0 or CC BY) - you can view this attribution directly on the image.
+Been out with your camera? You can contribute your own photos via the edit button on every detail page.
+
+## How to contribute
+
+NavigaTUM thrives on people reporting errors and filling gaps.
+The easiest way is the feedback form on every page - it creates a public issue [on GitHub](https://github.com/TUM-Dev/NavigaTUM/issues) whose progress you can follow.
+You can fix wrong coordinates or names directly on the detail page and [propose](/en/propose) missing entries.
+If you prefer working on the map, add missing details directly to [OpenStreetMap](https://www.openstreetmap.org) - they automatically show up here as well.
+And if you want to help build NavigaTUM itself: [the code is open source](https://github.com/TUM-Dev/NavigaTUM) and we are happy to welcome new contributors.


### PR DESCRIPTION
Rewrites the stale link-dump about pages (DE/EN) as prose that reflects the actual current data sources (OSM as backbone we contribute back to, Transitous instead of MVV, Roomfinder as archived legacy, IRIS/eat-api/UB, per-image licensing) and the contribution flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)