### PR TITLE
feat(search): expose event image crop offsets in search results

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -1288,6 +1288,8 @@ components:
         - organising_org_id
         - image
         - image_author
+        - image_thumb_offset
+        - image_header_offset
       properties:
         description:
           type: string
@@ -1312,6 +1314,20 @@ components:
           type: string
           description: The author of the event image (CC-BY attribution).
           example: Studentische Vertretung TUM
+        image_header_offset:
+          type: integer
+          format: int32
+          description: |-
+            Crop offset of the header image: pixels to shift the crop window
+            along the image's longer axis. `0` when unset, so a client can recover the crop.
+          example: 257
+        image_thumb_offset:
+          type: integer
+          format: int32
+          description: |-
+            Crop offset of the thumbnail image: pixels to shift the crop window
+            along the image's longer axis. `0` when unset, so a client can recover the crop.
+          example: 14
         lat:
           type: number
           format: double

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -20,6 +20,7 @@ from utils import TranslatableStr
 from utils import TranslatableStr as _
 
 from processors.df_utils import unflatten_row
+from processors.images import ImageOffset, ImageSource
 
 
 def _orjson_default(o: Json) -> Json:
@@ -85,6 +86,9 @@ class EventSearchDocument(TypedDict):
     organising_org_id: int
     image: str
     image_author: str
+    # Image crop offsets (pixel shift of the crop window along each image's longer axis), so a client can recover the crop.
+    image_thumb_offset: int
+    image_header_offset: int
     rank: int
     _geo: _GeoPoint
 
@@ -94,13 +98,19 @@ def _utc_rfc3339(value: str) -> str:
     return f"{datetime.fromisoformat(value).astimezone(UTC):%Y-%m-%dT%H:%M:%SZ}"
 
 
-def event_search_documents(events: dy.DataFrame[EventsSchema]) -> list[EventSearchDocument]:
+def event_search_documents(
+    events: dy.DataFrame[EventsSchema],
+    image_sources: Mapping[str, list[ImageSource]],
+) -> list[EventSearchDocument]:
     """Build one search document per events row for the default-disabled `event` facet."""
     docs: list[EventSearchDocument] = []
     for row in events.iter_rows(named=True):
         match = _EVENT_IMAGE_KEY_REGEX.match(row["image"])
         if match is None:
             raise ValueError(f"event image {row['image']!r} does not contain an extractable event key")
+        # An event has a single image; a key with no source entry crops at the unshifted (0) default.
+        sources = image_sources.get(match["key"])
+        offsets = sources[0].offsets if sources else ImageOffset()
         docs.append(
             {
                 # The addition key is the event's identity: Meilisearch upserts by `ms_id`,
@@ -114,6 +124,8 @@ def event_search_documents(events: dy.DataFrame[EventsSchema]) -> list[EventSear
                 "organising_org_id": row["organising_org_id"],
                 "image": row["image"],
                 "image_author": row["image_author"],
+                "image_thumb_offset": offsets.thumb,
+                "image_header_offset": offsets.header,
                 # Lecture precedent: uniform 0 keeps the `rank:desc` ranking rule neutral.
                 "rank": 0,
                 "_geo": {"lat": row["lat"], "lng": row["lon"]},
@@ -232,7 +244,7 @@ def export_for_search(data: dict[str, Entry]) -> None:
             },
         )
 
-    export.extend(event_search_documents(load_events()))
+    export.extend(event_search_documents(load_events(), ImageSource.load_all()))
 
     search_bytes = orjson.dumps(export)
     _make_sure_is_safe(search_bytes)

--- a/data/processors/test_export_search_events.py
+++ b/data/processors/test_export_search_events.py
@@ -3,6 +3,7 @@ import polars as pl
 from external.schemas.events import EventsSchema
 
 from processors.export import event_search_documents
+from processors.images import ImageOffset, ImageSource, UrlStr
 
 
 def _events(rows: list[dict[str, object]]) -> dy.DataFrame[EventsSchema]:
@@ -22,9 +23,18 @@ def _events(rows: list[dict[str, object]]) -> dy.DataFrame[EventsSchema]:
     return EventsSchema.validate(df)
 
 
+def _source(*, thumb: int, header: int) -> ImageSource:
+    """Build an img-sources entry carrying explicit crop offsets."""
+    return ImageSource(
+        author="Studentische Vertretung TUM",
+        license=UrlStr(text="CC BY 4.0"),
+        offsets=ImageOffset(thumb=thumb, header=header),
+    )
+
+
 def test_each_row_becomes_one_event_document() -> None:
     """One search document per CSV row, faceted as `event`, with the addition key as `ms_id`."""
-    docs = event_search_documents(_events([{}]))
+    docs = event_search_documents(_events([{}]), {})
 
     assert len(docs) == 1
     doc = docs[0]
@@ -43,6 +53,7 @@ def test_datetimes_are_normalised_to_utc() -> None:
                 {"starts_at": "2026-06-29T09:00:00.000Z", "ends_at": "2026-07-03T21:00:00.000Z"},
             ],
         ),
