### PR TITLE
fix(webclient): group same-hours days into one opening-hours rule

### DIFF
--- a/webclient/app/utils/openingHoursEditor.ts
+++ b/webclient/app/utils/openingHoursEditor.ts
@@ -1,18 +1,51 @@
-// Weekdays in OSM order. The assembler collapses runs of consecutive days that
-// share the same hours, so this order also defines what counts as "consecutive".
+// Weekdays in OSM order. The assembler groups days that share the same hours
+// into one rule, so this order defines both rule order and what counts as a
+// consecutive `Mo-We`-style run inside a day selector.
 export const OPENING_HOURS_DAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"] as const;
 export type OpeningHoursWeekday = (typeof OPENING_HOURS_DAYS)[number];
 
+// Every well-formed `HH:MM` (24h) wall-clock time and nothing else, built as
+// digit crossings (24 x 60 literals) so a malformed literal such as `"8:00"` is
+// a compile error, not just a runtime rejection. `TIME_RE` is the runtime
+// mirror of this type; keep the two in sync.
+type Digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9";
+type Hour = `${"0" | "1"}${Digit}` | `2${"0" | "1" | "2" | "3"}`;
+type Minute = `${"0" | "1" | "2" | "3" | "4" | "5"}${Digit}`;
+export type ClockTime = `${Hour}:${Minute}`;
+
+const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
 export interface TimeRange {
-  /** Opening time as `HH:MM` (24h). */
+  /** Opening time as `HH:MM` (24h); free-form until `isValidTimeRange` proves it. */
   from: string;
-  /** Closing time as `HH:MM` (24h). */
+  /** Closing time as `HH:MM` (24h); free-form until `isValidTimeRange` proves it. */
   to: string;
+}
+
+declare const validTimeRange: unique symbol;
+
+/**
+ * A `TimeRange` proven well-formed: both ends are `ClockTime`s and `from`
+ * precedes `to`. The ordering invariant has no structural encoding, so the
+ * symbol brand makes the `isValidTimeRange` guard the only way to obtain one.
+ */
+export interface ValidTimeRange {
+  readonly from: ClockTime;
+  readonly to: ClockTime;
+  readonly [validTimeRange]: true;
 }
 
 export type WeekSchedule = Record<OpeningHoursWeekday, TimeRange[]>;
 
