### PR TITLE
feat(search): add an event facet fed from events.csv

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -624,6 +624,16 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: search_events
+          in: query
+          description: |-
+            Include campus events in the search.
+
+            Most clients don't render events, so this facet is disabled by default.
+            Requesting `type=event` implies enabling it.
+          required: false
+          schema:
+            type: boolean
         - name: limit_sites
           in: query
           description: |-
@@ -673,6 +683,19 @@ paths:
           description: |-
             Maximum number of lectures to return.
 
+            Clamped to `0`..`1000`.
+            If this is a problem for you, please open an issue.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+        - name: limit_events
+          in: query
+          description: |-
+            Maximum number of events to return.
+
+            Only has an effect when the event facet is enabled (via `search_events`
+            or `type=event`).
             Clamped to `0`..`1000`.
             If this is a problem for you, please open an issue.
           required: false
@@ -1246,6 +1269,76 @@ components:
           type: string
           description: The JWT token, that can be used to generate feedback
           example: eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2Njk2MzczODEsImlhdCI6MTY2OTU5NDE4MSwibmJmIjoxNjY5NTk0MTkxLCJraWQiOjE1ODU0MTUyODk5MzI0MjU0Mzg2fQ.sN0WwXzsGhjOVaqWPe-Fl5x-gwZvh28MMUM-74MoNj4
+    EventEntry:
+      type: object
+      description: |-
+        A campus event search result, carrying the full event-proposal pre-fill payload.
+
+        One entry per `events.csv` row (an edition of an event, not an event name):
+        picking one in a client pre-fills the event proposal form without a second
+        round-trip, so every CSV column rides along.
+      required:
+        - id
+        - key
+        - name
+        - description
+        - starts_at
+        - ends_at
+        - lat
+        - lon
+        - organising_org_id
+        - image
+        - image_author
+      properties:
+        description:
+          type: string
+          description: The description of the event.
+          example: Open-air student festival.
+        ends_at:
+          type: string
+          format: date-time
+          description: When the event ends, as an RFC 3339 timestamp.
+          example: "2026-06-19T21:59:00Z"
+        id:
+          type: string
+          description: The id of this edition of the event.
+          example: event_9d02ddd940c43f87_2026-06-15
+        image:
+          type: string
+          description: The `/cdn/thumb/…` delivery path of the event image.
+          example: /cdn/thumb/event_9d02ddd940c43f87_0.webp
+        image_author:
+          type: string
+          description: The author of the event image (CC-BY attribution).
+          example: Studentische Vertretung TUM
+        key:
+          type: string
+          description: The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
+          example: event_9d02ddd940c43f87
+        lat:
+          type: number
+          format: double
+          description: Latitude of the event location.
+          example: 48.262908
+        lon:
+          type: number
+          format: double
+          description: Longitude of the event location.
+          example: 11.669102
+        name:
+          type: string
+          description: The display name of the result. Supports highlighting.
+          example: "\x19GARNIX\x17 Festival"
+        organising_org_id:
+          type: integer
+          format: int32
+          description: The `TUMonline` org id of the organising organisation.
+          example: 51897
+        starts_at:
+          type: string
+          format: date-time
+          description: When the event starts, as an RFC 3339 timestamp.
+          example: "2026-06-15T14:00:00Z"
     EventResponse:
       type: object
       required:
@@ -1314,6 +1407,32 @@ components:
           description: English title of the Entry
           examples:
             - Quantum teleportation
+    EventSection:
+      type: object
+      description: A section of campus event results.
+      required:
+        - entries
+        - n_visible
+        - estimatedTotalHits
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/EventEntry'
+        estimatedTotalHits:
+          type: integer
+          description: The estimated (not exact) number of hits for that query
+          example: 6
+          minimum: 0
+        n_visible:
+          type: integer
+          description: |-
+            A recommendation how many of the entries should be displayed by default.
+
+            The number is usually from `0`..`5`.
+            More results might be displayed when clicking "expand".
+          example: 4
+          minimum: 0
     EventTypeResponse:
       type: string
       enum:
@@ -1357,6 +1476,7 @@ components:
         - room
         - poi
         - lecture
+        - event
     FeaturedOverviewItemResponse:
       type: object
       required:
@@ -3362,17 +3482,29 @@ components:
                   type: string
                   enum:
                     - lectures
+        - allOf:
+            - $ref: '#/components/schemas/EventSection'
+            - type: object
+              required:
+                - facet
+              properties:
+                facet:
+                  type: string
+                  enum:
+                    - events
       description: |-
         One section of search results, grouped by facet.
 
         The `facet` is the discriminator: the four entity facets (sites, buildings,
         rooms, and POIs) carry [`LocationEntry`]s with the room-id formatting fields,
         the addresses facet carries [`AddressEntry`]s with their open Nominatim
-        `addresstype`, and the lectures facet carries [`LectureEntry`]s with their
-        bilingual titles and upcoming occurrences. Tagging the section by `facet`
-        means a consumer narrows once on the discriminator it already needs for the
-        section header and then sees exactly the entry shape that facet carries -
-        instead of a redundant per-entry `kind` repeated on every hit.
+        `addresstype`, the lectures facet carries [`LectureEntry`]s with their
+        bilingual titles and upcoming occurrences, and the events facet carries
+        [`EventEntry`]s with the event-proposal pre-fill payload. Tagging the section
+        by `facet` means a consumer narrows once on the discriminator it already
+        needs for the section header and then sees exactly the entry shape that
+        facet carries - instead of a redundant per-entry `kind` repeated on every
+        hit.
     RoomAddress:
       type: object
       required:

--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1274,12 +1274,11 @@ components:
       description: |-
         A campus event search result, carrying the full event-proposal pre-fill payload.
 
-        One entry per `events.csv` row (an edition of an event, not an event name):
-        picking one in a client pre-fills the event proposal form without a second
-        round-trip, so every CSV column rides along.
+        One entry per `events.csv` row, identified by the addition key: picking one
+        in a client pre-fills the event proposal form without a second round-trip,
+        so every CSV column rides along.
       required:
         - id
-        - key
         - name
         - description
         - starts_at
@@ -1301,8 +1300,10 @@ components:
           example: "2026-06-19T21:59:00Z"
         id:
           type: string
-          description: The id of this edition of the event.
-          example: event_9d02ddd940c43f87_2026-06-15
+          description: |-
+            The `event_<hash>` addition key - the upsert identity shared by the
+            `events.csv` row and its key-named images.
+          example: event_9d02ddd940c43f87
         image:
           type: string
           description: The `/cdn/thumb/…` delivery path of the event image.
@@ -1311,10 +1312,6 @@ components:
           type: string
           description: The author of the event image (CC-BY attribution).
           example: Studentische Vertretung TUM
-        key:
-          type: string
-          description: The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
-          example: event_9d02ddd940c43f87
         lat:
           type: number
           format: double

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -78,7 +78,6 @@ class EventSearchDocument(TypedDict):
 
     ms_id: str
     facet: str
-    key: str
     name: str
     starts_at: str
     ends_at: str
