### PR TITLE
fix(search): derive the section-count bound and stop retrying fetches during SSR

### DIFF
--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -12,6 +12,7 @@ use actix_web::{FromRequest, HttpRequest, HttpResponse, get, web};
 use meilisearch_sdk::client::Client;
 use serde::{Deserialize, Serialize};
 use std::future::{Ready, ready};
+use strum::EnumCount as _;
 use tokio::join;
 use tracing::{debug, error};
 use unicode_truncate::UnicodeTruncateStr as _;
@@ -530,10 +531,11 @@ pub async fn search_handler(data: web::Data<AppData>, args: SearchQueryArgs) -> 
 
     debug!(?results_sections, "searching returned");
 
-    if results_sections.len() > 5 {
+    if results_sections.len() > ResultFacet::COUNT {
         error!(
             returned_section_cnt = results_sections.len(),
-            "searching did not return expected the amount of sections it expected",
+            max_section_cnt = ResultFacet::COUNT,
+            "searching returned more sections than there are facets",
         );
         return HttpResponse::InternalServerError()
             .content_type("text/plain")

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -3,6 +3,7 @@ use meilisearch_sdk::client::Client;
 use parser::TextToken;
 use serde::Serialize;
 use std::fmt::{self, Debug, Formatter};
+use strum::EnumCount as _;
 use tracing::error;
 
 use crate::external::meilisearch::{GeoEntryQuery, LocationEntryType, MSHit, UpcomingEvent};
@@ -20,7 +21,7 @@ mod parser;
 /// The facet a [`ResultsSection`] groups - its identity in the merge ordering
 /// and the discriminator serialized as the section's `facet` tag. Internal; the
 /// wire form is generated from the [`ResultsSection`] variants.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::EnumCount)]
 pub enum ResultFacet {
     Sites,
     Buildings,
@@ -387,7 +388,7 @@ pub async fn do_geoentry_search(
     let mut pois_opt = Some(ResultsSection::Pois(section_pois));
     let mut lectures_opt = Some(ResultsSection::Lectures(section_lectures));
 
-    let mut sections: Vec<ResultsSection> = Vec::with_capacity(5);
+    let mut sections: Vec<ResultsSection> = Vec::with_capacity(ResultFacet::COUNT - 1);
     for facet in &facet_order {
         let taken = match facet {
             ResultFacet::Sites => sites_opt.take(),
@@ -420,6 +421,8 @@ mod test {
         reason = "tests assert via panic/unwrap and reference absolute paths to fixtures"
     )]
     use std::fmt::{self, Display, Formatter};
+
+    use strum::EnumCount as _;
 
     use super::*;
     use crate::routes::search::{CroppingMode, Highlighting, ParsedIdMode};
@@ -1040,6 +1043,9 @@ mod test {
             vec![],
         )
         .await;
+
+        // One section per non-address facet; the handler appends the address section.
+        assert_eq!(results.0.len(), ResultFacet::COUNT - 1);
 
         let lectures = results
             .0

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -2,6 +2,7 @@
 import { mdiMagnify, mdiMagnifyClose } from "@mdi/js";
 import type { components } from "~/api_types";
 import SearchResultRow from "~/components/SearchResultRow.vue";
+import { clientOnlyRetries } from "~/composables/common";
 import { categoriesForQuery, FILTER_QUERY_PARAM, type FilterId } from "~/composables/mapLayers";
 import { useSearchDropdownNav } from "~/composables/searchDropdownNav";
 import { useStagedSearchFilters } from "~/composables/searchFilters";
@@ -166,7 +167,7 @@ const { data, error } = useFetch<SearchResponse>(url, {
   lazy: true,
   dedupe: "cancel",
   credentials: "omit",
-  retry: 120,
+  retry: clientOnlyRetries(120),
   retryDelay: 1000,
 });
 </script>

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -2,6 +2,7 @@
 import { mdiCrosshairsGps, mdiMagnify } from "@mdi/js";
 import { useRouteQuery } from "@vueuse/router";
 import type { operations } from "~/api_types";
+import { clientOnlyRetries } from "~/composables/common";
 import { useSharedGeolocation } from "~/composables/geolocation";
 import { type ResultsSectionFacet, tagSectionEntries } from "~/utils/lectureRow";
 
@@ -171,7 +172,7 @@ const url = computed(() => {
 const { data, error } = await useFetch<SearchResponse>(url, {
   dedupe: "cancel",
   credentials: "omit",
-  retry: 120,
+  retry: clientOnlyRetries(120),
   retryDelay: 1000,
 });
 </script>

--- a/webclient/app/composables/common.ts
+++ b/webclient/app/composables/common.ts
@@ -13,3 +13,8 @@ export function allValues(value: LocationQueryValue | LocationQueryValue[]): str
   if (Array.isArray(value)) return value.filter((v): v is string => v !== null);
   return [value];
 }
+
+// During SSR, retrying a 5xx would stall the whole page render.
+export function clientOnlyRetries(retries: number): number | false {
+  return import.meta.server ? false : retries;
+}

--- a/webclient/app/pages/[type]/[id].vue
+++ b/webclient/app/pages/[type]/[id].vue
@@ -2,6 +2,7 @@
 import { useSwipe } from "@vueuse/core";
 import type { components } from "~/api_types";
 import DetailsContentSidebar from "~/components/DetailsContentSidebar.vue";
+import { clientOnlyRetries } from "~/composables/common";
 import { useEditProposal } from "~/composables/editProposal";
 
 const VALID_TYPE_RE = /^(campus|site|building|room|poi)$/;
@@ -28,7 +29,7 @@ const url = computed(
 const { data, error } = await useFetch<LocationDetailsResponse, string>(url, {
   dedupe: "cancel",
   credentials: "omit",
-  retry: 120,
+  retry: clientOnlyRetries(120),
   retryDelay: 1000,
 });
 

--- a/webclient/app/pages/embed/[id].vue
+++ b/webclient/app/pages/embed/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { mdiOpenInNew } from "@mdi/js";
 import type { components } from "~/api_types";
+import { clientOnlyRetries } from "~/composables/common";
 
 definePageMeta({
   layout: "embed",
@@ -19,7 +20,7 @@ const url = computed(
 const { data, error } = await useFetch<LocationDetailsResponse, string>(url, {
   dedupe: "cancel",
   credentials: "omit",
-  retry: 120,
+  retry: clientOnlyRetries(120),
   retryDelay: 1000,
 });
 

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -6,7 +6,7 @@ import { useTemplateRef } from "vue";
 import type { components, operations } from "~/api_types";
 import IndoorMap from "~/components/IndoorMap.vue";
 import Toast from "~/components/Toast.vue";
-import { firstOrDefault } from "~/composables/common";
+import { clientOnlyRetries, firstOrDefault } from "~/composables/common";
 import type { TimeSelection } from "~/types/navigation";
 import { entityPath, isEntityType } from "~/utils/entityPath";
 
@@ -80,7 +80,7 @@ const { data, status, error } = await useFetch<NavigationResponse>(
     })),
     dedupe: "defer",
     credentials: "omit",
-    retry: 10,
+    retry: clientOnlyRetries(10),
     retryDelay: 1000,
     key: "navigation",
   }

--- a/webclient/app/pages/search.vue
+++ b/webclient/app/pages/search.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { components } from "~/api_types";
 import SearchSectionList from "~/components/SearchSectionList.vue";
-import { firstOrDefault } from "~/composables/common";
+import { clientOnlyRetries, firstOrDefault } from "~/composables/common";
 import { categoriesForQuery } from "~/composables/mapLayers";
 import { useSearchFilters } from "~/composables/searchFilters";
 
@@ -57,7 +57,7 @@ const apiUrl = computed(() => {
 const { data } = useFetch<SearchResponse>(apiUrl, {
   dedupe: "cancel",
   credentials: "omit",
-  retry: 120,
+  retry: clientOnlyRetries(120),
   retryDelay: 1000,
 });
 const description = computed(() => {


### PR DESCRIPTION
Replaces the stale hardcoded 5-section bound (unchanged since #2912, so every `search_addresses=true` request has returned a 500 since the lectures facet landed) with the derived `ResultFacet::COUNT`, and disables `useFetch` retries during SSR so a deterministic 5xx no longer stalls `/navigate` page renders for ~20s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)