### PR TITLE
feat(server): upsert event proposals by the addition key

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -2623,7 +2623,9 @@ components:
             - "null"
     NewEvent:
       type: object
-      description: A proposed campus event, appended as a row to `data/sources/events.csv`.
+      description: |-
+        A proposed campus event, upserted by key into `data/sources/events.csv`: a row whose
+        image path derives from the addition key is replaced, otherwise the event is appended.
       required:
         - image
         - name

--- a/server/src/routes/feedback/proposed_edits/addition/building.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/building.rs
@@ -190,7 +190,7 @@ mod tests {
         clippy::panic_in_result_fn,
         reason = "tests assert via panic/unwrap"
     )]
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::fs;
 
     use insta::assert_snapshot;
@@ -216,6 +216,7 @@ mod tests {
             poi_keys: HashSet::new(),
             usage_ids: HashSet::new(),
             org_ids: HashSet::new(),
+            event_row_counts: HashMap::new(),
             now: chrono::Utc::now(),
         }
     }

--- a/server/src/routes/feedback/proposed_edits/addition/event.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/event.rs
@@ -1,5 +1,8 @@
 use std::fs::{self, OpenOptions};
-use std::path::Path;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::str;
 
 use chrono::{DateTime, Duration, FixedOffset, Utc};
 use serde::Deserialize;
@@ -16,7 +19,8 @@ const MIN_IMAGE_DIM: u32 = 256;
 const MAX_HORIZON_DAYS: i64 = 365;
 const MAX_DURATION_DAYS: i64 = 30;
 
