### PR TITLE
chore(server): enable clippy::cargo lint group

### DIFF
--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -70,7 +70,7 @@ jobs:
           workspaces: |
             server
       - run: rustup component add clippy
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings
         env:
           CARGO_INCREMENTAL: 0
           CARGO_NET_RETRY: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ use_self = "warn"
 
 # Pedantics without being too noisy
 pedantic = { level = "warn", priority = -1 }
+# Cargo lints guard the manifests (wildcard deps, feature naming).
+cargo = { level = "warn", priority = -1 }
+# Transitive version duplication (windows-sys, getrandom, ...) we cannot control.
+multiple_crate_versions = "allow"
+# motis-openapi-progenitor is generated and internal, never published to a registry.
+cargo_common_metadata = "allow"
 derive_partial_eq_without_eq = "allow"
 enum_variant_names = "allow"
 implicit_hasher = "allow"

--- a/server/src/routes/locations/details.rs
+++ b/server/src/routes/locations/details.rs
@@ -744,7 +744,8 @@ mod tests {
         clippy::panic_in_result_fn,
         clippy::cast_precision_loss,
         clippy::absolute_paths,
-        reason = "tests assert via panic/unwrap, cast freely, and reference absolute fixture paths"
+        clippy::indexing_slicing,
+        reason = "tests assert via panic/unwrap, cast freely, index JSON by key, and reference absolute fixture paths"
     )]
     use tokio::task::LocalSet;
     use tracing::info;


### PR DESCRIPTION
## What

Tightens the Rust lint config by enabling the `clippy::cargo` group at the workspace level, guarding the manifests against wildcard dependencies and feature-naming slips going forward.

The two noisy members of the group are muted with documented reasons:

- `multiple_crate_versions` — transitive version duplication (`windows-sys`, `getrandom`, ...) we cannot control.
- `cargo_common_metadata` — only fires on the generated, unpublished `motis-openapi-progenitor` crate.

The genuinely useful members (`wildcard_dependencies`, `negative_feature_names`, `redundant_feature_names`) currently produce **zero** warnings — the manifests are already clean, so this acts purely as a forward-looking guard.

## CI change

`clippy::cargo` needs the full dependency graph to evaluate, so the CI clippy step now runs with `--all-features`. I added `--all-targets` alongside so test and bench code are linted too — these were previously skipped. That surfaced one previously-unlinted `indexing_slicing` in the details test module, which is folded into that module's existing test-only `#![allow(...)]` block (same rationale as the `unwrap`/`panic` relaxations already there).

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` is green locally — the exact invocation CI now runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)