@@ -102,16 +101,14 @@ def event_search_documents(events: dy.DataFrame[EventsSchema]) -> list[EventSear
         match = _EVENT_IMAGE_KEY_REGEX.match(row["image"])
         if match is None:
             raise ValueError(f"event image {row['image']!r} does not contain an extractable event key")
-        starts_at = _utc_rfc3339(row["starts_at"])
         docs.append(
             {
-                # The date suffix keeps `ms_id` unique against legacy duplicate keys
-                # (same image resubmitted for a new edition before upsert-by-key landed).
-                "ms_id": f"{match['key']}_{starts_at[: len('2026-06-15')]}",
+                # The addition key is the event's identity: Meilisearch upserts by `ms_id`,
+                # so a resubmitted key replaces the document instead of adding a second one.
+                "ms_id": match["key"],
                 "facet": SearchFacet.EVENT.value,
-                "key": match["key"],
                 "name": row["name"],
-                "starts_at": starts_at,
+                "starts_at": _utc_rfc3339(row["starts_at"]),
                 "ends_at": _utc_rfc3339(row["ends_at"]),
                 "description": row["description"],
                 "organising_org_id": row["organising_org_id"],

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -1,7 +1,11 @@
 import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
+from typing import TypedDict
 
+import dataframely as dy
 import orjson
 import polars as pl
 import xxhash
@@ -26,17 +30,20 @@ def _orjson_default(o: Json) -> Json:
 
 class SearchFacet(StrEnum):
     """
-    The search facet a location is bucketed into by the search API.
+    The search facet a document is bucketed into by the search API.
 
-    The closed set the server's `facet` field is matched against. Location types
-    not listed here (the synthetic `root` node) have no facet and are not
-    locatable results, so they are skipped at export rather than indexed.
+    The closed set the server's `facet` field is matched against. Locations map
+    via `_TYPE_TO_FACET`; types not listed there (the synthetic `root` node)
+    have no facet and are not locatable results, so they are skipped at export
+    rather than indexed. Events come from `events.csv` instead of the location
+    tree.
     """
 
     SITE = "site"
     BUILDING = "building"
     ROOM = "room"
     POI = "poi"
+    EVENT = "event"
 
 
 # Location `type` -> the search facet it surfaces under.
@@ -54,6 +61,68 @@ _TYPE_TO_FACET: dict[str, SearchFacet] = {
 # Only the synthetic tree root - everything else must map to a facet, so an
 # unmapped type is a bug (a new type was added without deciding how it searches).
 _NON_SEARCHABLE_TYPES: frozenset[str] = frozenset({"root"})
+
+# The `event_<hash>` identity is the base name of the key-named image files.
+_EVENT_IMAGE_KEY_REGEX = re.compile(r"^/cdn/thumb/(?P<key>.+)_\d+\.webp$")
+
+
+class _GeoPoint(TypedDict):
+    """Meilisearch's `_geo` shape (note `lng`, not `lon`)."""
+
+    lat: float
+    lng: float
+
+
+class EventSearchDocument(TypedDict):
+    """One `events.csv` row as a search document for the `event` facet."""
+
+    ms_id: str
+    facet: str
+    key: str
+    name: str
+    starts_at: str
+    ends_at: str
+    description: str
+    organising_org_id: int
+    image: str
+    image_author: str
+    rank: int
+    _geo: _GeoPoint
+
+
+def _utc_rfc3339(value: str) -> str:
+    """Normalise an RFC 3339 timestamp to second-precision UTC (`…Z`)."""
+    return f"{datetime.fromisoformat(value).astimezone(UTC):%Y-%m-%dT%H:%M:%SZ}"
+
+
+def event_search_documents(events: dy.DataFrame[EventsSchema]) -> list[EventSearchDocument]:
+    """Build one search document per events row for the default-disabled `event` facet."""
+    docs: list[EventSearchDocument] = []
+    for row in events.iter_rows(named=True):
+        match = _EVENT_IMAGE_KEY_REGEX.match(row["image"])
+        if match is None:
+            raise ValueError(f"event image {row['image']!r} does not contain an extractable event key")
+        starts_at = _utc_rfc3339(row["starts_at"])
+        docs.append(
+            {
+                # The date suffix keeps `ms_id` unique against legacy duplicate keys
+                # (same image resubmitted for a new edition before upsert-by-key landed).
+                "ms_id": f"{match['key']}_{starts_at[: len('2026-06-15')]}",
+                "facet": SearchFacet.EVENT.value,
+                "key": match["key"],
+                "name": row["name"],
+                "starts_at": starts_at,
+                "ends_at": _utc_rfc3339(row["ends_at"]),
+                "description": row["description"],
+                "organising_org_id": row["organising_org_id"],
+                "image": row["image"],
+                "image_author": row["image_author"],
+                # Lecture precedent: uniform 0 keeps the `rank:desc` ranking rule neutral.
+                "rank": 0,
+                "_geo": {"lat": row["lat"], "lng": row["lon"]},
+            },
+        )
+    return docs
 
 
 OUTPUT_DIR_PATH = Path(__file__).parent.parent / "output"
@@ -101,7 +170,7 @@ def reconstruct_data(df: pl.DataFrame) -> dict[str, Entry]:
 
 def export_for_search(data: dict[str, Entry]) -> None:
     """Export a subset of the data for the /search api"""
-    export = []
+    export: list[Mapping[str, Json]] = []
     for _id, entry in data.items():
         facet = _TYPE_TO_FACET.get(entry["type"])
         if facet is None:
@@ -165,6 +234,8 @@ def export_for_search(data: dict[str, Entry]) -> None:
                 **geo,
             },
         )
+
+    export.extend(event_search_documents(load_events()))
 
     search_bytes = orjson.dumps(export)
     _make_sure_is_safe(search_bytes)

--- a/data/processors/test_export_search_events.py
+++ b/data/processors/test_export_search_events.py
@@ -23,15 +23,14 @@ def _events(rows: list[dict[str, object]]) -> dy.DataFrame[EventsSchema]:
 
 
 def test_each_row_becomes_one_event_document() -> None:
-    """One search document per CSV row, faceted as `event`, with the key-plus-date `ms_id`."""
+    """One search document per CSV row, faceted as `event`, with the addition key as `ms_id`."""
     docs = event_search_documents(_events([{}]))
 
     assert len(docs) == 1
     doc = docs[0]
     assert doc["facet"] == "event"
-    # The `event_<hash>` identity from the image path, plus the UTC start date for
-    # uniqueness against legacy duplicate keys.
-    assert doc["ms_id"] == "event_9d02ddd940c43f87_2026-06-15"
+    # The `event_<hash>` identity from the image path is the document identity.
+    assert doc["ms_id"] == "event_9d02ddd940c43f87"
     assert doc["name"] == "GARNIX Festival"
 
 
@@ -56,7 +55,6 @@ def test_document_carries_the_full_prefill_payload() -> None:
     """Everything a client needs to pre-fill the event proposal form rides along on the document."""
     doc = event_search_documents(_events([{}]))[0]
 
-    assert doc["key"] == "event_9d02ddd940c43f87"
     assert doc["description"] == "Open-air student festival."
     assert doc["organising_org_id"] == 51897
     assert doc["image"] == "/cdn/thumb/event_9d02ddd940c43f87_0.webp"
@@ -66,8 +64,8 @@ def test_document_carries_the_full_prefill_payload() -> None:
     assert doc["rank"] == 0
 
 
-def test_duplicate_keys_across_editions_get_distinct_ms_ids() -> None:
-    """Legacy rows may reuse one key for several editions; the date suffix keeps `ms_id` unique."""
+def test_duplicate_key_rows_collapse_to_one_document() -> None:
+    """Rows sharing a key share an `ms_id`, so Meilisearch keeps only the last - an upsert, not a second hit."""
     docs = event_search_documents(
         _events(
             [
@@ -77,5 +75,4 @@ def test_duplicate_keys_across_editions_get_distinct_ms_ids() -> None:
         ),
     )
 
-    assert docs[0]["key"] == docs[1]["key"]
-    assert docs[0]["ms_id"] != docs[1]["ms_id"]
+    assert docs[0]["ms_id"] == docs[1]["ms_id"]

--- a/data/processors/test_export_search_events.py
+++ b/data/processors/test_export_search_events.py
@@ -1,0 +1,81 @@
+import dataframely as dy
+import polars as pl
+from external.schemas.events import EventsSchema
+
+from processors.export import event_search_documents
+
+
+def _events(rows: list[dict[str, object]]) -> dy.DataFrame[EventsSchema]:
+    """Build a validated events frame from row dicts, defaulting every required column."""
+    defaults: dict[str, object] = {
+        "image": "/cdn/thumb/event_9d02ddd940c43f87_0.webp",
+        "lat": 48.262908,
+        "lon": 11.669102,
+        "name": "GARNIX Festival",
+        "starts_at": "2026-06-15T16:00:00+02:00",
+        "ends_at": "2026-06-19T23:59:00+02:00",
+        "description": "Open-air student festival.",
+        "organising_org_id": 51897,
+        "image_author": "Studentische Vertretung TUM",
+    }
+    df = pl.DataFrame([defaults | row for row in rows], schema=EventsSchema.to_polars_schema())
+    return EventsSchema.validate(df)
+
+
+def test_each_row_becomes_one_event_document() -> None:
+    """One search document per CSV row, faceted as `event`, with the key-plus-date `ms_id`."""
+    docs = event_search_documents(_events([{}]))
+
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc["facet"] == "event"
+    # The `event_<hash>` identity from the image path, plus the UTC start date for
+    # uniqueness against legacy duplicate keys.
+    assert doc["ms_id"] == "event_9d02ddd940c43f87_2026-06-15"
+    assert doc["name"] == "GARNIX Festival"
+
+
+def test_datetimes_are_normalised_to_utc() -> None:
+    """Offsets are converted to `Z` so Meilisearch's lexicographic sort on `starts_at` is chronological."""
+    docs = event_search_documents(
+        _events(
+            [
+                {"starts_at": "2026-06-15T16:00:00+02:00", "ends_at": "2026-06-19T23:59:00+02:00"},
+                {"starts_at": "2026-06-29T09:00:00.000Z", "ends_at": "2026-07-03T21:00:00.000Z"},
+            ],
+        ),
+    )
+
+    assert docs[0]["starts_at"] == "2026-06-15T14:00:00Z"
+    assert docs[0]["ends_at"] == "2026-06-19T21:59:00Z"
+    assert docs[1]["starts_at"] == "2026-06-29T09:00:00Z"
+    assert docs[1]["ends_at"] == "2026-07-03T21:00:00Z"
+
+
+def test_document_carries_the_full_prefill_payload() -> None:
+    """Everything a client needs to pre-fill the event proposal form rides along on the document."""
+    doc = event_search_documents(_events([{}]))[0]
+
+    assert doc["key"] == "event_9d02ddd940c43f87"
+    assert doc["description"] == "Open-air student festival."
+    assert doc["organising_org_id"] == 51897
+    assert doc["image"] == "/cdn/thumb/event_9d02ddd940c43f87_0.webp"
+    assert doc["image_author"] == "Studentische Vertretung TUM"
+    assert doc["_geo"] == {"lat": 48.262908, "lng": 11.669102}
+    # Lecture precedent: a uniform `rank` of 0 keeps the `rank:desc` ranking rule neutral.
+    assert doc["rank"] == 0
+
+
+def test_duplicate_keys_across_editions_get_distinct_ms_ids() -> None:
+    """Legacy rows may reuse one key for several editions; the date suffix keeps `ms_id` unique."""
+    docs = event_search_documents(
+        _events(
+            [
+                {"starts_at": "2025-06-16T16:00:00+02:00", "ends_at": "2025-06-20T23:59:00+02:00"},
+                {"starts_at": "2026-06-15T16:00:00+02:00", "ends_at": "2026-06-19T23:59:00+02:00"},
+            ],
+        ),
+    )
+
+    assert docs[0]["key"] == docs[1]["key"]
+    assert docs[0]["ms_id"] != docs[1]["ms_id"]

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -19,16 +19,19 @@ pub(crate) const BUILDING_FACET: &str = "building";
 pub(crate) const ROOM_FACET: &str = "room";
 pub(crate) const POI_FACET: &str = "poi";
 pub(crate) const LECTURE_FACET: &str = "lecture";
+pub(crate) const EVENT_FACET: &str = "event";
 /// Ordered list of facets the search federates over. Order is the priority
 /// used by the merger when distributing the over-fetched federation budget
 /// across facet caps. Lectures trail the geo facets so a course title only
-/// surfaces once the geo entries it competes with have had their say.
+/// surfaces once the geo entries it competes with have had their say; events
+/// trail last as the only default-disabled facet.
 pub(crate) const FACETS: &[&str] = &[
     SITE_FACET,
     BUILDING_FACET,
     ROOM_FACET,
     POI_FACET,
     LECTURE_FACET,
+    EVENT_FACET,
 ];
 
 /// Allowlisted values for the `?type=` query parameter.
@@ -44,6 +47,8 @@ pub enum FacetFilter {
     Room,
     Poi,
     Lecture,
+    /// Requesting the default-disabled event facet implies enabling it.
+    Event,
 }
 
 impl FacetFilter {
@@ -55,6 +60,7 @@ impl FacetFilter {
             Self::Room => ROOM_FACET,
             Self::Poi => POI_FACET,
             Self::Lecture => LECTURE_FACET,
+            Self::Event => EVENT_FACET,
         }
     }
 }
@@ -75,6 +81,11 @@ const FEDERATION_OVERFETCH_FACTOR: usize = 4;
 /// match. Empirical; revisit if snapshots show the deprioritisation is too
 /// aggressive or too weak.
 const LECTURE_FEDERATION_WEIGHT: f32 = 0.5;
+
+/// Per-query federation weight for the event facet. Same rationale as
+/// [`LECTURE_FEDERATION_WEIGHT`]: an event is a non-geo identity that should
+/// lose against equally-strong location matches, not a hard pin below them.
+const EVENT_FEDERATION_WEIGHT: f32 = 0.5;
 
 /// The type of a `NavigaTUM` entity surfaced as a search result.
 ///
@@ -112,6 +123,7 @@ pub enum MSHit {
     Room(GeoMSHit),
     Poi(GeoMSHit),
     Lecture(LectureMSHit),
+    Event(EventMSHit),
 }
 
 // The `facet` field is consumed as the enum tag, so it is absent here. Fields
@@ -187,6 +199,39 @@ pub struct LectureMSHit {
     rank: i32,
 }
 
+/// Coordinates in Meilisearch's `_geo` document shape (note `lng`, not `lon`).
+#[derive(Deserialize, Clone, Copy)]
+pub struct GeoPoint {
+    pub lat: f64,
+    pub lng: f64,
+}
+
+/// A campus event surfaced as the sixth search facet.
+///
+/// One document per `events.csv` row, exported by the data pipeline into
+/// `search_data.json`. Carries everything a client needs to pre-fill the event
+/// proposal form, so picking a search hit needs no second round-trip.
+///
+/// Every field is required: the pipeline always writes the full shape, so a
+/// missing field signals index corruption and should fail the deserialize loudly
+/// rather than be papered over with a default.
+#[derive(Deserialize, Clone)]
+pub struct EventMSHit {
+    pub ms_id: String,
+    /// The `event_<hash>` identity shared by the CSV row and its key-named images.
+    pub key: String,
+    pub name: String,
+    pub starts_at: DateTime<Utc>,
+    pub ends_at: DateTime<Utc>,
+    pub description: String,
+    pub organising_org_id: i32,
+    /// The `/cdn/thumb/…` delivery path of the event image.
+    pub image: String,
+    pub image_author: String,
+    #[serde(rename = "_geo")]
+    pub coords: GeoPoint,
+}
+
 impl Default for MSHit {
     fn default() -> Self {
         Self::Room(GeoMSHit::default())
@@ -201,6 +246,7 @@ impl MSHit {
         match self {
             Self::Site(geo) | Self::Building(geo) | Self::Room(geo) | Self::Poi(geo) => &geo.name,
             Self::Lecture(lecture) => &lecture.name,
+            Self::Event(event) => &event.name,
         }
     }
 }
@@ -217,6 +263,11 @@ impl Debug for MSHit {
             Self::Lecture(lecture) => f
                 .debug_struct("MSHit::Lecture")
                 .field("title_de", &lecture.title_de)
+                .finish(),
+            Self::Event(event) => f
+                .debug_struct("MSHit::Event")
+                .field("key", &event.key)
+                .field("name", &event.name)
                 .finish(),
         }
     }
@@ -266,9 +317,22 @@ impl GeoEntryQuery {
     pub async fn execute(self) -> Result<FederatedMultiSearchResponse<MSHit>, Error> {
         let entries = self.client.index(ENTRIES_INDEX);
         let sorting: Vec<&str> = self.sorting.iter().map(String::as_str).collect();
-        // One filter per facet, ordered to match `FACETS` so callers can
+        // Editions of a recurring event share a name and tie on every text
+        // ranking rule; sorting the event query by `starts_at` descending
+        // surfaces the newest edition first. The pipeline normalises the field
+        // to UTC, so Meilisearch's lexicographic string sort is chronological.
+        let event_sorting: Vec<&str> = sorting.iter().copied().chain(["starts_at:desc"]).collect();
+        // The event facet is default-disabled: a zero cap drops its query from
+        // the federation entirely, keeping the request (and thus the result
+        // set) identical to one predating the facet.
+        let active_facets: Vec<&str> = FACETS
+            .iter()
+            .copied()
+            .filter(|facet| *facet != EVENT_FACET || self.limits.events_count > 0)
+            .collect();
+        // One filter per facet, ordered to match `active_facets` so callers can
         // reason about per-facet behavior consistently.
-        let per_facet_filters: Vec<String> = FACETS
+        let per_facet_filters: Vec<String> = active_facets
             .iter()
             .map(|f| compose_filter(&facet_eq(f), &self.user_filter))
             .collect();
@@ -281,17 +345,26 @@ impl GeoEntryQuery {
         let mut facets_by_index = HashMap::new();
         facets_by_index.insert(ENTRIES_INDEX.to_string(), vec![FACET_FIELD.to_string()]);
 
-        // `per_facet_filters` is built from `FACETS`, so zipping recovers each
-        // filter's facet. The lecture query carries a sub-unit federation weight
-        // so its hits are demoted relative to the geo facets when Meilisearch
-        // merges the five result sets by weighted `_rankingScore`.
+        // `per_facet_filters` is built from `active_facets`, so zipping recovers
+        // each filter's facet. The lecture and event queries carry a sub-unit
+        // federation weight so their hits are demoted relative to the geo facets
+        // when Meilisearch merges the per-facet result sets by weighted
+        // `_rankingScore`.
         let mut multi = self.client.multi_search();
-        for (facet, filter) in FACETS.iter().zip(&per_facet_filters) {
-            let query = self.facet_query(&entries, filter, &sorting);
-            if *facet == LECTURE_FACET {
-                multi.with_search_query_and_weight(query, LECTURE_FEDERATION_WEIGHT);
-            } else {
-                multi.with_search_query(query);
+        for (facet, filter) in active_facets.iter().zip(&per_facet_filters) {
+            match *facet {
+                LECTURE_FACET => {
+                    let query = self.facet_query(&entries, filter, &sorting);
+                    multi.with_search_query_and_weight(query, LECTURE_FEDERATION_WEIGHT);
+                }
+                EVENT_FACET => {
+                    let query = self.facet_query(&entries, filter, &event_sorting);
+                    multi.with_search_query_and_weight(query, EVENT_FEDERATION_WEIGHT);
+                }
+                _ => {
+                    let query = self.facet_query(&entries, filter, &sorting);
+                    multi.with_search_query(query);
+                }
             }
         }
         multi

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -217,9 +217,8 @@ pub struct GeoPoint {
 /// rather than be papered over with a default.
 #[derive(Deserialize, Clone)]
 pub struct EventMSHit {
-    pub ms_id: String,
     /// The `event_<hash>` identity shared by the CSV row and its key-named images.
-    pub key: String,
+    pub ms_id: String,
     pub name: String,
     pub starts_at: DateTime<Utc>,
     pub ends_at: DateTime<Utc>,
@@ -266,7 +265,7 @@ impl Debug for MSHit {
                 .finish(),
             Self::Event(event) => f
                 .debug_struct("MSHit::Event")
-                .field("key", &event.key)
+                .field("ms_id", &event.ms_id)
                 .field("name", &event.name)
                 .finish(),
         }

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -100,6 +100,12 @@ pub struct SearchQueryArgs {
     /// Only activate this when you really need it.
     search_addresses: Option<bool>,
 
+    /// Include campus events in the search.
+    ///
+    /// Most clients don't render events, so this facet is disabled by default.
+    /// Requesting `type=event` implies enabling it.
+    search_events: Option<bool>,
+
     /// Maximum number of sites (campus / site / area) to return.
     ///
     /// Clamped to `0`..`1000`.
@@ -134,6 +140,15 @@ pub struct SearchQueryArgs {
     /// If this is a problem for you, please open an issue.
     #[schema(default = 5, maximum = 1000, minimum = 0)]
     limit_lectures: Option<usize>,
+
+    /// Maximum number of events to return.
+    ///
+    /// Only has an effect when the event facet is enabled (via `search_events`
+    /// or `type=event`).
+    /// Clamped to `0`..`1000`.
+    /// If this is a problem for you, please open an issue.
+    #[schema(default = 5, maximum = 1000, minimum = 0)]
+    limit_events: Option<usize>,
 
     /// Maximum number of results to return.
     ///
@@ -234,6 +249,9 @@ impl Debug for SearchResponse {
                 ResultFacet::Lectures => {
                     base.field("lectures", section);
                 }
+                ResultFacet::Events => {
+                    base.field("events", section);
+                }
                 ResultFacet::Addresses => {
                     base.field("addresses", section);
                 }
@@ -251,6 +269,10 @@ pub struct Limits {
     pub rooms_count: usize,
     pub pois_count: usize,
     pub lectures_count: usize,
+    /// `0` encodes "facet disabled": the event facet is default-disabled, so a
+    /// disabled request keeps the federation budget (and thus the result set)
+    /// byte-identical to one predating the facet.
+    pub events_count: usize,
     pub total_count: usize,
 }
 
@@ -263,6 +285,7 @@ impl Limits {
             .saturating_add(self.rooms_count)
             .saturating_add(self.pois_count)
             .saturating_add(self.lectures_count)
+            .saturating_add(self.events_count)
     }
 }
 
@@ -274,6 +297,7 @@ impl Debug for Limits {
             .field("rooms", &self.rooms_count)
             .field("pois", &self.pois_count)
             .field("lectures", &self.lectures_count)
+            .field("events", &self.events_count)
             .field("total", &self.total_count)
             .finish()
     }
@@ -288,6 +312,8 @@ impl Default for Limits {
             rooms_count: 10,
             pois_count: 5,
             lectures_count: 5,
+            // Mirrors the parameterless request: the event facet is default-disabled.
+            events_count: 0,
         }
     }
 }
@@ -295,6 +321,8 @@ impl Default for Limits {
 impl From<&SearchQueryArgs> for Limits {
     fn from(args: &SearchQueryArgs) -> Self {
         let total_count = args.limit_all.unwrap_or(10).clamp(0, 1_000);
+        let events_enabled =
+            args.search_events.unwrap_or(false) || args.filter_type.contains(&FacetFilter::Event);
         Self {
             sites_count: args
                 .limit_sites
@@ -321,6 +349,14 @@ impl From<&SearchQueryArgs> for Limits {
                 .unwrap_or(5)
                 .clamp(0, 1_000)
                 .min(total_count),
+            events_count: if events_enabled {
+                args.limit_events
+                    .unwrap_or(5)
+                    .clamp(0, 1_000)
+                    .min(total_count)
+            } else {
+                0
+            },
             total_count,
         }
     }
@@ -619,12 +655,14 @@ mod tests {
         assert!(limits.rooms_count <= 1_000);
         assert!(limits.pois_count <= 1_000);
         assert!(limits.lectures_count <= 1_000);
+        assert!(limits.events_count <= 1_000);
 
         assert!(limits.sites_count <= limits.total_count);
         assert!(limits.buildings_count <= limits.total_count);
         assert!(limits.rooms_count <= limits.total_count);
         assert!(limits.pois_count <= limits.total_count);
         assert!(limits.lectures_count <= limits.total_count);
+        assert!(limits.events_count <= limits.total_count);
     }
 
     #[test]
@@ -636,6 +674,7 @@ mod tests {
         assert_eq!(limits.rooms_count, 10);
         assert_eq!(limits.pois_count, 5);
         assert_eq!(limits.lectures_count, 5);
+        assert_eq!(limits.events_count, 0);
         assert_limits_invariants(&limits);
     }
 
@@ -648,6 +687,8 @@ mod tests {
             limit_buildings: Some(usize::MAX),
             limit_pois: Some(usize::MAX),
             limit_lectures: Some(usize::MAX),
+            limit_events: Some(usize::MAX),
+            search_events: Some(true),
             ..Default::default()
         };
         let limits = Limits::from(&input);
@@ -658,6 +699,7 @@ mod tests {
         assert_eq!(limits.buildings_count, 1_000);
         assert_eq!(limits.pois_count, 1_000);
         assert_eq!(limits.lectures_count, 1_000);
+        assert_eq!(limits.events_count, 1_000);
         assert_limits_invariants(&limits);
     }
 
@@ -670,6 +712,8 @@ mod tests {
             limit_buildings: Some(100),
             limit_pois: Some(100),
             limit_lectures: Some(100),
+            limit_events: Some(100),
+            search_events: Some(true),
             ..Default::default()
         };
         let limits = Limits::from(&input);
@@ -680,6 +724,7 @@ mod tests {
         assert_eq!(limits.buildings_count, 10);
         assert_eq!(limits.pois_count, 10);
         assert_eq!(limits.lectures_count, 10);
+        assert_eq!(limits.events_count, 10);
         assert_limits_invariants(&limits);
     }
 
@@ -692,6 +737,8 @@ mod tests {
             limit_buildings: Some(0),
             limit_pois: Some(0),
             limit_lectures: Some(0),
+            limit_events: Some(0),
+            search_events: Some(true),
             ..Default::default()
         };
         let limits = Limits::from(&input);
@@ -702,6 +749,7 @@ mod tests {
         assert_eq!(limits.buildings_count, 0);
         assert_eq!(limits.pois_count, 0);
         assert_eq!(limits.lectures_count, 0);
+        assert_eq!(limits.events_count, 0);
         assert_limits_invariants(&limits);
     }
 
@@ -713,9 +761,10 @@ mod tests {
             rooms_count: 3,
             pois_count: 4,
             lectures_count: 5,
+            events_count: 6,
             total_count: 100,
         };
-        assert_eq!(limits.per_facet_total(), 15);
+        assert_eq!(limits.per_facet_total(), 21);
     }
 
     #[test]
@@ -860,9 +909,11 @@ mod tests {
                 FacetFilter::Building,
                 FacetFilter::Room,
                 FacetFilter::Poi,
+                FacetFilter::Lecture,
+                FacetFilter::Event,
             ],
         );
-        insta::assert_snapshot!(filter, @r#"(facet IN ["site", "building", "room", "poi"])"#);
+        insta::assert_snapshot!(filter, @r#"(facet IN ["site", "building", "room", "poi", "lecture", "event"])"#);
     }
 
     #[test]
@@ -890,6 +941,45 @@ mod tests {
         let near = "48.123,11.456".to_string();
         let sorting = build_meilisearch_sorting(Some(&near));
         assert_eq!(sorting, vec!["_geoPoint(48.123,11.456):asc"]);
+    }
+
+    #[test]
+    fn query_accepts_event_facet_type() {
+        let args: SearchQueryArgs = serde_html_form::from_str("q=garnix&type=event").unwrap();
+        assert_eq!(args.filter_type, vec![FacetFilter::Event]);
+    }
+
+    #[test]
+    fn limits_events_are_disabled_by_default() {
+        let args: SearchQueryArgs = serde_html_form::from_str("q=garnix").unwrap();
+        let limits = Limits::from(&args);
+        assert_eq!(limits.events_count, 0);
+    }
+
+    #[test]
+    fn limits_events_enabled_by_search_events_param() {
+        let args: SearchQueryArgs =
+            serde_html_form::from_str("q=garnix&search_events=true").unwrap();
+        let limits = Limits::from(&args);
+        assert_eq!(limits.events_count, 5);
+    }
+
+    #[test]
+    fn limits_event_type_filter_implies_enabling() {
+        let args: SearchQueryArgs = serde_html_form::from_str("q=garnix&type=event").unwrap();
+        let limits = Limits::from(&args);
+        assert_eq!(limits.events_count, 5);
+    }
+
+    #[test]
+    fn limits_limit_events_only_applies_when_enabled() {
+        // Without enabling the facet, the per-facet limit has nothing to limit.
+        let args: SearchQueryArgs = serde_html_form::from_str("q=garnix&limit_events=2").unwrap();
+        assert_eq!(Limits::from(&args).events_count, 0);
+
+        let args: SearchQueryArgs =
+            serde_html_form::from_str("q=garnix&search_events=true&limit_events=2").unwrap();
+        assert_eq!(Limits::from(&args).events_count, 2);
     }
 
     #[test]

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -285,7 +285,6 @@ fn make_event_entry(
     let name = highlighted_name_for_hit(hit, highlight);
     super::EventEntry {
         id: event.ms_id.clone(),
-        key: event.key.clone(),
         name,
         description: event.description.clone(),
         starts_at: event.starts_at,

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -5,8 +5,8 @@ use meilisearch_sdk::search::SearchResult;
 use super::ResultFacet;
 use super::highlight::{HighlightContext, highlighted_name_for_hit};
 use crate::external::meilisearch::{
-    BUILDING_FACET, FACET_FIELD, GeoMSHit, LECTURE_FACET, LectureMSHit, MSHit, POI_FACET,
-    ROOM_FACET, SITE_FACET,
+    BUILDING_FACET, EVENT_FACET, EventMSHit, FACET_FIELD, GeoMSHit, LECTURE_FACET, LectureMSHit,
+    MSHit, POI_FACET, ROOM_FACET, SITE_FACET,
 };
 use crate::routes::search::Limits;
 
@@ -16,6 +16,7 @@ pub(super) struct MergedSections {
     pub(super) rooms: super::LocationSection,
     pub(super) pois: super::LocationSection,
     pub(super) lectures: super::LectureSection,
+    pub(super) events: super::EventSection,
     /// Facets in the order their first hit appeared in the ranked Meilisearch
     /// results. Facets that never received a hit are not included.
     pub(super) facet_order: Vec<ResultFacet>,
@@ -54,6 +55,18 @@ impl SectionVisibility for super::LectureSection {
     }
 }
 
+impl SectionVisibility for super::EventSection {
+    fn entries_len(&self) -> usize {
+        self.entries.len()
+    }
+    fn n_visible(&self) -> usize {
+        self.n_visible
+    }
+    fn set_n_visible(&mut self, n: usize) {
+        self.n_visible = n;
+    }
+}
+
 #[tracing::instrument(skip(hits, facet_distribution, highlight))]
 pub(super) fn merge_search_results(
     limits: &Limits,
@@ -72,7 +85,12 @@ pub(super) fn merge_search_results(
         n_visible: 0,
         estimated_total_hits: totals.lectures,
     };
-    let mut facet_order: Vec<ResultFacet> = Vec::with_capacity(5);
+    let mut events = super::EventSection {
+        entries: Vec::new(),
+        n_visible: 0,
+        estimated_total_hits: totals.events,
+    };
+    let mut facet_order: Vec<ResultFacet> = Vec::with_capacity(6);
 
     // The visible count of any facet that already has hits is frozen the
     // moment a *new* facet's first hit appears in the ranking. This preserves
@@ -83,7 +101,8 @@ pub(super) fn merge_search_results(
             + active_count(&buildings)
             + active_count(&rooms)
             + active_count(&pois)
-            + active_count(&lectures);
+            + active_count(&lectures)
+            + active_count(&events);
         if cap >= limits.total_count {
             break;
         }
@@ -123,6 +142,10 @@ pub(super) fn merge_search_results(
                     .push(make_lecture_entry(lecture, hit, highlight));
                 ResultFacet::Lectures
             }
+            MSHit::Event(event) if events.entries.len() < limits.events_count => {
+                events.entries.push(make_event_entry(event, hit, highlight));
+                ResultFacet::Events
+            }
             _ => continue,
         };
 
@@ -134,6 +157,7 @@ pub(super) fn merge_search_results(
                     ResultFacet::Rooms => freeze_if_first(&mut rooms),
                     ResultFacet::Pois => freeze_if_first(&mut pois),
                     ResultFacet::Lectures => freeze_if_first(&mut lectures),
+                    ResultFacet::Events => freeze_if_first(&mut events),
                     ResultFacet::Addresses => {}
                 }
             }
@@ -148,6 +172,7 @@ pub(super) fn merge_search_results(
     finalize_visible(&mut rooms);
     finalize_visible(&mut pois);
     finalize_visible(&mut lectures);
+    finalize_visible(&mut events);
 
     MergedSections {
         sites,
@@ -155,6 +180,7 @@ pub(super) fn merge_search_results(
         rooms,
         pois,
         lectures,
+        events,
         facet_order,
     }
 }
@@ -247,6 +273,31 @@ fn make_lecture_entry(
     }
 }
 
+/// Build a result entry for an event hit.
+///
+/// Beyond the highlighted `name`, the entry is a 1:1 copy of the stored
+/// document: every field is part of the proposal-form pre-fill payload.
+fn make_event_entry(
+    event: &EventMSHit,
+    hit: &SearchResult<MSHit>,
+    highlight: &HighlightContext<'_>,
+) -> super::EventEntry {
+    let name = highlighted_name_for_hit(hit, highlight);
+    super::EventEntry {
+        id: event.ms_id.clone(),
+        key: event.key.clone(),
+        name,
+        description: event.description.clone(),
+        starts_at: event.starts_at,
+        ends_at: event.ends_at,
+        lat: event.coords.lat,
+        lon: event.coords.lng,
+        organising_org_id: event.organising_org_id,
+        image: event.image.clone(),
+        image_author: event.image_author.clone(),
+    }
+}
+
 #[derive(Default)]
 struct FacetTotals {
     sites: usize,
@@ -254,6 +305,7 @@ struct FacetTotals {
     rooms: usize,
     pois: usize,
     lectures: usize,
+    events: usize,
 }
 
 fn facet_totals(distribution: Option<&HashMap<String, HashMap<String, usize>>>) -> FacetTotals {
@@ -266,5 +318,6 @@ fn facet_totals(distribution: Option<&HashMap<String, HashMap<String, usize>>>) 
         rooms: facet.get(ROOM_FACET).copied().unwrap_or(0),
         pois: facet.get(POI_FACET).copied().unwrap_or(0),
         lectures: facet.get(LECTURE_FACET).copied().unwrap_or(0),
+        events: facet.get(EVENT_FACET).copied().unwrap_or(0),
     }
 }

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -28,6 +28,7 @@ pub enum ResultFacet {
     Rooms,
     Pois,
     Lectures,
+    Events,
     Addresses,
 }
 
@@ -105,6 +106,48 @@ pub struct LectureEntry {
     upcoming: Vec<UpcomingEvent>,
 }
 
+/// A campus event search result, carrying the full event-proposal pre-fill payload.
+///
+/// One entry per `events.csv` row (an edition of an event, not an event name):
+/// picking one in a client pre-fills the event proposal form without a second
+/// round-trip, so every CSV column rides along.
+#[derive(Serialize, Debug, Clone, utoipa::ToSchema)]
+pub struct EventEntry {
+    /// The id of this edition of the event.
+    #[schema(example = "event_9d02ddd940c43f87_2026-06-15")]
+    id: String,
+    /// The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
+    #[schema(example = "event_9d02ddd940c43f87")]
+    key: String,
+    /// The display name of the result. Supports highlighting.
+    #[schema(example = "\x19GARNIX\x17 Festival")]
+    name: String,
+    /// The description of the event.
+    #[schema(example = "Open-air student festival.")]
+    description: String,
+    /// When the event starts, as an RFC 3339 timestamp.
+    #[schema(example = "2026-06-15T14:00:00Z")]
+    starts_at: DateTime<Utc>,
+    /// When the event ends, as an RFC 3339 timestamp.
+    #[schema(example = "2026-06-19T21:59:00Z")]
+    ends_at: DateTime<Utc>,
+    /// Latitude of the event location.
+    #[schema(example = 48.262908)]
+    lat: f64,
+    /// Longitude of the event location.
+    #[schema(example = 11.669102)]
+    lon: f64,
+    /// The `TUMonline` org id of the organising organisation.
+    #[schema(example = 51897)]
+    organising_org_id: i32,
+    /// The `/cdn/thumb/…` delivery path of the event image.
+    #[schema(example = "/cdn/thumb/event_9d02ddd940c43f87_0.webp")]
+    image: String,
+    /// The author of the event image (CC-BY attribution).
+    #[schema(example = "Studentische Vertretung TUM")]
+    image_author: String,
+}
+
 /// A Nominatim address search result.
 ///
 /// Unlike a [`LocationEntry`], an address is not a `NavigaTUM` entity: it has no
@@ -160,6 +203,22 @@ pub struct LectureSection {
     estimated_total_hits: usize,
 }
 
+/// A section of campus event results.
+#[derive(Serialize, Clone, utoipa::ToSchema)]
+pub struct EventSection {
+    entries: Vec<EventEntry>,
+    /// A recommendation how many of the entries should be displayed by default.
+    ///
+    /// The number is usually from `0`..`5`.
+    /// More results might be displayed when clicking "expand".
+    #[schema(example = 4)]
+    n_visible: usize,
+    /// The estimated (not exact) number of hits for that query
+    #[serde(rename = "estimatedTotalHits")]
+    #[schema(example = 6)]
+    estimated_total_hits: usize,
+}
+
 /// A section of Nominatim address results.
 #[derive(Serialize, Clone, utoipa::ToSchema)]
 pub struct AddressSection {
@@ -181,11 +240,13 @@ pub struct AddressSection {
 /// The `facet` is the discriminator: the four entity facets (sites, buildings,
 /// rooms, and POIs) carry [`LocationEntry`]s with the room-id formatting fields,
 /// the addresses facet carries [`AddressEntry`]s with their open Nominatim
-/// `addresstype`, and the lectures facet carries [`LectureEntry`]s with their
-/// bilingual titles and upcoming occurrences. Tagging the section by `facet`
-/// means a consumer narrows once on the discriminator it already needs for the
-/// section header and then sees exactly the entry shape that facet carries -
-/// instead of a redundant per-entry `kind` repeated on every hit.
+/// `addresstype`, the lectures facet carries [`LectureEntry`]s with their
+/// bilingual titles and upcoming occurrences, and the events facet carries
+/// [`EventEntry`]s with the event-proposal pre-fill payload. Tagging the section
+/// by `facet` means a consumer narrows once on the discriminator it already
+/// needs for the section header and then sees exactly the entry shape that
+/// facet carries - instead of a redundant per-entry `kind` repeated on every
+/// hit.
 #[derive(Serialize, Clone, utoipa::ToSchema)]
 #[serde(tag = "facet", rename_all = "snake_case")]
 pub enum ResultsSection {
@@ -195,6 +256,7 @@ pub enum ResultsSection {
     Pois(LocationSection),
     Addresses(AddressSection),
     Lectures(LectureSection),
+    Events(EventSection),
 }
 
 impl ResultsSection {
@@ -207,6 +269,7 @@ impl ResultsSection {
             Self::Pois(_) => ResultFacet::Pois,
             Self::Addresses(_) => ResultFacet::Addresses,
             Self::Lectures(_) => ResultFacet::Lectures,
+            Self::Events(_) => ResultFacet::Events,
         }
     }
 }
@@ -224,6 +287,10 @@ impl Debug for ResultsSection {
                 .finish(),
             Self::Lectures(b) => f
                 .debug_tuple("Lectures")
+                .field(&TruncatedEntries(&b.entries))
+                .finish(),
+            Self::Events(b) => f
+                .debug_tuple("Events")
                 .field(&TruncatedEntries(&b.entries))
                 .finish(),
         }
@@ -266,6 +333,13 @@ impl ResultsSection {
             _ => None,
         }
     }
+    /// The events section's body, if this is the events section.
+    fn events(&self) -> Option<&EventSection> {
+        match self {
+            Self::Events(s) => Some(s),
+            _ => None,
+        }
+    }
     /// Whether this section has no entries.
     fn is_empty(&self) -> bool {
         match self {
@@ -274,6 +348,7 @@ impl ResultsSection {
             }
             Self::Addresses(b) => b.entries.is_empty(),
             Self::Lectures(b) => b.entries.is_empty(),
+            Self::Events(b) => b.entries.is_empty(),
         }
     }
     /// The ids of every entry in this section, regardless of facet.
@@ -284,6 +359,7 @@ impl ResultsSection {
             }
             Self::Addresses(b) => b.entries.iter().map(|e| e.id.as_str()).collect(),
             Self::Lectures(b) => b.entries.iter().map(|e| e.id.as_str()).collect(),
+            Self::Events(b) => b.entries.iter().map(|e| e.id.as_str()).collect(),
         }
     }
 }
@@ -365,6 +441,7 @@ pub async fn do_geoentry_search(
         rooms: mut section_rooms,
         pois: section_pois,
         lectures: section_lectures,
+        events: section_events,
         facet_order,
     } = merger::merge_search_results(
         &limits,
@@ -387,6 +464,10 @@ pub async fn do_geoentry_search(
     let mut rooms_opt = Some(ResultsSection::Rooms(section_rooms));
     let mut pois_opt = Some(ResultsSection::Pois(section_pois));
     let mut lectures_opt = Some(ResultsSection::Lectures(section_lectures));
+    // Address precedent for a default-disabled facet: the section only exists
+    // when its query ran, so disabled requests keep their pre-facet shape.
+    let mut events_opt =
+        (limits.events_count > 0).then_some(ResultsSection::Events(section_events));
 
     let mut sections: Vec<ResultsSection> = Vec::with_capacity(ResultFacet::COUNT - 1);
     for facet in &facet_order {
@@ -396,15 +477,23 @@ pub async fn do_geoentry_search(
             ResultFacet::Rooms => rooms_opt.take(),
             ResultFacet::Pois => pois_opt.take(),
             ResultFacet::Lectures => lectures_opt.take(),
+            ResultFacet::Events => events_opt.take(),
             ResultFacet::Addresses => None,
         };
         if let Some(s) = taken {
             sections.push(s);
         }
     }
-    for trailing in [sites_opt, buildings_opt, rooms_opt, pois_opt, lectures_opt]
-        .into_iter()
-        .flatten()
+    for trailing in [
+        sites_opt,
+        buildings_opt,
+        rooms_opt,
+        pois_opt,
+        lectures_opt,
+        events_opt,
+    ]
+    .into_iter()
+    .flatten()
     {
         sections.push(trailing);
     }
@@ -1044,8 +1133,9 @@ mod test {
         )
         .await;
 
-        // One section per non-address facet; the handler appends the address section.
-        assert_eq!(results.0.len(), ResultFacet::COUNT - 1);
+        // One section per federated facet, minus events (default-disabled here);
+        // the handler appends the address section.
+        assert_eq!(results.0.len(), ResultFacet::COUNT - 2);
 
         let lectures = results
             .0
@@ -1077,6 +1167,298 @@ mod test {
         insta::with_settings!({
             info => &"q=Navigatumlehre",
             description => "lecture facet returns a bilingual hit with its next occurrence",
+        }, {
+            insta::assert_yaml_snapshot!(results.0, { ".**.estimatedTotalHits" => "[estimatedTotalHits]"});
+        });
+    }
+
+    /// The full document shape the data pipeline exports for one `events.csv` row.
+    fn garnix_event_document() -> serde_json::Value {
+        serde_json::json!({
+            "ms_id": "event_9d02ddd940c43f87_2026-06-15",
+            "facet": "event",
+            "key": "event_9d02ddd940c43f87",
+            "name": "GARNIX Festival",
+            "starts_at": "2026-06-15T14:00:00Z",
+            "ends_at": "2026-06-19T21:59:00Z",
+            "description": "Open-air student festival.",
+            "organising_org_id": 51897,
+            "image": "/cdn/thumb/event_9d02ddd940c43f87_0.webp",
+            "image_author": "Studentische Vertretung TUM",
+            "rank": 0,
+            "_geo": {"lat": 48.262908, "lng": 11.669102},
+        })
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_event_facet_returns_the_prefill_payload() {
+        let ms = MeiliSearchTestContainer::new().await;
+        let task = ms
+            .client
+            .index("entries")
+            .add_documents(&[garnix_event_document()], Some("ms_id"))
+            .await
+            .unwrap()
+            .wait_for_completion(&ms.client, None, Some(std::time::Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(task, meilisearch_sdk::tasks::Task::Succeeded { .. }),
+            "event document upsert should succeed, got {task:?}"
+        );
+
+        let limits = Limits {
+            events_count: 5,
+            ..Limits::default()
+        };
+        let results = do_geoentry_search(
+            &ms.client,
+            "garnix",
+            limits,
+            FormattingConfig::default(),
+            String::new(),
+            vec![],
+        )
+        .await;
+
+        // One section per federated facet incl. events; the handler appends addresses.
+        assert_eq!(results.0.len(), ResultFacet::COUNT - 1);
+
+        let events = results
+            .0
+            .iter()
+            .find_map(ResultsSection::events)
+            .expect("expected an Events section for an event-name query");
+        let top = events
+            .entries
+            .first()
+            .expect("expected at least one event entry");
+        // Everything the propose page needs to pre-fill the event form rides along.
+        assert_eq!(top.id, "event_9d02ddd940c43f87_2026-06-15");
+        assert_eq!(top.key, "event_9d02ddd940c43f87");
+        assert_eq!(top.name, "\u{19}GARNIX\u{17} Festival");
+        assert_eq!(top.description, "Open-air student festival.");
+        assert_eq!(
+            top.starts_at,
+            "2026-06-15T14:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        assert_eq!(
+            top.ends_at,
+            "2026-06-19T21:59:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+        assert!((top.lat - 48.262908).abs() < f64::EPSILON);
+        assert!((top.lon - 11.669102).abs() < f64::EPSILON);
+        assert_eq!(top.organising_org_id, 51897);
+        assert_eq!(top.image, "/cdn/thumb/event_9d02ddd940c43f87_0.webp");
+        assert_eq!(top.image_author, "Studentische Vertretung TUM");
+
+        // The event surfaces only in its own section, never in the five geo/lecture ones.
+        for section in &results.0 {
+            if section.facet() != ResultFacet::Events {
+                assert!(
+                    !section.entry_ids().contains(&top.id.as_str()),
+                    "event leaked into the {facet:?} section",
+                    facet = section.facet()
+                );
+            }
+        }
+
+        insta::with_settings!({
+            info => &"q=garnix, search_events=true",
+            description => "the event facet returns the full proposal-form pre-fill payload",
+        }, {
+            insta::assert_yaml_snapshot!(results.0, { ".**.estimatedTotalHits" => "[estimatedTotalHits]"});
+        });
+    }
+
+    /// The event facet is default-disabled: without `search_events=true` or
+    /// `type=event` (both encoded as a non-zero `events_count`), an indexed
+    /// event must be invisible - no events section, no hits in other sections.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_event_facet_is_invisible_unless_enabled() {
+        let ms = MeiliSearchTestContainer::new().await;
+        let task = ms
+            .client
+            .index("entries")
+            .add_documents(&[garnix_event_document()], Some("ms_id"))
+            .await
+            .unwrap()
+            .wait_for_completion(&ms.client, None, Some(std::time::Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(task, meilisearch_sdk::tasks::Task::Succeeded { .. }),
+            "event document upsert should succeed, got {task:?}"
+        );
+
+        let results = do_geoentry_search(
+            &ms.client,
+            "garnix",
+            Limits::default(),
+            FormattingConfig::default(),
+            String::new(),
+            vec![],
+        )
+        .await;
+
+        // The response keeps its pre-facet shape: the five always-on sections.
+        assert_eq!(results.0.len(), ResultFacet::COUNT - 2);
+        assert!(
+            results.0.iter().find_map(ResultsSection::events).is_none(),
+            "a disabled event facet must not produce an events section"
+        );
+        for section in &results.0 {
+            assert!(
+                !section
+                    .entry_ids()
+                    .contains(&"event_9d02ddd940c43f87_2026-06-15"),
+                "event leaked into the {facet:?} section despite the facet being disabled",
+                facet = section.facet()
+            );
+        }
+    }
+
+    /// `?type=event` end-to-end below the handler: `Limits::from` turns the
+    /// filter into a non-zero `events_count` (unit-tested in `routes::search`),
+    /// and the `facet IN ["event"]` user filter built from it must keep every
+    /// other section empty even when a geo entry matches the query.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_event_type_filter_returns_only_events() {
+        let ms = MeiliSearchTestContainer::new().await;
+        // A building sharing the query token, to prove the type filter excludes it.
+        let building = serde_json::json!({
+            "ms_id": "building_testfixture0001",
+            "facet": "building",
+            "type": "building",
+            "room_code": "GRX",
+            "name": "GARNIX Pavillon",
+            "type_common_name": "Gebäude",
+            "rank": 100,
+            "parent_building_names": [],
+            "parent_keywords": ["garching"],
+        });
+        let task = ms
+            .client
+            .index("entries")
+            .add_documents(&[building, garnix_event_document()], Some("ms_id"))
+            .await
+            .unwrap()
+            .wait_for_completion(&ms.client, None, Some(std::time::Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(task, meilisearch_sdk::tasks::Task::Succeeded { .. }),
+            "fixture upsert should succeed, got {task:?}"
+        );
+
+        let limits = Limits {
+            events_count: 5,
+            ..Limits::default()
+        };
+        let results = do_geoentry_search(
+            &ms.client,
+            "garnix",
+            limits,
+            FormattingConfig::default(),
+            r#"(facet IN ["event"])"#.to_string(),
+            vec![],
+        )
+        .await;
+
+        let events = results
+            .0
+            .iter()
+            .find_map(ResultsSection::events)
+            .expect("expected an Events section for a type=event query");
+        assert_eq!(events.entries.len(), 1);
+        assert_eq!(
+            events.entries.first().unwrap().id,
+            "event_9d02ddd940c43f87_2026-06-15"
+        );
+        for section in &results.0 {
+            assert!(
+                section.facet() == ResultFacet::Events || section.is_empty(),
+                "type=event must keep the {facet:?} section empty",
+                facet = section.facet()
+            );
+        }
+    }
+
+    /// Editions of a recurring event share a name, so they tie on every text
+    /// ranking rule. The per-query `starts_at:desc` sort breaks the tie in
+    /// favour of the newest edition - the one a proposer wants to start from.
+    /// The older edition is inserted first so that, without the sort, insertion
+    /// order would surface it on top and fail the test.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_newest_event_edition_ranks_first() {
+        let ms = MeiliSearchTestContainer::new().await;
+        let editions = [
+            serde_json::json!({
+                "ms_id": "event_9d02ddd940c43f87_2025-06-16",
+                "facet": "event",
+                "key": "event_9d02ddd940c43f87",
+                "name": "GARNIX Festival",
+                "starts_at": "2025-06-16T14:00:00Z",
+                "ends_at": "2025-06-20T21:59:00Z",
+                "description": "Last year's edition.",
+                "organising_org_id": 51897,
+                "image": "/cdn/thumb/event_9d02ddd940c43f87_0.webp",
+                "image_author": "Studentische Vertretung TUM",
+                "rank": 0,
+                "_geo": {"lat": 48.262908, "lng": 11.669102},
+            }),
+            garnix_event_document(),
+        ];
+        let task = ms
+            .client
+            .index("entries")
+            .add_documents(&editions, Some("ms_id"))
+            .await
+            .unwrap()
+            .wait_for_completion(&ms.client, None, Some(std::time::Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(task, meilisearch_sdk::tasks::Task::Succeeded { .. }),
+            "event document upsert should succeed, got {task:?}"
+        );
+
+        let limits = Limits {
+            events_count: 5,
+            ..Limits::default()
+        };
+        let results = do_geoentry_search(
+            &ms.client,
+            "garnix",
+            limits,
+            FormattingConfig::default(),
+            String::new(),
+            vec![],
+        )
+        .await;
+
+        let events = results
+            .0
+            .iter()
+            .find_map(ResultsSection::events)
+            .expect("expected an Events section for an event-name query");
+        let ids: Vec<&str> = events.entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "event_9d02ddd940c43f87_2026-06-15",
+                "event_9d02ddd940c43f87_2025-06-16",
+            ],
+            "the newest edition must rank first"
+        );
+
+        insta::with_settings!({
+            info => &"q=garnix, search_events=true",
+            description => "same-name editions are sorted by starts_at descending",
         }, {
             insta::assert_yaml_snapshot!(results.0, { ".**.estimatedTotalHits" => "[estimatedTotalHits]"});
         });

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -108,17 +108,15 @@ pub struct LectureEntry {
 
 /// A campus event search result, carrying the full event-proposal pre-fill payload.
 ///
-/// One entry per `events.csv` row (an edition of an event, not an event name):
-/// picking one in a client pre-fills the event proposal form without a second
-/// round-trip, so every CSV column rides along.
+/// One entry per `events.csv` row, identified by the addition key: picking one
+/// in a client pre-fills the event proposal form without a second round-trip,
+/// so every CSV column rides along.
 #[derive(Serialize, Debug, Clone, utoipa::ToSchema)]
 pub struct EventEntry {
-    /// The id of this edition of the event.
-    #[schema(example = "event_9d02ddd940c43f87_2026-06-15")]
-    id: String,
-    /// The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
+    /// The `event_<hash>` addition key - the upsert identity shared by the
+    /// `events.csv` row and its key-named images.
     #[schema(example = "event_9d02ddd940c43f87")]
-    key: String,
+    id: String,
     /// The display name of the result. Supports highlighting.
     #[schema(example = "\x19GARNIX\x17 Festival")]
     name: String,
@@ -1175,9 +1173,8 @@ mod test {
     /// The full document shape the data pipeline exports for one `events.csv` row.
     fn garnix_event_document() -> serde_json::Value {
         serde_json::json!({
-            "ms_id": "event_9d02ddd940c43f87_2026-06-15",
+            "ms_id": "event_9d02ddd940c43f87",
             "facet": "event",
-            "key": "event_9d02ddd940c43f87",
             "name": "GARNIX Festival",
             "starts_at": "2026-06-15T14:00:00Z",
             "ends_at": "2026-06-19T21:59:00Z",
@@ -1235,8 +1232,7 @@ mod test {
             .first()
             .expect("expected at least one event entry");
         // Everything the propose page needs to pre-fill the event form rides along.
-        assert_eq!(top.id, "event_9d02ddd940c43f87_2026-06-15");
-        assert_eq!(top.key, "event_9d02ddd940c43f87");
+        assert_eq!(top.id, "event_9d02ddd940c43f87");
         assert_eq!(top.name, "\u{19}GARNIX\u{17} Festival");
         assert_eq!(top.description, "Open-air student festival.");
         assert_eq!(
@@ -1311,9 +1307,7 @@ mod test {
         );
         for section in &results.0 {
             assert!(
-                !section
-                    .entry_ids()
-                    .contains(&"event_9d02ddd940c43f87_2026-06-15"),
+                !section.entry_ids().contains(&"event_9d02ddd940c43f87"),
                 "event leaked into the {facet:?} section despite the facet being disabled",
                 facet = section.facet()
             );
@@ -1374,10 +1368,7 @@ mod test {
             .find_map(ResultsSection::events)
             .expect("expected an Events section for a type=event query");
         assert_eq!(events.entries.len(), 1);
-        assert_eq!(
-            events.entries.first().unwrap().id,
-            "event_9d02ddd940c43f87_2026-06-15"
-        );
+        assert_eq!(events.entries.first().unwrap().id, "event_9d02ddd940c43f87");
         for section in &results.0 {
             assert!(
                 section.facet() == ResultFacet::Events || section.is_empty(),
@@ -1387,26 +1378,26 @@ mod test {
         }
     }
 
-    /// Editions of a recurring event share a name, so they tie on every text
-    /// ranking rule. The per-query `starts_at:desc` sort breaks the tie in
-    /// favour of the newest edition - the one a proposer wants to start from.
-    /// The older edition is inserted first so that, without the sort, insertion
-    /// order would surface it on top and fail the test.
+    /// Successive editions of a recurring event (submitted with new posters, so
+    /// new keys) share a name and tie on every text ranking rule. The per-query
+    /// `starts_at:desc` sort breaks the tie in favour of the newest edition -
+    /// the one a proposer wants to start from. The older edition is inserted
+    /// first so that, without the sort, insertion order would surface it on top
+    /// and fail the test.
     #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_newest_event_edition_ranks_first() {
         let ms = MeiliSearchTestContainer::new().await;
         let editions = [
             serde_json::json!({
-                "ms_id": "event_9d02ddd940c43f87_2025-06-16",
+                "ms_id": "event_17ddb108241f623c",
                 "facet": "event",
-                "key": "event_9d02ddd940c43f87",
                 "name": "GARNIX Festival",
                 "starts_at": "2025-06-16T14:00:00Z",
                 "ends_at": "2025-06-20T21:59:00Z",
                 "description": "Last year's edition.",
                 "organising_org_id": 51897,
-                "image": "/cdn/thumb/event_9d02ddd940c43f87_0.webp",
+                "image": "/cdn/thumb/event_17ddb108241f623c_0.webp",
                 "image_author": "Studentische Vertretung TUM",
                 "rank": 0,
                 "_geo": {"lat": 48.262908, "lng": 11.669102},
@@ -1449,10 +1440,7 @@ mod test {
         let ids: Vec<&str> = events.entries.iter().map(|e| e.id.as_str()).collect();
         assert_eq!(
             ids,
-            [
-                "event_9d02ddd940c43f87_2026-06-15",
-                "event_9d02ddd940c43f87_2025-06-16",
-            ],
+            ["event_9d02ddd940c43f87", "event_17ddb108241f623c"],
             "the newest edition must rank first"
         );
 

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
@@ -1,0 +1,41 @@
+---
+source: server/src/search_executor/mod.rs
+description: the event facet returns the full proposal-form pre-fill payload
+expression: results.0
+info: "q=garnix, search_events=true"
+---
+- facet: events
+  entries:
+    - id: event_9d02ddd940c43f87_2026-06-15
+      key: event_9d02ddd940c43f87
+      name: "\u0019GARNIX\u0017 Festival"
+      description: Open-air student festival.
+      starts_at: "2026-06-15T14:00:00Z"
+      ends_at: "2026-06-19T21:59:00Z"
+      lat: 48.262908
+      lon: 11.669102
+      organising_org_id: 51897
+      image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
+      image_author: Studentische Vertretung TUM
+  n_visible: 1
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: buildings
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: rooms
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: lectures
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
@@ -6,8 +6,7 @@ info: "q=garnix, search_events=true"
 ---
 - facet: events
   entries:
-    - id: event_9d02ddd940c43f87_2026-06-15
-      key: event_9d02ddd940c43f87
+    - id: event_9d02ddd940c43f87
       name: "\u0019GARNIX\u0017 Festival"
       description: Open-air student festival.
       starts_at: "2026-06-15T14:00:00Z"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
@@ -6,8 +6,7 @@ info: "q=garnix, search_events=true"
 ---
 - facet: events
   entries:
-    - id: event_9d02ddd940c43f87_2026-06-15
-      key: event_9d02ddd940c43f87
+    - id: event_9d02ddd940c43f87
       name: "\u0019GARNIX\u0017 Festival"
       description: Open-air student festival.
       starts_at: "2026-06-15T14:00:00Z"
@@ -17,8 +16,7 @@ info: "q=garnix, search_events=true"
       organising_org_id: 51897
       image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
       image_author: Studentische Vertretung TUM
-    - id: event_9d02ddd940c43f87_2025-06-16
-      key: event_9d02ddd940c43f87
+    - id: event_17ddb108241f623c
       name: "\u0019GARNIX\u0017 Festival"
       description: "Last year's edition."
       starts_at: "2025-06-16T14:00:00Z"
@@ -26,7 +24,7 @@ info: "q=garnix, search_events=true"
       lat: 48.262908
       lon: 11.669102
       organising_org_id: 51897
-      image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
+      image: /cdn/thumb/event_17ddb108241f623c_0.webp
       image_author: Studentische Vertretung TUM
   n_visible: 2
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
@@ -1,0 +1,52 @@
+---
+source: server/src/search_executor/mod.rs
+description: same-name editions are sorted by starts_at descending
+expression: results.0
+info: "q=garnix, search_events=true"
+---
+- facet: events
+  entries:
+    - id: event_9d02ddd940c43f87_2026-06-15
+      key: event_9d02ddd940c43f87
+      name: "\u0019GARNIX\u0017 Festival"
+      description: Open-air student festival.
+      starts_at: "2026-06-15T14:00:00Z"
+      ends_at: "2026-06-19T21:59:00Z"
+      lat: 48.262908
+      lon: 11.669102
+      organising_org_id: 51897
+      image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
+      image_author: Studentische Vertretung TUM
+    - id: event_9d02ddd940c43f87_2025-06-16
+      key: event_9d02ddd940c43f87
+      name: "\u0019GARNIX\u0017 Festival"
+      description: "Last year's edition."
+      starts_at: "2025-06-16T14:00:00Z"
+      ends_at: "2025-06-20T21:59:00Z"
+      lat: 48.262908
+      lon: 11.669102
+      organising_org_id: 51897
+      image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
+      image_author: Studentische Vertretung TUM
+  n_visible: 2
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: buildings
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: rooms
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: lectures
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/setup/meilisearch.rs
+++ b/server/src/setup/meilisearch.rs
@@ -82,7 +82,7 @@ pub async fn setup(client: &Client) -> anyhow::Result<()> {
             "sort",
             "exactness",
         ])
-        .with_sortable_attributes(["_geo", "next_occurrence_at"])
+        .with_sortable_attributes(["_geo", "next_occurrence_at", "starts_at"])
         .with_searchable_attributes([
             "room_code",
             "room_code_normalised",

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -636,9 +636,9 @@ export type components = {
     /**
      * @description A campus event search result, carrying the full event-proposal pre-fill payload.
      *
-     *     One entry per `events.csv` row (an edition of an event, not an event name):
-     *     picking one in a client pre-fills the event proposal form without a second
-     *     round-trip, so every CSV column rides along.
+     *     One entry per `events.csv` row, identified by the addition key: picking one
+     *     in a client pre-fills the event proposal form without a second round-trip,
+     *     so every CSV column rides along.
      */
     readonly EventEntry: {
       /**
@@ -653,8 +653,9 @@ export type components = {
        */
       readonly ends_at: string;
       /**
-       * @description The id of this edition of the event.
-       * @example event_9d02ddd940c43f87_2026-06-15
+       * @description The `event_<hash>` addition key - the upsert identity shared by the
+       *     `events.csv` row and its key-named images.
+       * @example event_9d02ddd940c43f87
        */
       readonly id: string;
       /**
@@ -667,11 +668,6 @@ export type components = {
        * @example Studentische Vertretung TUM
        */
       readonly image_author: string;
-      /**
-       * @description The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
-       * @example event_9d02ddd940c43f87
-       */
-      readonly key: string;
       /**
        * Format: double
        * @description Latitude of the event location.

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -633,6 +633,75 @@ export type components = {
        */
       readonly token: string;
     };
+    /**
+     * @description A campus event search result, carrying the full event-proposal pre-fill payload.
+     *
+     *     One entry per `events.csv` row (an edition of an event, not an event name):
+     *     picking one in a client pre-fills the event proposal form without a second
+     *     round-trip, so every CSV column rides along.
+     */
+    readonly EventEntry: {
+      /**
+       * @description The description of the event.
+       * @example Open-air student festival.
+       */
+      readonly description: string;
+      /**
+       * Format: date-time
+       * @description When the event ends, as an RFC 3339 timestamp.
+       * @example 2026-06-19T21:59:00Z
+       */
+      readonly ends_at: string;
+      /**
+       * @description The id of this edition of the event.
+       * @example event_9d02ddd940c43f87_2026-06-15
+       */
+      readonly id: string;
+      /**
+       * @description The `/cdn/thumb/…` delivery path of the event image.
+       * @example /cdn/thumb/event_9d02ddd940c43f87_0.webp
+       */
+      readonly image: string;
+      /**
+       * @description The author of the event image (CC-BY attribution).
+       * @example Studentische Vertretung TUM
+       */
+      readonly image_author: string;
+      /**
+       * @description The `event_<hash>` identity shared by the `events.csv` row and its key-named images.
+       * @example event_9d02ddd940c43f87
+       */
+      readonly key: string;
+      /**
+       * Format: double
+       * @description Latitude of the event location.
+       * @example 48.262908
+       */
+      readonly lat: number;
+      /**
+       * Format: double
+       * @description Longitude of the event location.
+       * @example 11.669102
+       */
+      readonly lon: number;
+      /**
+       * @description The display name of the result. Supports highlighting.
+       * @example GARNIX Festival
+       */
+      readonly name: string;
+      /**
+       * Format: int32
+       * @description The `TUMonline` org id of the organising organisation.
+       * @example 51897
+       */
+      readonly organising_org_id: number;
+      /**
+       * Format: date-time
+       * @description When the event starts, as an RFC 3339 timestamp.
+       * @example 2026-06-15T14:00:00Z
+       */
+      readonly starts_at: string;
+    };
     readonly EventResponse: {
       /**
        * @description For some Entrys, we do have more information (what kind of a `lecture` is it? What kind of an other `entry` is it?)
@@ -688,6 +757,23 @@ export type components = {
        */
       readonly title_en: string;
     };
+    /** @description A section of campus event results. */
+    readonly EventSection: {
+      readonly entries: readonly components["schemas"]["EventEntry"][];
+      /**
+       * @description The estimated (not exact) number of hits for that query
+       * @example 6
+       */
+      readonly estimatedTotalHits: number;
+      /**
+       * @description A recommendation how many of the entries should be displayed by default.
+       *
+       *     The number is usually from `0`..`5`.
+       *     More results might be displayed when clicking "expand".
+       * @example 4
+       */
+      readonly n_visible: number;
+    };
     /** @enum {string} */
     readonly EventTypeResponse: "lecture" | "exercise" | "exam" | "barred" | "other";
     readonly ExtraComputedPropResponse: {
@@ -706,7 +792,7 @@ export type components = {
      *     of accepted values.
      * @enum {string}
      */
-    readonly FacetFilter: "site" | "building" | "room" | "poi" | "lecture";
+    readonly FacetFilter: "site" | "building" | "room" | "poi" | "lecture" | "event";
     readonly FeaturedOverviewItemResponse: {
       /** @description The id of the entry */
       readonly id: string;
@@ -1962,11 +2048,13 @@ export type components = {
      *     The `facet` is the discriminator: the four entity facets (sites, buildings,
      *     rooms, and POIs) carry [`LocationEntry`]s with the room-id formatting fields,
      *     the addresses facet carries [`AddressEntry`]s with their open Nominatim
-     *     `addresstype`, and the lectures facet carries [`LectureEntry`]s with their
-     *     bilingual titles and upcoming occurrences. Tagging the section by `facet`
-     *     means a consumer narrows once on the discriminator it already needs for the
-     *     section header and then sees exactly the entry shape that facet carries -
-     *     instead of a redundant per-entry `kind` repeated on every hit.
+     *     `addresstype`, the lectures facet carries [`LectureEntry`]s with their
+     *     bilingual titles and upcoming occurrences, and the events facet carries
+     *     [`EventEntry`]s with the event-proposal pre-fill payload. Tagging the section
+     *     by `facet` means a consumer narrows once on the discriminator it already
+     *     needs for the section header and then sees exactly the entry shape that
+     *     facet carries - instead of a redundant per-entry `kind` repeated on every
+     *     hit.
      */
     readonly ResultsSection:
       | (components["schemas"]["LocationSection"] & {
@@ -1992,6 +2080,10 @@ export type components = {
       | (components["schemas"]["LectureSection"] & {
           /** @enum {string} */
           readonly facet: "lectures";
+        })
+      | (components["schemas"]["EventSection"] & {
+          /** @enum {string} */
+          readonly facet: "events";
         });
     readonly RoomAddress: {
       readonly place: string;
@@ -2977,6 +3069,13 @@ export interface operations {
          */
         readonly search_addresses?: boolean;
         /**
+         * @description Include campus events in the search.
+         *
+         *     Most clients don't render events, so this facet is disabled by default.
+         *     Requesting `type=event` implies enabling it.
+         */
+        readonly search_events?: boolean;
+        /**
          * @description Maximum number of sites (campus / site / area) to return.
          *
          *     Clamped to `0`..`1000`.
@@ -3011,6 +3110,15 @@ export interface operations {
          *     If this is a problem for you, please open an issue.
          */
         readonly limit_lectures?: number;
+        /**
+         * @description Maximum number of events to return.
+         *
+         *     Only has an effect when the event facet is enabled (via `search_events`
+         *     or `type=event`).
+         *     Clamped to `0`..`1000`.
+         *     If this is a problem for you, please open an issue.
+         */
+        readonly limit_events?: number;
         /**
          * @description Maximum number of results to return.
          *

--- a/webclient/app/utils/lectureRow.ts
+++ b/webclient/app/utils/lectureRow.ts
@@ -46,6 +46,10 @@ export function tagSectionEntries(section: ResultsSection): SearchResultEntry[] 
   if (section.facet === "addresses") {
     return section.entries.map((entry) => ({ kind: "address", ...entry }));
   }
+  // Events never appear here: this client does not enable the default-off facet (UI lands in #3258).
+  if (section.facet === "events") {
+    return [];
+  }
   return section.entries.map((entry) => ({ kind: "location", ...entry }));
 }
 


### PR DESCRIPTION
Resolves https://github.com/TUM-Dev/NavigaTUM/issues/3256 (PR 1 of 2; the propose-page UI follows in #3258 after autofix syncs the api types).

Events from `data/sources/events.csv` become searchable through `/api/search` as a sixth, default-disabled facet, so the propose page can look up previously submitted events by name and pre-fill the proposal form from a hit.