-/// A proposed campus event, appended as a row to `data/sources/events.csv`.
+/// A proposed campus event, upserted by key into `data/sources/events.csv`: a row whose
+/// image path derives from the addition key is replaced, otherwise the event is appended.
 #[derive(Debug, Deserialize, Clone, utoipa::ToSchema)]
 pub struct NewEvent {
     pub image: Image,
@@ -40,6 +44,14 @@ fn is_valid_event_key(key: &str) -> bool {
         && hash
             .bytes()
             .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// The addition key an `event_image` CSV value derives from (`/cdn/thumb/{key}_{slot}.webp`).
+pub(super) fn event_key_of_image_path(image: &str) -> Option<&str> {
+    let stem = image.strip_prefix("/cdn/thumb/")?.strip_suffix(".webp")?;
+    let (key, slot) = stem.rsplit_once('_')?;
+    (!slot.is_empty() && slot.bytes().all(|b| b.is_ascii_digit()) && is_valid_event_key(key))
+        .then_some(key)
 }
 
 /// `D.M.YY HH:MM` (no zero padding) in the event's own offset.
@@ -112,18 +124,10 @@ impl NewEvent {
         Ok(())
     }
 
-    fn append_events_row(&self, image: &str, base_dir: &Path) -> anyhow::Result<()> {
-        let csv_path = base_dir.join("data").join("sources").join("events.csv");
-        // Guard a missing trailing newline, so the row isn't glued onto the last one.
-        if let Some(&last) = fs::read(&csv_path)?.last()
-            && last != b'\n'
-        {
-            anyhow::bail!("events.csv does not end with a newline; refusing to append");
-        }
-        let file = OpenOptions::new().append(true).open(&csv_path)?;
+    fn write_row(&self, image: &str, out: impl io::Write) -> anyhow::Result<()> {
         let mut writer = csv::WriterBuilder::new()
             .has_headers(false)
-            .from_writer(file);
+            .from_writer(out);
         writer.write_record([
             image,
             &self.coords.lat().to_string(),
@@ -138,12 +142,83 @@ impl NewEvent {
         writer.flush()?;
         Ok(())
     }
+
+    fn append_events_row(&self, image: &str, csv_path: &Path) -> anyhow::Result<()> {
+        // Guard a missing trailing newline, so the row isn't glued onto the last one.
+        if let Some(&last) = fs::read(csv_path)?.last()
+            && last != b'\n'
+        {
+            anyhow::bail!("events.csv does not end with a newline; refusing to append");
+        }
+        let file = OpenOptions::new().append(true).open(csv_path)?;
+        self.write_row(image, file)
+    }
+
+    /// Splices the new row over `row` so every other byte of the CSV stays untouched.
+    fn replace_events_row(
+        &self,
+        image: &str,
+        csv_path: &Path,
+        raw: &[u8],
+        row: Range<usize>,
+    ) -> anyhow::Result<()> {
+        let before = raw
+            .get(..row.start)
+            .ok_or_else(|| anyhow::anyhow!("row start {} outside events.csv", row.start))?;
+        let after = raw
+            .get(row.end..)
+            .ok_or_else(|| anyhow::anyhow!("row end {} outside events.csv", row.end))?;
+        let mut out = Vec::with_capacity(raw.len());
+        out.extend_from_slice(before);
+        self.write_row(image, &mut out)?;
+        out.extend_from_slice(after);
+        fs::write(csv_path, out)?;
+        Ok(())
+    }
+}
+
+fn events_csv_path(base_dir: &Path) -> PathBuf {
+    base_dir.join("data").join("sources").join("events.csv")
+}
+
+/// Byte range of the single `events.csv` row whose image path derives from `key`.
+fn matching_row_range(raw: &[u8], key: &str) -> anyhow::Result<Option<Range<usize>>> {
+    let mut reader = csv::Reader::from_reader(raw);
+    reader.byte_headers()?;
+    let mut record = csv::ByteRecord::new();
+    let mut matched = None;
+    loop {
+        let start = usize::try_from(reader.position().byte())?;
+        if !reader.read_byte_record(&mut record)? {
+            break;
+        }
+        let image = str::from_utf8(record.get(0).unwrap_or_default())?;
+        if event_key_of_image_path(image) == Some(key) {
+            // validate() already rejects multi-match keys; a second hit here means the CSV
+            // changed between validation and apply.
+            anyhow::ensure!(
+                matched.is_none(),
+                "multiple events.csv rows match `{key}`; refusing to replace"
+            );
+            matched = Some(start..usize::try_from(reader.position().byte())?);
+        }
+    }
+    Ok(matched)
 }
 
 impl AppliableAddition for NewEvent {
     fn validate(&self, key: &str, snap: &RepoSnapshot) -> Result<(), AdditionError> {
         if !is_valid_event_key(key) {
             return Err(AdditionError::BadId(key.to_string()));
+        }
+        // Identity = key, so one existing row is an update; more than one (legacy data
+        // only) leaves no way to pick the row to replace.
+        let row_count = snap.event_row_counts.get(key).copied().unwrap_or(0);
+        if row_count > 1 {
+            return Err(AdditionError::DuplicateEventRows {
+                key: key.to_string(),
+                count: row_count,
+            });
         }
         if self.name.trim().is_empty() || self.name.len() > MAX_NAME_LEN {
             return Err(AdditionError::BadName {
@@ -165,13 +240,23 @@ impl AppliableAddition for NewEvent {
     }
 
     fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<String> {
-        let image_md = self.image.apply(key, base_dir, branch)?;
+        let csv_path = events_csv_path(base_dir);
+        let raw = fs::read(&csv_path)?;
         // Content-addressed key, so always the first slot.
         let image = format!("/cdn/thumb/{key}_0.webp");
-        self.append_events_row(&image, base_dir)?;
+        // Identity = key: an existing row under this key makes the addition an update.
+        let (verb, image_md) = if let Some(row) = matching_row_range(&raw, key)? {
+            let image_md = self.image.replace(key, base_dir, branch)?;
+            self.replace_events_row(&image, &csv_path, &raw, row)?;
+            ("update", image_md)
+        } else {
+            let image_md = self.image.apply(key, base_dir, branch)?;
+            self.append_events_row(&image, &csv_path)?;
+            ("new", image_md)
+        };
 
         Ok(format!(
-            "new event `{name}` ({starts_at} - {ends_at}, org `{org}`)\n\n{image_md}",
+            "{verb} event `{name}` ({starts_at} - {ends_at}, org `{org}`)\n\n{image_md}",
             name = self.name,
             starts_at = format_de(&self.starts_at)?,
             ends_at = format_de(&self.ends_at)?,
@@ -194,7 +279,7 @@ mod tests {
         clippy::needless_pass_by_value,
         reason = "tests assert via panic/unwrap and index into known-shape JSON fixtures"
     )]
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::io::Cursor;
 
     use base64::Engine as _;
@@ -228,6 +313,7 @@ mod tests {
             poi_keys: HashSet::new(),
             usage_ids: HashSet::new(),
             org_ids: HashSet::from([51897]),
+            event_row_counts: HashMap::new(),
             now,
         }
     }
@@ -249,6 +335,21 @@ mod tests {
 
     fn sample_event() -> NewEvent {
         serde_json::from_value(event_json(json!(image_b64(300, 300)))).unwrap()
+    }
+
+    #[rstest]
+    #[case::slot0(
+        "/cdn/thumb/event_9d02ddd940c43f87_0.webp",
+        Some("event_9d02ddd940c43f87")
+    )]
+    #[case::higher_slot("/cdn/thumb/event_abc_12.webp", Some("event_abc"))]
+    #[case::missing_leading_slash("cdn/thumb/event_abc_0.webp", None)]
+    #[case::no_slot("/cdn/thumb/event_abc.webp", None)]
+    #[case::non_numeric_slot("/cdn/thumb/event_abc_x.webp", None)]
+    #[case::not_an_event("/cdn/thumb/5510.02.001_0.webp", None)]
+    #[case::uppercase_hash("/cdn/thumb/event_ABC_0.webp", None)]
+    fn derives_event_key_from_image_path(#[case] image: &str, #[case] expected: Option<&str>) {
+        assert_eq!(event_key_of_image_path(image), expected);
     }
 
     #[test]
@@ -353,6 +454,30 @@ mod tests {
     }
 
     #[test]
+    fn key_with_multiple_existing_rows_is_rejected() {
+        let mut snap = snapshot_at(fixed_now());
+        snap.event_row_counts
+            .insert("event_9d02ddd940c43f87".to_string(), 2);
+        let err = sample_event()
+            .validate("event_9d02ddd940c43f87", &snap)
+            .unwrap_err();
+        assert!(
+            matches!(err, AdditionError::DuplicateEventRows { count: 2, .. }),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn key_with_one_existing_row_passes_validation() {
+        let mut snap = snapshot_at(fixed_now());
+        snap.event_row_counts
+            .insert("event_9d02ddd940c43f87".to_string(), 1);
+        sample_event()
+            .validate("event_9d02ddd940c43f87", &snap)
+            .unwrap();
+    }
+
+    #[test]
     fn unknown_org_id_is_rejected() {
         let mut value = event_json(json!(image_b64(300, 300)));
         value["organising_org_id"] = json!(999_999);
@@ -363,6 +488,111 @@ mod tests {
         assert!(
             matches!(err, AdditionError::UnknownOrgId(999_999)),
             "got: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_replaces_existing_row_for_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let sources = dir.path().join("data").join("sources");
+        let lg = sources.join("img").join("lg");
+        fs::create_dir_all(&lg).unwrap();
+        fs::write(
+            sources.join("img").join("img-sources.yaml"),
+            "event_9d02ddd940c43f87:\n  0:\n    author: Old Author\n    license:\n      text: Old-License\n",
+        )
+        .unwrap();
+        fs::write(lg.join("event_9d02ddd940c43f87_0.webp"), b"old-bytes").unwrap();
+        // The multi-line quoted description before the matched row is the shape a naive
+        // line-based replace would corrupt.
+        fs::write(
+            sources.join("events.csv"),
+            "event_image,event_lat,event_lon,event_name,event_datetime_start_at,event_datetime_end_at,event_description,event_organising_org_id,event_image_author\n\
+            /cdn/thumb/event_aaa_0.webp,48.1,11.5,Before,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,\"multi\nline, stays untouched\",1,Studi\n\
+            /cdn/thumb/event_9d02ddd940c43f87_0.webp,48.0,11.0,Old Name,2026-06-01T10:00:00+02:00,2026-06-02T10:00:00+02:00,Old description.,99,Old Author\n\
+            /cdn/thumb/event_bbb_0.webp,48.2,11.6,After,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,stays too,1,Studi\n",
+        )
+        .unwrap();
+
+        let summary = sample_event()
+            .apply("event_9d02ddd940c43f87", dir.path(), "branch")
+            .unwrap();
+        assert_snapshot!(summary, @r"
+        update event `GARNIX Festival` (10.6.26 16:00 - 12.6.26 23:00, org `51897`)
+
+        ![image showing event_9d02ddd940c43f87](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp)
+        ");
+
+        let csv = fs::read_to_string(sources.join("events.csv")).unwrap();
+        assert_snapshot!(csv, @r#"
+        event_image,event_lat,event_lon,event_name,event_datetime_start_at,event_datetime_end_at,event_description,event_organising_org_id,event_image_author
+        /cdn/thumb/event_aaa_0.webp,48.1,11.5,Before,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,"multi
+        line, stays untouched",1,Studi
+        /cdn/thumb/event_9d02ddd940c43f87_0.webp,48.262908,11.669102,GARNIX Festival,2026-06-10T16:00:00+02:00,2026-06-12T23:00:00+02:00,"Live music, food trucks, and stands.",51897,Studi
+        /cdn/thumb/event_bbb_0.webp,48.2,11.6,After,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,stays too,1,Studi
+        "#);
+    }
+
+    #[test]
+    fn update_replaces_image_files_and_metadata_idempotently() {
+        let dir = tempfile::tempdir().unwrap();
+        let sources = dir.path().join("data").join("sources");
+        let lg = sources.join("img").join("lg");
+        fs::create_dir_all(&lg).unwrap();
+        // A legacy second slot plus a foreign key's entry: the update must drop the former
+        // and leave the latter alone.
+        fs::write(
+            sources.join("img").join("img-sources.yaml"),
+            "event_9d02ddd940c43f87:\n  0:\n    author: Old Author\n    license:\n      text: Old-License\n  1:\n    author: Stray Author\n    license:\n      text: Stray-License\nevent_bbb:\n  0:\n    author: Other\n    license:\n      text: CC0\n",
+        )
+        .unwrap();
+        fs::write(lg.join("event_9d02ddd940c43f87_0.webp"), b"old-bytes").unwrap();
+        fs::write(lg.join("event_9d02ddd940c43f87_1.webp"), b"stray-bytes").unwrap();
+        fs::write(lg.join("event_bbb_0.webp"), b"other-bytes").unwrap();
+        fs::write(
+            sources.join("events.csv"),
+            "event_image,event_lat,event_lon,event_name,event_datetime_start_at,event_datetime_end_at,event_description,event_organising_org_id,event_image_author\n\
+            /cdn/thumb/event_9d02ddd940c43f87_0.webp,48.0,11.0,Old Name,2026-06-01T10:00:00+02:00,2026-06-02T10:00:00+02:00,Old description.,99,Old Author\n",
+        )
+        .unwrap();
+
+        sample_event()
+            .apply("event_9d02ddd940c43f87", dir.path(), "branch")
+            .unwrap();
+
+        let poster = fs::read(lg.join("event_9d02ddd940c43f87_0.webp")).unwrap();
+        assert_ne!(poster, b"old-bytes");
+        assert!(!lg.join("event_9d02ddd940c43f87_1.webp").exists());
+        assert_eq!(
+            fs::read(lg.join("event_bbb_0.webp")).unwrap(),
+            b"other-bytes"
+        );
+        let yaml = fs::read_to_string(sources.join("img").join("img-sources.yaml")).unwrap();
+        assert_snapshot!(yaml, @r"
+        event_9d02ddd940c43f87:
+          0:
+            author: Studi
+            license:
+              text: CC-BY
+        event_bbb:
+          0:
+            author: Other
+            license:
+              text: CC0
+        ");
+
+        // Resubmitting the identical request must not change the files again.
+        let csv_after_first = fs::read(sources.join("events.csv")).unwrap();
+        sample_event()
+            .apply("event_9d02ddd940c43f87", dir.path(), "branch")
+            .unwrap();
+        assert_eq!(
+            fs::read(lg.join("event_9d02ddd940c43f87_0.webp")).unwrap(),
+            poster
+        );
+        assert_eq!(
+            fs::read(sources.join("events.csv")).unwrap(),
+            csv_after_first
         );
     }
 

--- a/server/src/routes/feedback/proposed_edits/addition/poi.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/poi.rs
@@ -168,7 +168,7 @@ mod tests {
         clippy::panic_in_result_fn,
         reason = "tests assert via panic/unwrap"
     )]
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::fs;
 
     use insta::assert_snapshot;
@@ -185,6 +185,7 @@ mod tests {
             poi_keys: HashSet::from(["existing-poi".to_string()]),
             usage_ids: HashSet::new(),
             org_ids: HashSet::new(),
+            event_row_counts: HashMap::new(),
             now: chrono::Utc::now(),
         }
     }

--- a/server/src/routes/feedback/proposed_edits/addition/room.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/room.rs
@@ -207,7 +207,7 @@ mod tests {
         clippy::panic_in_result_fn,
         reason = "tests assert via panic/unwrap"
     )]
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::fs;
 
     use insta::assert_snapshot;
@@ -224,6 +224,7 @@ mod tests {
             poi_keys: HashSet::new(),
             usage_ids: HashSet::from([12]),
             org_ids: HashSet::new(),
+            event_row_counts: HashMap::new(),
             now: chrono::Utc::now(),
         }
     }

--- a/server/src/routes/feedback/proposed_edits/addition/validation.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/validation.rs
@@ -1,6 +1,6 @@
 //! Validates against the cloned `TempRepo` itself, not an in-memory cache, so additions can't
 //! pass validation against state that has already drifted from disk.
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::fs::{self, File};
 use std::io::{BufRead as _, BufReader, ErrorKind};
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use super::areatree::{AreatreeIndex, AreatreeKind};
+use super::event::event_key_of_image_path;
 
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -108,6 +109,8 @@ pub enum AdditionError {
     ImageTooSmall { width: u32, height: u32, min: u32 },
     #[error("organising_org_id {0} is not in orgs-de_tumonline.csv")]
     UnknownOrgId(i32),
+    #[error("events.csv contains {count} rows for `{key}`; cannot determine which row to replace")]
+    DuplicateEventRows { key: String, count: usize },
 }
 
 #[derive(Debug)]
@@ -118,6 +121,9 @@ pub struct RepoSnapshot {
     pub poi_keys: HashSet<String>,
     pub usage_ids: HashSet<u32>,
     pub org_ids: HashSet<i32>,
+    /// How many `events.csv` rows derive from each event key; an event addition under a key
+    /// with exactly one row is an update, more than one is a validation failure.
+    pub event_row_counts: HashMap<String, usize>,
     /// Request time, so now-relative addition rules are deterministic per request.
     pub now: DateTime<Utc>,
 }
@@ -201,6 +207,23 @@ impl RepoSnapshot {
             .filter_map(|s| s.parse::<i32>().ok())
             .collect();
 
+        let events_csv = base_dir.join("data").join("sources").join("events.csv");
+        let event_row_counts = match File::open(&events_csv) {
+            Ok(file) => {
+                let mut counts: HashMap<String, usize> = HashMap::new();
+                // Descriptions span multiple lines, so this needs a real CSV parser.
+                for record in csv::Reader::from_reader(file).into_records() {
+                    let record = record?;
+                    if let Some(key) = record.get(0).and_then(event_key_of_image_path) {
+                        *counts.entry(key.to_string()).or_default() += 1;
+                    }
+                }
+                counts
+            }
+            Err(e) if e.kind() == ErrorKind::NotFound => HashMap::new(),
+            Err(e) => return Err(e.into()),
+        };
+
         Ok(Self {
             areatree,
             tumonline_room_codes,
@@ -208,6 +231,7 @@ impl RepoSnapshot {
             poi_keys,
             usage_ids,
             org_ids,
+            event_row_counts,
             now: Utc::now(),
         })
     }
@@ -293,5 +317,26 @@ mod tests {
         assert!(snap.org_ids.contains(&1));
         assert!(snap.poi_keys.contains("validierungsautomat-1"));
         assert!(snap.user_added_room_codes.contains("5117.EG.999"));
+        // No events.csv in this fixture, so no event rows are counted.
+        assert!(snap.event_row_counts.is_empty());
+    }
+
+    #[test]
+    fn counts_event_rows_by_key() {
+        let dir = build_dir();
+        // The duplicate `event_aaa` rows and the multi-line quoted description are the two
+        // legacy-data shapes the counting has to survive.
+        fs::write(
+            dir.path().join("data").join("sources").join("events.csv"),
+            "event_image,event_lat,event_lon,event_name,event_datetime_start_at,event_datetime_end_at,event_description,event_organising_org_id,event_image_author\n\
+            /cdn/thumb/event_aaa_0.webp,48.1,11.5,A,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,\"multi\nline, description\",1,Studi\n\
+            /cdn/thumb/event_aaa_1.webp,48.1,11.5,A again,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,duplicate key,1,Studi\n\
+            /cdn/thumb/event_bbb_0.webp,48.2,11.6,B,2026-06-15T16:00:00+02:00,2026-06-16T16:00:00+02:00,single,1,Studi\n",
+        )
+        .unwrap();
+        let snap = RepoSnapshot::load(dir.path()).unwrap();
+        assert_eq!(snap.event_row_counts.get("event_aaa"), Some(&2));
+        assert_eq!(snap.event_row_counts.get("event_bbb"), Some(&1));
+        assert_eq!(snap.event_row_counts.len(), 2);
     }
 }

--- a/server/src/routes/feedback/proposed_edits/image.rs
+++ b/server/src/routes/feedback/proposed_edits/image.rs
@@ -96,16 +96,58 @@ impl Image {
     fn save_metadata(&self, key: &str, image_dir: &Path) -> anyhow::Result<()> {
         // Sanitize the key to prevent path traversal attacks
         let safe_key = sanitize_key(key)?;
-
+        Self::update_metadata_file(image_dir, |image_sources| {
+            self.apply_metadata_to(safe_key, image_sources);
+        })
+    }
+    fn update_metadata_file(
+        image_dir: &Path,
+        update: impl FnOnce(&mut BTreeMap<String, BTreeMap<u32, ImageMetadata>>),
+    ) -> anyhow::Result<()> {
         let file = File::open(image_dir.join("img-sources.yaml"))?;
         let mut image_sources =
             serde_yaml::from_reader::<_, BTreeMap<String, BTreeMap<u32, ImageMetadata>>>(file)?;
-        // add the desired change
-        self.apply_metadata_to(safe_key, &mut image_sources);
-        // save to disk
+        update(&mut image_sources);
         let file = File::create(image_dir.join("img-sources.yaml"))?;
         serde_yaml::to_writer(file, &image_sources)?;
         Ok(())
+    }
+    /// Replaces the key's images instead of appending a slot: slot 0 is overwritten, stray
+    /// higher slots are removed, and the key's img-sources entry is reset to the new metadata.
+    pub(super) fn replace(
+        &self,
+        key: &str,
+        base_dir: &Path,
+        branch: &str,
+    ) -> anyhow::Result<String> {
+        let safe_key = sanitize_key(key)?;
+        let image_dir = base_dir.join("data").join("sources").join("img");
+        let lg_dir = image_dir.join("lg");
+        let filename = format!("{safe_key}_0.webp");
+        let slot_prefix = format!("{safe_key}_");
+        for entry in fs::read_dir(&lg_dir)? {
+            let entry = entry?;
+            if let Some(name) = entry.file_name().to_str()
+                && name.starts_with(&slot_prefix)
+                && name != filename
+            {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        self.save_content(&lg_dir.join(&filename))
+            .inspect_err(|e| error!(?self, error = ?e, "Error replacing image"))?;
+        Self::update_metadata_file(&image_dir, |image_sources| {
+            image_sources.insert(
+                safe_key.to_string(),
+                BTreeMap::from([(0, self.metadata.clone())]),
+            );
+        })?;
+        Ok(Self::summary_markdown(key, branch, &filename))
+    }
+    fn summary_markdown(key: &str, branch: &str, filename: &str) -> String {
+        format!(
+            "![image showing {key}](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/{branch}/data/sources/img/lg/{filename})"
+        )
     }
     fn image_should_be_saved_at(key: &str, image_dir: &Path) -> anyhow::Result<PathBuf> {
         // Sanitize the key to prevent path traversal attacks
@@ -178,9 +220,10 @@ impl AppliableEdit for Image {
         self.save_metadata(key, &image_dir)
             .inspect_err(|e| error!(?self, error = ?e, "Error saving metadata"))?;
 
-        Ok(format!(
-            "![image showing {key}](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/{branch}/data/sources/img/lg/{filename})",
-            filename = target.file_name().unwrap_or_default().to_string_lossy()
+        Ok(Self::summary_markdown(
+            key,
+            branch,
+            &target.file_name().unwrap_or_default().to_string_lossy(),
         ))
     }
 }

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1540,7 +1540,10 @@ export type components = {
       readonly short_name?: string | null;
       readonly visible_id?: string | null;
     };
-    /** @description A proposed campus event, appended as a row to `data/sources/events.csv`. */
+    /**
+     * @description A proposed campus event, upserted by key into `data/sources/events.csv`: a row whose
+     *     image path derives from the addition key is replaced, otherwise the event is appended.
+     */
     readonly NewEvent: {
       readonly coords: components["schemas"]["Coordinate"];
       readonly description: string;


### PR DESCRIPTION
Resolves #3257

Event additions previously always appended a row to `data/sources/events.csv`. The client-minted addition key (`event_<hash>`) is now the row identity, making the propose flow's "update an existing event" half work server-side.