### PR TITLE
fix(webclient): preserve event image crop offsets when editing an existing event

### DIFF
--- a/webclient/app/components/AddEventFields.vue
+++ b/webclient/app/components/AddEventFields.vue
@@ -33,7 +33,7 @@ import {
   formatEventDateRange,
   wallTimeToRfc3339,
 } from "~/utils/datetime";
-import { cropToBlob, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
+import { clampCropOffset, cropToBlob, HEADER_TARGET, THUMB_TARGET } from "~/utils/imageCrop";
 
 type EventEntry = components["schemas"]["EventEntry"];
 type SearchResponse = components["schemas"]["SearchResponse"];
@@ -125,7 +125,8 @@ function fileToBase64(file: File): Promise<string | null> {
   });
 }
 
-async function processFile(file: File): Promise<void> {
+// `adopt` is set only when re-fetching a based-on event's own image, so its saved crop survives.
+async function processFile(file: File, adopt = false): Promise<void> {
   // Picking or unlinking a based-on event swaps the draft object while the image may
   // still be decoding; writes must land on the draft this file was selected for.
   const target = draft.value;
@@ -168,9 +169,15 @@ async function processFile(file: File): Promise<void> {
   draft.value.image = { base64, fileName: file.name || "event-image" };
   draft.value.image_width = bitmap.width;
   draft.value.image_height = bitmap.height;
-  // A new image recentres both crops; their offset bounds depend on the new dimensions.
-  draft.value.image_thumb_offset = 0;
-  draft.value.image_header_offset = 0;
+  // A new image recentres both crops; adopting the based-on image restores its saved crop,
+  // clamped to the loaded dimensions so a since-replaced source can't push it out of bounds.
+  const basedOn = adopt ? draft.value.based_on : null;
+  draft.value.image_thumb_offset = basedOn
+    ? clampCropOffset(bitmap.width, bitmap.height, THUMB_TARGET, basedOn.thumb_offset)
+    : 0;
+  draft.value.image_header_offset = basedOn
+    ? clampCropOffset(bitmap.width, bitmap.height, HEADER_TARGET, basedOn.header_offset)
+    : 0;
   // In locked update mode the adopted key stays the identity, whatever the image.
   if (!draft.value.based_on) draft.value.id = `event_${hash}`;
 }
@@ -236,7 +243,10 @@ async function adoptEvent(entry: EventEntry): Promise<void> {
     const blob = await res.blob();
     // The user may have unlinked or re-picked while the image was downloading.
     if (draft.value.based_on?.id !== entry.id) return;
-    await processFile(new File([blob], `${entry.id}_0.webp`, { type: blob.type || "image/webp" }));
+    await processFile(
+      new File([blob], `${entry.id}_0.webp`, { type: blob.type || "image/webp" }),
+      true
+    );
   } catch {
     if (draft.value.based_on?.id === entry.id) prefillError.value = t("prefill_image_failed");
   }

--- a/webclient/app/composables/additionSchema.ts
+++ b/webclient/app/composables/additionSchema.ts
@@ -291,13 +291,15 @@ function buildPoi(draft: PoiDraft): Addition {
   } as Addition;
 }
 
-// The search hit a locked draft is based on: its key is the upsert identity,
-// and its name and last-held dates feed the banner.
+// The search hit a locked draft is based on: its key is the upsert identity, its name and
+// last-held dates feed the banner, and its crop offsets let the re-fetched image keep its crop.
 export interface EventBasedOn {
   id: string;
   name: string;
   starts_at: string;
   ends_at: string;
+  thumb_offset: number;
+  header_offset: number;
 }
 
 export interface EventDraft extends DraftBase {
@@ -354,12 +356,16 @@ export function eventDraftFromEntry(entry: EventEntry, now: number): EventDraft 
     name: entry.name,
     starts_at: entry.starts_at,
     ends_at: entry.ends_at,
+    thumb_offset: entry.image_thumb_offset,
+    header_offset: entry.image_header_offset,
   };
   draft.name = entry.name;
   draft.description = entry.description;
   draft.organising_org_id = entry.organising_org_id;
   draft.coords = { lat: entry.lat, lon: entry.lon, picked: true };
   draft.image_author = entry.image_author;
+  draft.image_thumb_offset = entry.image_thumb_offset;
+  draft.image_header_offset = entry.image_header_offset;
   // Past dates fail the server's EventEnded validation; only a still-running edition pre-fills them.
   if (Date.parse(entry.ends_at) > now) {
     draft.starts_at = rfc3339ToWallTime(entry.starts_at) ?? "";

--- a/webclient/test/additionSchema.event.test.ts
+++ b/webclient/test/additionSchema.event.test.ts
@@ -104,6 +104,8 @@ describe("eventDraftFromEntry", () => {
       organising_org_id: 51897,
       image: "/cdn/thumb/event_4a3e5d2fd5b338e4_0.webp",
       image_author: "Studentische Vertretung TUM",
+      image_thumb_offset: 14,
+      image_header_offset: 257,
       ...overrides,
     };
   }
@@ -116,14 +118,32 @@ describe("eventDraftFromEntry", () => {
       name: "GARNIX Festival",
       starts_at: "2026-06-15T14:00:00Z",
       ends_at: "2026-06-19T21:59:00Z",
+      thumb_offset: 14,
+      header_offset: 257,
     });
     expect(draft.name).toBe("GARNIX Festival");
     expect(draft.description).toBe("Open-air student festival.");
     expect(draft.organising_org_id).toBe(51897);
     expect(draft.coords).toEqual({ lat: 48.262908, lon: 11.669102, picked: true });
     expect(draft.image_author).toBe("Studentische Vertretung TUM");
+    expect(draft.image_thumb_offset).toBe(14);
+    expect(draft.image_header_offset).toBe(257);
     // The image rides in separately through the upload path.
     expect(draft.image).toBeNull();
+  });
+
+  it("re-sends the saved crop when an unmodified edit is rebuilt", () => {
+    // A non-zero offset must survive eventDraftFromEntry -> buildEvent, or the upsert flattens it.
+    const upcoming = entry({
+      starts_at: new Date(Date.now() + 2 * DAY_MS).toISOString(),
+      ends_at: new Date(Date.now() + 3 * DAY_MS).toISOString(),
+    });
+    const draft = eventDraftFromEntry(upcoming, Date.now());
+    draft.image = { base64: "Zm9v", fileName: "event_4a3e5d2fd5b338e4_0.webp" };
+    draft.image_width = 1448;
+    draft.image_height = 2048;
+    const built = buildAddition(draft);
+    expect(built).toMatchObject({ image: { metadata: { offsets: { thumb: 14, header: 257 } } } });
   });
 
   it("pre-fills the dates of a not-yet-ended event as the same instants", () => {


### PR DESCRIPTION
Editing an existing event from the propose page flattened its carefully positioned thumb/header crop: the pre-fill dropped the saved offsets, re-fetching the adopted image recentred both to `0`, and the server's full-metadata replace then stored `0`. Now that search results expose `image_thumb_offset` / `image_header_offset` (#3266, #3270), the edit round-trips the crop.

- `eventDraftFromEntry` copies the offsets into both the draft and the remembered `based_on` identity.
- Adopting the unchanged image restores those offsets (clamped to the loaded image's dimensions) instead of resetting to `0`; a genuinely new upload still recentres to `0`.
- Added a unit test covering the `eventDraftFromEntry → buildEvent` offset round-trip (fails against the old behaviour).

Closes #3267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)