+        {},
     )
 
     assert docs[0]["starts_at"] == "2026-06-15T14:00:00Z"
@@ -53,7 +64,7 @@ def test_datetimes_are_normalised_to_utc() -> None:
 
 def test_document_carries_the_full_prefill_payload() -> None:
     """Everything a client needs to pre-fill the event proposal form rides along on the document."""
-    doc = event_search_documents(_events([{}]))[0]
+    doc = event_search_documents(_events([{}]), {})[0]
 
     assert doc["description"] == "Open-air student festival."
     assert doc["organising_org_id"] == 51897
@@ -73,6 +84,32 @@ def test_duplicate_key_rows_collapse_to_one_document() -> None:
                 {"starts_at": "2026-06-15T16:00:00+02:00", "ends_at": "2026-06-19T23:59:00+02:00"},
             ],
         ),
+        {},
     )
 
     assert docs[0]["ms_id"] == docs[1]["ms_id"]
+
+
+def test_crop_offsets_ride_along() -> None:
+    """The offsets keyed by the addition key thread onto the document for crop recovery."""
+    doc = event_search_documents(
+        _events([{"image": "/cdn/thumb/event_17ddb108241f623c_0.webp"}]),
+        {"event_17ddb108241f623c": [_source(thumb=14, header=257)]},
+    )[0]
+
+    assert doc["image_thumb_offset"] == 14
+    assert doc["image_header_offset"] == 257
+
+
+def test_missing_or_offset_less_source_defaults_to_zero() -> None:
+    """An event with no img-source entry - or an entry without explicit offsets - crops unshifted."""
+    no_entry = event_search_documents(_events([{}]), {})[0]
+    assert no_entry["image_thumb_offset"] == 0
+    assert no_entry["image_header_offset"] == 0
+
+    entry_without_offsets = event_search_documents(
+        _events([{}]),
+        {"event_9d02ddd940c43f87": [ImageSource(author="a", license=UrlStr(text="CC BY 4.0"))]},
+    )[0]
+    assert entry_without_offsets["image_thumb_offset"] == 0
+    assert entry_without_offsets["image_header_offset"] == 0

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -212,9 +212,11 @@ pub struct GeoPoint {
 /// `search_data.json`. Carries everything a client needs to pre-fill the event
 /// proposal form, so picking a search hit needs no second round-trip.
 ///
-/// Every field is required: the pipeline always writes the full shape, so a
-/// missing field signals index corruption and should fail the deserialize loudly
-/// rather than be papered over with a default.
+/// Every field is required, with one exception: the pipeline always writes the
+/// full shape, so a missing field signals index corruption and should fail the
+/// deserialize loudly rather than be papered over with a default. The two image
+/// crop offsets are the exception - they were added after the facet shipped, so
+/// documents indexed before then lack them and must default to `0`.
 #[derive(Deserialize, Clone)]
 pub struct EventMSHit {
     /// The `event_<hash>` identity shared by the CSV row and its key-named images.
@@ -227,6 +229,12 @@ pub struct EventMSHit {
     /// The `/cdn/thumb/…` delivery path of the event image.
     pub image: String,
     pub image_author: String,
+    /// Crop offset of the thumbnail image: pixels to shift the crop window along the image's longer axis.
+    #[serde(default)]
+    pub image_thumb_offset: i32,
+    /// Crop offset of the header image: pixels to shift the crop window along the image's longer axis.
+    #[serde(default)]
+    pub image_header_offset: i32,
     #[serde(rename = "_geo")]
     pub coords: GeoPoint,
 }

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -294,6 +294,8 @@ fn make_event_entry(
         organising_org_id: event.organising_org_id,
         image: event.image.clone(),
         image_author: event.image_author.clone(),
+        image_thumb_offset: event.image_thumb_offset,
+        image_header_offset: event.image_header_offset,
     }
 }
 

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -1285,7 +1285,9 @@ mod test {
     async fn test_event_image_crop_offsets_thread_through() {
         let ms = MeiliSearchTestContainer::new().await;
         let mut document = garnix_event_document();
-        let fields = document.as_object_mut().expect("event document is a JSON object");
+        let fields = document
+            .as_object_mut()
+            .expect("event document is a JSON object");
         fields.insert("image_thumb_offset".to_owned(), serde_json::json!(14));
         fields.insert("image_header_offset".to_owned(), serde_json::json!(257));
         let task = ms

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -144,6 +144,14 @@ pub struct EventEntry {
     /// The author of the event image (CC-BY attribution).
     #[schema(example = "Studentische Vertretung TUM")]
     image_author: String,
+    /// Crop offset of the thumbnail image: pixels to shift the crop window
+    /// along the image's longer axis. `0` when unset, so a client can recover the crop.
+    #[schema(example = 14)]
+    image_thumb_offset: i32,
+    /// Crop offset of the header image: pixels to shift the crop window
+    /// along the image's longer axis. `0` when unset, so a client can recover the crop.
+    #[schema(example = 257)]
+    image_header_offset: i32,
 }
 
 /// A Nominatim address search result.
@@ -1248,6 +1256,10 @@ mod test {
         assert_eq!(top.organising_org_id, 51897);
         assert_eq!(top.image, "/cdn/thumb/event_9d02ddd940c43f87_0.webp");
         assert_eq!(top.image_author, "Studentische Vertretung TUM");
+        // This document predates the crop offsets: a pre-existing index entry lacking
+        // the fields must deserialize to 0, not fail.
+        assert_eq!(top.image_thumb_offset, 0);
+        assert_eq!(top.image_header_offset, 0);
 
         // The event surfaces only in its own section, never in the five geo/lecture ones.
         for section in &results.0 {
@@ -1266,6 +1278,52 @@ mod test {
         }, {
             insta::assert_yaml_snapshot!(results.0, { ".**.estimatedTotalHits" => "[estimatedTotalHits]"});
         });
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_event_image_crop_offsets_thread_through() {
+        let ms = MeiliSearchTestContainer::new().await;
+        let mut document = garnix_event_document();
+        let fields = document.as_object_mut().expect("event document is a JSON object");
+        fields.insert("image_thumb_offset".to_owned(), serde_json::json!(14));
+        fields.insert("image_header_offset".to_owned(), serde_json::json!(257));
+        let task = ms
+            .client
+            .index("entries")
+            .add_documents(&[document], Some("ms_id"))
+            .await
+            .unwrap()
+            .wait_for_completion(&ms.client, None, Some(std::time::Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            matches!(task, meilisearch_sdk::tasks::Task::Succeeded { .. }),
+            "event document upsert should succeed, got {task:?}"
+        );
+
+        let limits = Limits {
+            events_count: 5,
+            ..Limits::default()
+        };
+        let results = do_geoentry_search(
+            &ms.client,
+            "garnix",
+            limits,
+            FormattingConfig::default(),
+            String::new(),
+            vec![],
+        )
+        .await;
+
+        let top = results
+            .0
+            .iter()
+            .find_map(ResultsSection::events)
+            .and_then(|events| events.entries.first())
+            .expect("expected at least one event entry");
+        assert_eq!(top.image_thumb_offset, 14);
+        assert_eq!(top.image_header_offset, 257);
     }
 
     /// The event facet is default-disabled: without `search_events=true` or

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__event_facet_returns_the_prefill_payload.snap
@@ -16,6 +16,8 @@ info: "q=garnix, search_events=true"
       organising_org_id: 51897
       image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
       image_author: Studentische Vertretung TUM
+      image_thumb_offset: 0
+      image_header_offset: 0
   n_visible: 1
   estimatedTotalHits: "[estimatedTotalHits]"
 - facet: sites

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__newest_event_edition_ranks_first.snap
@@ -16,6 +16,8 @@ info: "q=garnix, search_events=true"
       organising_org_id: 51897
       image: /cdn/thumb/event_9d02ddd940c43f87_0.webp
       image_author: Studentische Vertretung TUM
+      image_thumb_offset: 0
+      image_header_offset: 0
     - id: event_17ddb108241f623c
       name: "\u0019GARNIX\u0017 Festival"
       description: "Last year's edition."
@@ -26,6 +28,8 @@ info: "q=garnix, search_events=true"
       organising_org_id: 51897
       image: /cdn/thumb/event_17ddb108241f623c_0.webp
       image_author: Studentische Vertretung TUM
+      image_thumb_offset: 0
+      image_header_offset: 0
   n_visible: 2
   estimatedTotalHits: "[estimatedTotalHits]"
 - facet: sites

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -669,6 +669,20 @@ export type components = {
        */
       readonly image_author: string;
       /**
+       * Format: int32
+       * @description Crop offset of the header image: pixels to shift the crop window
+       *     along the image's longer axis. `0` when unset, so a client can recover the crop.
+       * @example 257
+       */
+      readonly image_header_offset: number;
+      /**
+       * Format: int32
+       * @description Crop offset of the thumbnail image: pixels to shift the crop window
+       *     along the image's longer axis. `0` when unset, so a client can recover the crop.
+       * @example 14
+       */
+      readonly image_thumb_offset: number;
+      /**
        * Format: double
        * @description Latitude of the event location.
        * @example 48.262908


### PR DESCRIPTION
Closes #3266. Threads `image_thumb_offset`/`image_header_offset` from img-sources.yaml through the event search path so a client can recover the existing crop when pre-filling the proposal form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)