### PR TITLE
fix(webclient): the /propose send button could never enable

### DIFF
--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -217,7 +217,9 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
         type="text"
         :placeholder="t('name_placeholder')"
         class="focusable input-field w-full rounded border px-2 py-1 text-sm"
+        :class="errorFor('name') ? '!border-red-500 dark:!border-red-400' : ''"
       />
+      <p v-if="errorFor('name')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("name") }}</p>
     </div>
 
     <div>
@@ -230,7 +232,9 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
         rows="3"
         :placeholder="t('description_placeholder')"
         class="focusable input-field w-full resize-y rounded border px-2 py-1 text-sm"
+        :class="errorFor('description') ? '!border-red-500 dark:!border-red-400' : ''"
       />
+      <p v-if="errorFor('description')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("description") }}</p>
       <p class="text-zinc-500 dark:text-zinc-400 mt-1 text-xs">{{ t("description_help") }}</p>
     </div>
 
@@ -327,6 +331,7 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
           </Transition>
         </div>
       </Combobox>
+      <p v-if="errorFor('organising_org_id')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("organising_org_id") }}</p>
     </div>
 
     <div>
@@ -344,6 +349,7 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
       <p v-if="draft.coords.picked" class="text-zinc-600 dark:text-zinc-300 mt-1 text-xs">
         {{ draft.coords.lat.toFixed(5) }}, {{ draft.coords.lon.toFixed(5) }}
       </p>
+      <p v-else-if="errorFor('coords.picked')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("coords.picked") }}</p>
     </div>
 
     <div>
