### PR TITLE
chore(webclient): tighten Biome lint with noExplicitAny, a11y, Vue and shadow rules

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -45,11 +45,18 @@
       "nursery": {
         "useSortedClasses": "error",
         "useVueDefineMacrosOrder": "error",
-        "noNestedPromises": "error"
+        "noNestedPromises": "error",
+        "noAmbiguousAnchorText": "warn",
+        "noVueOptionsApi": "error",
+        "useVueVForKey": "error",
+        "noShadow": "error"
       },
       "recommended": true,
+      "a11y": {
+        "noNoninteractiveElementInteractions": "error"
+      },
       "suspicious": {
-        "noExplicitAny": "off",
+        "noExplicitAny": "error",
         "noArrayIndexKey": "off",
         "noConsole": { "level": "error", "options": { "allow": ["error", "warn"] } },
         "noEvolvingTypes": "error",

--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -85,7 +85,7 @@ function createMarker(hueRotation = 0) {
 }
 
 function initMap(containerId: string): MapLibreMap {
-  const map = new MapLibreMap({
+  const mapInstance = new MapLibreMap({
     container: containerId,
     // while having the hash in the url is nice, it is overridden on map load anyway => not much use
     hash: false,
@@ -108,13 +108,13 @@ function initMap(containerId: string): MapLibreMap {
     validateStyle: import.meta.env.DEV,
     maplibreLogo: true,
   });
-  attachWebglGuard(map);
+  attachWebglGuard(mapInstance);
 
   // Each source / style change causes the map to get
   // into "loading" state, so map.loaded() is not reliable
   // enough to know whether just the initial loading has
   // succeeded.
-  map.on("load", () => {
+  mapInstance.on("load", () => {
     initialLoaded.value = true;
 
     // controls
@@ -135,7 +135,7 @@ function initMap(containerId: string): MapLibreMap {
         trackUserLocation: true,
       })
     );
-    map.addControl(new CombinedControlGroup(controls), "top-right");
+    mapInstance.addControl(new CombinedControlGroup(controls), "top-right");
 
     // Set available floors if provided
     if (props.floors && props.floors.length > 0) {
@@ -147,15 +147,15 @@ function initMap(containerId: string): MapLibreMap {
     }
   });
 
-  map.addControl(floorControl.value, "top-left");
+  mapInstance.addControl(floorControl.value, "top-left");
 
   // Listen for floor level changes and adjust zoom if needed
   floorControl.value.on("level-changed", (event: { level: number | null }) => {
-    if (event.level !== null && map) {
-      const currentMapZoom = map.getZoom();
+    if (event.level !== null && mapInstance) {
+      const currentMapZoom = mapInstance.getZoom();
       // Our floors are only visible at zoom level 17+
       if (currentMapZoom < 17) {
-        map.easeTo({
+        mapInstance.easeTo({
           zoom: 17,
           duration: 2000,
         });
@@ -163,7 +163,7 @@ function initMap(containerId: string): MapLibreMap {
     }
   });
 
-  return map;
+  return mapInstance;
 }
 
 // --- Loading components ---

--- a/webclient/app/components/EntryPicker.vue
+++ b/webclient/app/components/EntryPicker.vue
@@ -32,7 +32,7 @@ const searchUrl = computed(() => {
   if (debounced.value.length < 2) return null;
   const params = new URLSearchParams();
   params.set("q", debounced.value);
-  for (const t of props.allowedTypes) params.append("type", t);
+  for (const allowedType of props.allowedTypes) params.append("type", allowedType);
   params.set("limit_all", "8");
   // Disable highlight markers so we can use the response strings as plain text.
   params.set("pre_highlight", "");

--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -20,7 +20,7 @@ type ItineraryResponse = components["schemas"]["ItineraryResponse"];
 // Simplified GeoJSON Feature type to avoid deep type inference
 interface SimpleGeoJSONFeature {
   type: "Feature";
-  properties: Record<string, any>;
+  properties: Record<string, unknown>;
   geometry: {
     type: "LineString";
     coordinates: number[][];
@@ -89,7 +89,7 @@ function createMarker(hueRotation = 0): HTMLDivElement {
 }
 
 function initMap(containerId: string): MapLibreMap {
-  const map = new MapLibreMap({
+  const mapInstance = new MapLibreMap({
     container: containerId,
     // Reflect the viewport in the URL hash so the map state is deep-linkable.
     hash: true,
@@ -110,14 +110,14 @@ function initMap(containerId: string): MapLibreMap {
     center: [11.670099, 48.266921],
     zoom: zoom.value,
   });
-  attachWebglGuard(map);
+  attachWebglGuard(mapInstance);
 
   // Each source / style change causes the map to get
   // into "loading" state, so map.loaded() is not reliable
   // enough to know whether just the initial loading has
   // succeeded.
-  map.on("load", () => {
-    map.addControl(new NavigationControl({}), "top-left");
+  mapInstance.on("load", () => {
+    mapInstance.addControl(new NavigationControl({}), "top-left");
 
     const location = new GeolocateControl({
       positionOptions: {
@@ -143,11 +143,11 @@ function initMap(containerId: string): MapLibreMap {
       geolocationState.value.triggeringSearchBarId = null;
     });
 
-    map.addControl(location);
+    mapInstance.addControl(location);
     geolocateControl.value = location;
 
     // Add Valhalla route source and layers
-    map.addSource("route", {
+    mapInstance.addSource("route", {
       type: "geojson",
       data: {
         type: "Feature",
@@ -158,7 +158,7 @@ function initMap(containerId: string): MapLibreMap {
         },
       },
     });
-    map.addLayer({
+    mapInstance.addLayer({
       id: "route",
       type: "line",
       source: "route",
@@ -171,7 +171,7 @@ function initMap(containerId: string): MapLibreMap {
         "line-width": 7,
       },
     });
-    map.addLayer({
+    mapInstance.addLayer({
       id: "route-symbol",
       type: "symbol",
       source: "route",
@@ -185,7 +185,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Add Motis route sources and layers
-    map.addSource("motis-routes", {
+    mapInstance.addSource("motis-routes", {
       type: "geojson",
       data: {
         type: "FeatureCollection",
@@ -194,7 +194,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Add multiple layers for different transport modes
-    map.addLayer({
+    mapInstance.addLayer({
       id: "motis-route-walk",
       type: "line",
       source: "motis-routes",
@@ -211,7 +211,7 @@ function initMap(containerId: string): MapLibreMap {
       },
     });
 
-    map.addLayer({
+    mapInstance.addLayer({
       id: "motis-route-transit",
       type: "line",
       source: "motis-routes",
@@ -228,7 +228,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Highlighted leg layer
-    map.addLayer({
+    mapInstance.addLayer({
       id: "motis-route-highlighted",
       type: "line",
       source: "motis-routes",
@@ -245,7 +245,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Add source for platform change markers
-    map.addSource("platform-changes", {
+    mapInstance.addSource("platform-changes", {
       type: "geojson",
       data: {
         type: "FeatureCollection",
@@ -254,7 +254,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Add platform change layers AFTER all route layers so they render on top
-    map.addLayer({
+    mapInstance.addLayer({
       id: "platform-changes",
       type: "circle",
       source: "platform-changes",
@@ -270,7 +270,7 @@ function initMap(containerId: string): MapLibreMap {
     });
 
     // Platform change text layer
-    map.addLayer({
+    mapInstance.addLayer({
       id: "platform-changes-text",
       type: "symbol",
       source: "platform-changes",
@@ -294,7 +294,7 @@ function initMap(containerId: string): MapLibreMap {
     afterLoaded.value();
   });
 
-  return map;
+  return mapInstance;
 }
 
 function drawRoute(shapes: readonly Coordinate[], isAfterLoaded = false) {

--- a/webclient/app/pages/[type]/[id].vue
+++ b/webclient/app/pages/[type]/[id].vue
@@ -8,8 +8,8 @@ import { useEditProposal } from "~/composables/editProposal";
 const VALID_TYPE_RE = /^(campus|site|building|room|poi)$/;
 
 definePageMeta({
-  validate(route) {
-    return VALID_TYPE_RE.test(route.params.type as string);
+  validate(to) {
+    return VALID_TYPE_RE.test(to.params.type as string);
   },
   layout: "fullscreen",
 });
@@ -74,19 +74,19 @@ watch([data], () => {
 const description = computed(() => {
   if (data.value === undefined || data.value === null) return "";
 
-  let description = t("details_for");
+  let text = t("details_for");
   if (data.value.name.includes(data.value.type_common_name)) {
-    description += ` ${data.value.name}`;
+    text += ` ${data.value.name}`;
   } else {
-    description += ` ${data.value.type_common_name} ${data.value.name}`;
+    text += ` ${data.value.type_common_name} ${data.value.name}`;
   }
   if (data.value.props.computed) {
-    description += ":";
+    text += ":";
     for (const prop of data.value.props.computed) {
-      description += `\n- ${prop.name}: ${prop.text}`;
+      text += `\n- ${prop.name}: ${prop.text}`;
     }
   }
-  return description;
+  return text;
 });
 const title = computed(() => data.value?.name || `${route.params.id} - Navigatum`);
 const canonicalUrl = computed(() => {


### PR DESCRIPTION
Enables noExplicitAny, noNoninteractiveElementInteractions, noAmbiguousAnchorText, noVueOptionsApi, useVueVForKey and noShadow, fixing the few sites they surfaced; lint and type-check pass clean.