-const TIME_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+// The editor components own the mutable draft types; the assemblers below take
+// these deep read-only views instead, so the type system proves they never
+// mutate a draft.
+type DeepReadonly<T> = T extends readonly (infer U)[]
+  ? readonly DeepReadonly<U>[]
+  : T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+export type WeekScheduleView = DeepReadonly<WeekSchedule>;
 
 export function emptyWeekSchedule(): WeekSchedule {
   return {
@@ -28,14 +61,14 @@ export function emptyWeekSchedule(): WeekSchedule {
 
 // A range is valid when both ends are `HH:MM` and it does not run backwards.
 // Overnight spans (e.g. 22:00-02:00) are intentionally rejected for v1.
-export function isValidTimeRange(range: TimeRange): boolean {
+export function isValidTimeRange(range: Readonly<TimeRange>): range is ValidTimeRange {
   return TIME_RE.test(range.from) && TIME_RE.test(range.to) && range.from < range.to;
 }
 
 // Drop invalid ranges, deduplicate, and sort so the hours are deterministic
 // regardless of the order the user entered them, then join as one OSM time
 // selector (e.g. `08:00-12:00,13:00-17:00`). Empty when nothing is valid.
-export function osmRangeList(ranges: readonly TimeRange[]): string {
+export function osmRangeList(ranges: readonly Readonly<TimeRange>[]): string {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const range of ranges) {
@@ -48,38 +81,56 @@ export function osmRangeList(ranges: readonly TimeRange[]): string {
   return out.sort().join(",");
 }
 
+// An OSM weekday selector for the given days. Lone days stay `Fr`; a two-day
+// run stays a plain list (`Mo,Tu` - a dash between adjacent days names no day
+// in between and reads oddly); runs of three or more collapse to `Mo-We`.
+// Runs join with commas (`Mo-We,Fr`).
+function osmDaySelector(openDays: ReadonlySet<OpeningHoursWeekday>): string {
+  const runs: { start: OpeningHoursWeekday; end: OpeningHoursWeekday; length: number }[] = [];
+  let previousDayOpen = false;
+  for (const day of OPENING_HOURS_DAYS) {
+    const open = openDays.has(day);
+    if (open) {
+      const run = previousDayOpen ? runs.at(-1) : undefined;
+      if (run) {
+        run.end = day;
+        run.length += 1;
+      } else {
+        runs.push({ start: day, end: day, length: 1 });
+      }
+    }
+    previousDayOpen = open;
+  }
+  return runs
+    .map(({ start, end, length }) => {
+      if (length === 1) return start;
+      return length === 2 ? `${start},${end}` : `${start}-${end}`;
+    })
+    .join(",");
+}
+
 /**
  * Assemble a structured week into a plain OSM `opening_hours` string.
  *
- * Days that share identical hours are collapsed into a single `Mo-Fr 08:00-20:00`
- * rule; days with no valid ranges are treated as closed and omitted entirely
- * (their absence is what marks them closed in OSM). Returns `""` when every day
- * is closed, which `hasWeeklyHours` reads as "no weekly schedule to submit".
+ * All days that share identical hours are grouped into a single rule, even
+ * non-adjacent ones (`Tu,Th 13:00-13:30`, `Mo-We,Fr 08:00-18:00`); days with no
+ * valid ranges are treated as closed and omitted entirely (their absence is
+ * what marks them closed in OSM). Grouping is purely syntactic: every day still
+ * appears in exactly one rule, so OSM's per-day override semantics are
+ * unaffected. Returns `""` when every day is closed, which `hasWeeklyHours`
+ * reads as "no weekly schedule to submit".
  */
-export function buildOsmOpeningHours(week: WeekSchedule): string {
-  const perDay = OPENING_HOURS_DAYS.map((day) => osmRangeList(week[day]));
-
-  const rules: string[] = [];
-  let runStart = 0;
-  while (runStart < OPENING_HOURS_DAYS.length) {
-    const hours = perDay[runStart] ?? "";
-    if (!hours) {
-      runStart += 1;
-      continue;
-    }
-    let runEnd = runStart;
-    while (runEnd + 1 < OPENING_HOURS_DAYS.length && perDay[runEnd + 1] === hours) {
-      runEnd += 1;
-    }
-    const days =
-      runStart === runEnd
-        ? OPENING_HOURS_DAYS[runStart]
-        : `${OPENING_HOURS_DAYS[runStart]}-${OPENING_HOURS_DAYS[runEnd]}`;
-    rules.push(`${days} ${hours}`);
-    runStart = runEnd + 1;
+export function buildOsmOpeningHours(week: WeekScheduleView): string {
+  // Map insertion order is first-occurrence day order, which fixes the rule order.
+  const daysByHours = new Map<string, Set<OpeningHoursWeekday>>();
+  for (const day of OPENING_HOURS_DAYS) {
+    const hours = osmRangeList(week[day]);
+    if (!hours) continue;
+    const days = daysByHours.get(hours);
+    if (days) days.add(day);
+    else daysByHours.set(hours, new Set([day]));
   }
-
-  return rules.join("; ");
+  return Array.from(daysByHours, ([hours, days]) => `${osmDaySelector(days)} ${hours}`).join("; ");
 }
 
 // The semester-macro prefixes the data pipeline understands: `lecture:`
@@ -112,6 +163,8 @@ export interface OpeningHoursDraft {
   sourceUrl: string;
 }
 
+export type OpeningHoursDraftView = DeepReadonly<OpeningHoursDraft>;
+
 export function emptyOpeningHoursDraft(): OpeningHoursDraft {
   return {
     mode: "always",
@@ -126,24 +179,27 @@ export function emptyOpeningHoursDraft(): OpeningHoursDraft {
 // Whether the draft states any regular weekly hours. The holiday rule only
 // augments a weekly schedule, so a bare `PH off` default must not count as a
 // schedule worth submitting on its own.
-export function hasWeeklyHours(draft: OpeningHoursDraft): boolean {
+export function hasWeeklyHours(draft: OpeningHoursDraftView): boolean {
   return activeWeeks(draft).some((week) => buildOsmOpeningHours(week) !== "");
 }
 
 // The OSM `PH` rule. Mirrors a weekday: hours when open, `PH off` when the
 // holiday row is left empty (most facilities are shut on public holidays).
-export function buildPublicHolidayRule(ranges: TimeRange[]): string {
+// The return type records that, unlike a weekly schedule, it is never empty.
+export function buildPublicHolidayRule(ranges: readonly Readonly<TimeRange>[]): `PH ${string}` {
   const hours = osmRangeList(ranges);
   return hours ? `PH ${hours}` : "PH off";
 }
 
 // The week schedules that actually contribute for the chosen mode; the others
 // are kept as drafts but ignored, so toggling modes never loses what was typed.
-export function activeWeeks(draft: OpeningHoursDraft): WeekSchedule[] {
+export function activeWeeks(
+  draft: OpeningHoursDraftView
+): readonly [WeekScheduleView] | readonly [WeekScheduleView, WeekScheduleView] {
   return draft.mode === "always" ? [draft.always] : [draft.lecture, draft.break];
 }
 
-export function draftHasInvalidRange(draft: OpeningHoursDraft): boolean {
+export function draftHasInvalidRange(draft: OpeningHoursDraftView): boolean {
   const weekInvalid = activeWeeks(draft).some((week) =>
     OPENING_HOURS_DAYS.some((day) => week[day].some((range) => !isValidTimeRange(range)))
   );
@@ -159,7 +215,7 @@ export function draftHasInvalidRange(draft: OpeningHoursDraft): boolean {
  * public-holiday (`PH`) rule is always appended, defaulting to `PH off`, so the
  * result is never empty - callers gate submission on `hasWeeklyHours` instead.
  */
-export function buildDraftOpeningHours(draft: OpeningHoursDraft): string {
+export function buildDraftOpeningHours(draft: OpeningHoursDraftView): string {
   const base =
     draft.mode === "always"
       ? buildOsmOpeningHours(draft.always)
@@ -171,7 +227,6 @@ export function buildDraftOpeningHours(draft: OpeningHoursDraft): string {
           .join("; ");
 
   const rules = base ? [base] : [];
-  const holiday = buildPublicHolidayRule(draft.holiday);
-  if (holiday) rules.push(holiday);
+  rules.push(buildPublicHolidayRule(draft.holiday));
   return rules.join("; ");
 }

--- a/webclient/test/openingHoursEditor.test.ts
+++ b/webclient/test/openingHoursEditor.test.ts
@@ -48,15 +48,50 @@ describe("buildOsmOpeningHours", () => {
     expect(buildOsmOpeningHours(w)).toBe("Mo-Fr 08:00-20:00");
   });
 
-  it("emits distinct rules and omits closed days", () => {
+  it("groups non-adjacent days with identical hours into one rule", () => {
     const w = week({
       Mo: [{ from: "08:00", to: "20:00" }],
       Tu: [{ from: "08:00", to: "20:00" }],
       Fr: [{ from: "08:00", to: "20:00" }],
       Sa: [{ from: "09:00", to: "14:00" }],
     });
-    // We/Th are closed, so the Mo-Tu run breaks before Fr.
-    expect(buildOsmOpeningHours(w)).toBe("Mo-Tu 08:00-20:00; Fr 08:00-20:00; Sa 09:00-14:00");
+    // We/Th are closed and omitted; Fr joins the Mo,Tu rule as a day-list entry.
+    expect(buildOsmOpeningHours(w)).toBe("Mo,Tu,Fr 08:00-20:00; Sa 09:00-14:00");
+  });
+
+  it("renders a two-day run as a list and three or more as a range", () => {
+    const hours = [{ from: "08:00", to: "18:00" }];
+    // `Mo-Tu` names no day in between, so the dash only starts at three days.
+    expect(buildOsmOpeningHours(week({ Mo: hours, Tu: hours }))).toBe("Mo,Tu 08:00-18:00");
+    expect(buildOsmOpeningHours(week({ Mo: hours, Tu: hours, We: hours }))).toBe(
+      "Mo-We 08:00-18:00"
+    );
+  });
+
+  it("groups lone same-hours days into a day list", () => {
+    const w = week({
+      Tu: [{ from: "13:00", to: "13:30" }],
+      Th: [{ from: "13:00", to: "13:30" }],
+    });
+    expect(buildOsmOpeningHours(w)).toBe("Tu,Th 13:00-13:30");
+  });
+
+  it("mixes a consecutive run and a lone day in one selector", () => {
+    const w = week({
+      Mo: [{ from: "08:00", to: "18:00" }],
+      Tu: [{ from: "08:00", to: "18:00" }],
+      We: [{ from: "08:00", to: "18:00" }],
+      Fr: [{ from: "08:00", to: "18:00" }],
+    });
+    expect(buildOsmOpeningHours(w)).toBe("Mo-We,Fr 08:00-18:00");
+  });
+
+  it("keeps days with different hours in separate rules", () => {
+    const w = week({
+      Tu: [{ from: "13:00", to: "13:30" }],
+      Th: [{ from: "13:00", to: "14:00" }],
+    });
+    expect(buildOsmOpeningHours(w)).toBe("Tu 13:00-13:30; Th 13:00-14:00");
   });
 
   it("renders a single open day without a range dash", () => {
@@ -131,7 +166,7 @@ describe("buildDraftOpeningHours", () => {
     draft.always.Tu = [{ from: "08:00", to: "20:00" }];
     // The lecture/break drafts are ignored while mode is "always".
     draft.lecture.Mo = [{ from: "06:00", to: "07:00" }];
-    expect(buildDraftOpeningHours(draft)).toBe("Mo-Tu 08:00-20:00; PH off");
+    expect(buildDraftOpeningHours(draft)).toBe("Mo,Tu 08:00-20:00; PH off");
   });
 
   it("combines lecture and break schedules with macros in semester mode", () => {
@@ -141,7 +176,7 @@ describe("buildDraftOpeningHours", () => {
     draft.lecture.Tu = [{ from: "08:00", to: "20:00" }];
     draft.break.Mo = [{ from: "10:00", to: "16:00" }];
     expect(buildDraftOpeningHours(draft)).toBe(
-      "lecture: Mo-Tu 08:00-20:00; break: Mo 10:00-16:00; PH off"
+      "lecture: Mo,Tu 08:00-20:00; break: Mo 10:00-16:00; PH off"
     );
   });
 
@@ -150,6 +185,16 @@ describe("buildDraftOpeningHours", () => {
     draft.mode = "semester";
     draft.lecture.Mo = [{ from: "08:00", to: "20:00" }];
     expect(buildDraftOpeningHours(draft)).toBe("lecture: Mo 08:00-20:00; PH off");
+  });
+
+  it("emits one macro prefix for same-hours days in semester mode", () => {
+    const draft = emptyOpeningHoursDraft();
+    draft.mode = "semester";
+    draft.lecture.Tu = [{ from: "13:00", to: "13:30" }];
+    draft.lecture.Th = [{ from: "13:00", to: "13:30" }];
+    // Grouping into a day list keeps this a single rule, so `scopeOsmRules`
+    // does not repeat the `lecture:` prefix per day.
+    expect(buildDraftOpeningHours(draft)).toBe("lecture: Tu,Th 13:00-13:30; PH off");
   });
 
   it("ignores invalid ranges in inactive periods", () => {


### PR DESCRIPTION
The opening-hours feedback serializer now groups all days sharing identical hours into one OSM rule with a day-list selector (dashes only for runs of three or more days), so semester-mode proposals submit `lecture: Tu,Th 13:00-13:30; PH off` instead of repeating the `lecture:` macro for every day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)