@@ -417,7 +423,9 @@ const previewEvent = computed<EventPreviewPopup | null>(() => {
         type="text"
         :placeholder="t('image_author_placeholder')"
         class="focusable input-field w-full rounded border px-2 py-1 text-sm"
+        :class="errorFor('image_author') ? '!border-red-500 dark:!border-red-400' : ''"
       />
+      <p v-if="errorFor('image_author')" class="text-red-700 dark:text-red-200 mt-1 text-xs">{{ errorFor("image_author") }}</p>
     </div>
 
     <div class="bg-blue-50 dark:bg-blue-900 border-blue-200 dark:border-blue-700 flex items-start gap-2 rounded border p-3">
@@ -487,6 +495,7 @@ de:
     event_too_far_out: Der Beginn liegt mehr als ein Jahr in der Zukunft.
     event_too_long: Die Veranstaltung darf höchstens 30 Tage dauern.
     org_required: Bitte wähle eine Organisation aus.
+    coords_required: Bitte wähle einen Ort auf der Karte aus.
     image_required: Bitte lade ein Bild hoch.
     image_too_small: Das Bild muss mindestens 256px auf der kürzeren Seite haben.
     image_author_required: Bitte gib die Urheber:in des Bildes an.
@@ -535,6 +544,7 @@ en:
     event_too_far_out: The start is more than a year in the future.
     event_too_long: The event may last at most 30 days.
     org_required: Please choose an organisation.
+    coords_required: Please pick a location on the map.
     image_required: Please upload an image.
     image_too_small: The image must be at least 256px on its shorter edge.
     image_author_required: Please enter the image author.

--- a/webclient/app/composables/submissionGate.ts
+++ b/webclient/app/composables/submissionGate.ts
@@ -1,0 +1,24 @@
+export type SubmissionBlock =
+  | "submitting"
+  | "already_succeeded"
+  | "token_unavailable"
+  | "incomplete_fields"
+  | "consent_missing"
+  | null;
+
+export interface SubmissionGateState {
+  submitting: boolean;
+  succeeded: boolean;
+  blockedByToken: boolean;
+  draftReady: boolean;
+  privacyChecked: boolean;
+}
+
+export function submissionBlock(state: SubmissionGateState): SubmissionBlock {
+  if (state.submitting) return "submitting";
+  if (state.succeeded) return "already_succeeded";
+  if (state.blockedByToken) return "token_unavailable";
+  if (!state.draftReady) return "incomplete_fields";
+  if (!state.privacyChecked) return "consent_missing";
+  return null;
+}

--- a/webclient/app/pages/propose.vue
+++ b/webclient/app/pages/propose.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { LocationQueryRaw } from "vue-router";
+import AddProposalForm from "~/components/AddProposalForm.vue";
 import {
-  type Addition,
   type AdditionDraft,
   type AdditionKind,
   additionRegistry,
@@ -9,6 +9,7 @@ import {
 } from "~/composables/additionSchema";
 import { firstOrDefault } from "~/composables/common";
 import { useFeedbackSubmission } from "~/composables/feedbackSubmission";
+import { submissionBlock } from "~/composables/submissionGate";
 import { useKnownOrgs } from "~/composables/useKnownOrgs";
 
 const { t } = useI18n({ useScope: "local" });
@@ -82,23 +83,30 @@ watch(
   }
 );
 
-const formRef = ref<{
-  validateAndBuild(): {
-    id: string;
-    displayName: string;
-    addition: NonNullable<Addition>;
-  } | null;
-  clearPending(): void;
-  draftIsReady: { value: boolean };
-} | null>(null);
+const formRef = ref<InstanceType<typeof AddProposalForm> | null>(null);
 
 const privacyChecked = ref(false);
 
-const canSubmit = computed(() => {
-  if (submission.submitting.value || submission.successUrl.value) return false;
-  if (submission.blockedByToken.value) return false;
-  if (!privacyChecked.value) return false;
-  return formRef.value?.draftIsReady.value === true;
+const sendBlock = computed(() =>
+  submissionBlock({
+    submitting: submission.submitting.value,
+    succeeded: Boolean(submission.successUrl.value),
+    blockedByToken: submission.blockedByToken.value,
+    draftReady: formRef.value?.draftIsReady === true,
+    privacyChecked: privacyChecked.value,
+  })
+);
+const canSubmit = computed(() => sendBlock.value === null);
+
+const blockingReason = computed(() => {
+  switch (sendBlock.value) {
+    case "incomplete_fields":
+      return t("blocked_incomplete");
+    case "consent_missing":
+      return t("blocked_consent");
+    default:
+      return null;
+  }
 });
 
 async function send() {
@@ -137,14 +145,19 @@ async function cancel() {
         <FeedbackConsentCheckbox v-model="privacyChecked" />
       </div>
 
-      <div class="float-right mt-6 flex flex-row-reverse gap-2">
-        <FeedbackSubmitButton
-          :submitting="submission.submitting.value"
-          :blocked="submission.blockedByToken.value"
-          :disabled="!canSubmit"
-          @click="send"
-        />
-        <Btn variant="linkButton" size="md" @click="cancel">{{ t("cancel") }}</Btn>
+      <div class="mt-6 flex flex-col items-end gap-2">
+        <p v-if="blockingReason" class="text-amber-700 dark:text-amber-300 text-right text-xs">
+          {{ blockingReason }}
+        </p>
+        <div class="flex flex-row-reverse gap-2">
+          <FeedbackSubmitButton
+            :submitting="submission.submitting.value"
+            :blocked="submission.blockedByToken.value"
+            :disabled="!canSubmit"
+            @click="send"
+          />
+          <Btn variant="linkButton" size="md" @click="cancel">{{ t("cancel") }}</Btn>
+        </div>
       </div>
     </template>
 
@@ -174,6 +187,8 @@ async function cancel() {
 de:
   title: Neuen Eintrag vorschlagen
   description: Schlage einen neuen Raum, ein neues Gebäude, einen POI oder eine Veranstaltung für NavigaTUM vor.
+  blocked_incomplete: Bitte fülle alle hervorgehobenen Pflichtfelder aus, um den Vorschlag zu senden.
+  blocked_consent: Bitte akzeptiere die Datenschutzerklärung, um den Vorschlag zu senden.
   cancel: Abbrechen
   back_home: Zur Startseite
   thank_you: Vielen Dank!
@@ -183,6 +198,8 @@ de:
 en:
   title: Propose a new entry
   description: Propose a new room, building, POI, or event for NavigaTUM.
+  blocked_incomplete: Please complete all highlighted required fields to send the proposal.
+  blocked_consent: Please accept the privacy statement to send the proposal.
   cancel: Cancel
   back_home: Back to home
   thank_you: Thank you!

--- a/webclient/test/submissionGate.test.ts
+++ b/webclient/test/submissionGate.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { type SubmissionGateState, submissionBlock } from "../app/composables/submissionGate";
+
+const ready: SubmissionGateState = {
+  submitting: false,
+  succeeded: false,
+  blockedByToken: false,
+  draftReady: true,
+  privacyChecked: true,
+};
+
+describe("submissionBlock", () => {
+  it("allows sending once every gate is satisfied", () => {
+    expect(submissionBlock(ready)).toBeNull();
+  });
+
+  it.each([
+    ["submitting", { submitting: true }, "submitting"],
+    ["already succeeded", { succeeded: true }, "already_succeeded"],
+    ["token unavailable", { blockedByToken: true }, "token_unavailable"],
+    ["incomplete form", { draftReady: false }, "incomplete_fields"],
+    ["consent missing", { privacyChecked: false }, "consent_missing"],
+  ] as const)("blocks on %s", (_label, override, expected) => {
+    expect(submissionBlock({ ...ready, ...override })).toBe(expected);
+  });
+
+  it("never silently disables for a user-actionable reason", () => {
+    for (const draftReady of [true, false]) {
+      for (const privacyChecked of [true, false]) {
+        const block = submissionBlock({ ...ready, draftReady, privacyChecked });
+        const expected = draftReady
+          ? privacyChecked
+            ? null
+            : "consent_missing"
+          : "incomplete_fields";
+        expect(block).toBe(expected);
+      }
+    }
+  });
+});


### PR DESCRIPTION
The page read the form's ref-unwrapped `draftIsReady` with a stray `.value` (always `undefined`, so Send stayed greyed out); this fixes the read, types `formRef` from the component so it can't recur, and surfaces why a blocked Send is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)