### PR TITLE
fix(server): name-based event PR titles and tidier batch PR bodies

### DIFF
--- a/server/src/routes/feedback/batch_processor/mod.rs
+++ b/server/src/routes/feedback/batch_processor/mod.rs
@@ -76,9 +76,9 @@ pub async fn update_batch_pr_metadata(
 
     // Append the new edit's description
     let updated_description = if current_description.is_empty() {
-        format!("## Batched Edits\n\n### Edit #{edit_count}\n{new_edit_description}")
+        format!("<sub>Batched edits</sub>\n\n{new_edit_description}")
     } else {
-        format!("{current_description}\n\n---\n\n### Edit #{edit_count}\n{new_edit_description}")
+        format!("{current_description}\n\n---\n\n{new_edit_description}")
     };
 
     let github = GitHub::default();

--- a/server/src/routes/feedback/proposed_edits/addition/building.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/building.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use super::super::coordinate::Coordinate;
-use super::AppliableAddition;
 use super::areatree::{AreatreeKind, format_line, insert_under};
+use super::{AppliableAddition, AppliedAddition};
 use super::validation::{AdditionError, AdditionVariant, CollisionSource, RepoSnapshot};
 
 const MAX_NAME_LEN: usize = 200;
@@ -136,7 +136,7 @@ impl AppliableAddition for NewBuilding {
         Ok(())
     }
 
-    fn apply(&self, _key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<String> {
+    fn apply(&self, _key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<AppliedAddition> {
         let areatree_path = base_dir
             .join("data")
             .join("processors")
@@ -167,14 +167,16 @@ impl AppliableAddition for NewBuilding {
             }
         }
 
-        Ok(self.coords.fenced_geojson_feature(&serde_json::json!({
-            "kind": "new-building",
-            "id": effective_id,
-            "name": self.name,
-            "node_kind": self.kind,
-            "parent_id": self.parent_id,
-            "building_prefixes": self.building_prefixes,
-        })))
+        Ok(AppliedAddition::created(self.coords.fenced_geojson_feature(
+            &serde_json::json!({
+                "kind": "new-building",
+                "id": effective_id,
+                "name": self.name,
+                "node_kind": self.kind,
+                "parent_id": self.parent_id,
+                "building_prefixes": self.building_prefixes,
+            }),
+        )))
     }
 
     fn kind_label(&self) -> &'static str {
@@ -302,7 +304,8 @@ mod tests {
 
         let summary = sample_building()
             .apply("0103", dir.path(), "branch")
-            .unwrap();
+            .unwrap()
+            .summary;
         assert_snapshot!(summary, @r#"
         ```geojson
         {

--- a/server/src/routes/feedback/proposed_edits/addition/building.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/building.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use super::super::coordinate::Coordinate;
 use super::areatree::{AreatreeKind, format_line, insert_under};
-use super::{AppliableAddition, AppliedAddition};
 use super::validation::{AdditionError, AdditionVariant, CollisionSource, RepoSnapshot};
+use super::{AppliableAddition, AppliedAddition};
 
 const MAX_NAME_LEN: usize = 200;
 
@@ -167,16 +167,16 @@ impl AppliableAddition for NewBuilding {
             }
         }
 
-        Ok(AppliedAddition::created(self.coords.fenced_geojson_feature(
-            &serde_json::json!({
+        Ok(AppliedAddition::created(
+            self.coords.fenced_geojson_feature(&serde_json::json!({
                 "kind": "new-building",
                 "id": effective_id,
                 "name": self.name,
                 "node_kind": self.kind,
                 "parent_id": self.parent_id,
                 "building_prefixes": self.building_prefixes,
-            }),
-        )))
+            })),
+        ))
     }
 
     fn kind_label(&self) -> &'static str {

--- a/server/src/routes/feedback/proposed_edits/addition/event.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/event.rs
@@ -529,7 +529,9 @@ mod tests {
         );
         assert_eq!(
             applied.image_url.as_deref(),
-            Some("https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp")
+            Some(
+                "https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp"
+            )
         );
 
         let csv = fs::read_to_string(sources.join("events.csv")).unwrap();
@@ -628,7 +630,9 @@ mod tests {
         );
         assert_eq!(
             applied.image_url.as_deref(),
-            Some("https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp")
+            Some(
+                "https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp"
+            )
         );
 
         let csv = fs::read_to_string(sources.join("events.csv")).unwrap();

--- a/server/src/routes/feedback/proposed_edits/addition/event.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/event.rs
@@ -10,8 +10,8 @@ use serde::Deserialize;
 use super::super::AppliableEdit as _;
 use super::super::coordinate::Coordinate;
 use super::super::image::Image;
-use super::AppliableAddition;
 use super::validation::{AdditionError, RepoSnapshot};
+use super::{AppliableAddition, AppliedAddition};
 
 const MAX_NAME_LEN: usize = 200;
 /// The photo marker renders a 256×256 thumb crop, so smaller uploads would be upscaled.
@@ -239,29 +239,34 @@ impl AppliableAddition for NewEvent {
         Ok(())
     }
 
-    fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<String> {
+    fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<AppliedAddition> {
         let csv_path = events_csv_path(base_dir);
         let raw = fs::read(&csv_path)?;
         // Content-addressed key, so always the first slot.
         let image = format!("/cdn/thumb/{key}_0.webp");
         // Identity = key: an existing row under this key makes the addition an update.
-        let (verb, image_md) = if let Some(row) = matching_row_range(&raw, key)? {
-            let image_md = self.image.replace(key, base_dir, branch)?;
+        let replaced = if let Some(row) = matching_row_range(&raw, key)? {
+            self.image.replace(key, base_dir, branch)?;
             self.replace_events_row(&image, &csv_path, &raw, row)?;
-            ("update", image_md)
+            true
         } else {
-            let image_md = self.image.apply(key, base_dir, branch)?;
+            self.image.apply(key, base_dir, branch)?;
             self.append_events_row(&image, &csv_path)?;
-            ("new", image_md)
+            false
         };
 
-        Ok(format!(
-            "{verb} event `{name}` ({starts_at} - {ends_at}, org `{org}`)\n\n{image_md}",
-            name = self.name,
-            starts_at = format_de(&self.starts_at)?,
-            ends_at = format_de(&self.ends_at)?,
-            org = self.organising_org_id,
-        ))
+        let verb = if replaced { "update" } else { "new" };
+        Ok(AppliedAddition {
+            summary: format!(
+                "{verb} event \"{name}\" ({starts_at} - {ends_at}, org `{org}`)",
+                name = self.name,
+                starts_at = format_de(&self.starts_at)?,
+                ends_at = format_de(&self.ends_at)?,
+                org = self.organising_org_id,
+            ),
+            image_url: Some(Image::raw_lg_url(key, branch)?),
+            replaced,
+        })
     }
 
     fn kind_label(&self) -> &'static str {
@@ -514,14 +519,18 @@ mod tests {
         )
         .unwrap();
 
-        let summary = sample_event()
+        let applied = sample_event()
             .apply("event_9d02ddd940c43f87", dir.path(), "branch")
             .unwrap();
-        assert_snapshot!(summary, @r"
-        update event `GARNIX Festival` (10.6.26 16:00 - 12.6.26 23:00, org `51897`)
-
-        ![image showing event_9d02ddd940c43f87](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp)
-        ");
+        assert!(applied.replaced);
+        assert_eq!(
+            applied.summary,
+            "update event \"GARNIX Festival\" (10.6.26 16:00 - 12.6.26 23:00, org `51897`)"
+        );
+        assert_eq!(
+            applied.image_url.as_deref(),
+            Some("https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp")
+        );
 
         let csv = fs::read_to_string(sources.join("events.csv")).unwrap();
         assert_snapshot!(csv, @r#"
@@ -609,14 +618,18 @@ mod tests {
         )
         .unwrap();
 
-        let summary = sample_event()
+        let applied = sample_event()
             .apply("event_9d02ddd940c43f87", dir.path(), "branch")
             .unwrap();
-        assert_snapshot!(summary, @r"
-        new event `GARNIX Festival` (10.6.26 16:00 - 12.6.26 23:00, org `51897`)
-
-        ![image showing event_9d02ddd940c43f87](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp)
-        ");
+        assert!(!applied.replaced);
+        assert_eq!(
+            applied.summary,
+            "new event \"GARNIX Festival\" (10.6.26 16:00 - 12.6.26 23:00, org `51897`)"
+        );
+        assert_eq!(
+            applied.image_url.as_deref(),
+            Some("https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/branch/data/sources/img/lg/event_9d02ddd940c43f87_0.webp")
+        );
 
         let csv = fs::read_to_string(sources.join("events.csv")).unwrap();
         assert_snapshot!(csv, @r#"

--- a/server/src/routes/feedback/proposed_edits/addition/mod.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/mod.rs
@@ -28,8 +28,29 @@ pub enum Addition {
 
 pub trait AppliableAddition {
     fn validate(&self, key: &str, snap: &RepoSnapshot) -> Result<(), AdditionError>;
-    fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<String>;
+    fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<AppliedAddition>;
     fn kind_label(&self) -> &'static str;
+}
+
+/// The result of applying an [`Addition`], as the PR description renders it.
+pub struct AppliedAddition {
+    /// One-line human summary for the PR body.
+    pub summary: String,
+    /// Image to show beside the summary (events only).
+    pub image_url: Option<String>,
+    /// Whether an existing entry was replaced rather than created (events only).
+    pub replaced: bool,
+}
+
+impl AppliedAddition {
+    /// A new addition with no image.
+    pub fn created(summary: String) -> Self {
+        Self {
+            summary,
+            image_url: None,
+            replaced: false,
+        }
+    }
 }
 
 impl Addition {
@@ -46,12 +67,25 @@ impl Addition {
         self.as_appliable().validate(key, snap)
     }
 
-    pub fn apply(&self, key: &str, base_dir: &Path, branch: &str) -> anyhow::Result<String> {
+    pub fn apply(
+        &self,
+        key: &str,
+        base_dir: &Path,
+        branch: &str,
+    ) -> anyhow::Result<AppliedAddition> {
         self.as_appliable().apply(key, base_dir, branch)
     }
 
     pub fn kind_label(&self) -> &'static str {
         self.as_appliable().kind_label()
+    }
+
+    /// The event's name, or `None` for non-event additions.
+    pub fn event_name(&self) -> Option<&str> {
+        match self {
+            Self::Event(e) => Some(&e.name),
+            _ => None,
+        }
     }
 }
 

--- a/server/src/routes/feedback/proposed_edits/addition/poi.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/poi.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use super::super::coordinate::Coordinate;
-use super::AppliableAddition;
 use super::validation::{AdditionError, CollisionSource, RepoSnapshot};
+use super::{AppliableAddition, AppliedAddition};
 
 const MAX_NAME_LEN: usize = 200;
 const MAX_KEY_LEN: usize = 64;
@@ -122,7 +122,7 @@ impl AppliableAddition for NewPoi {
         Ok(())
     }
 
-    fn apply(&self, key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<String> {
+    fn apply(&self, key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<AppliedAddition> {
         let yaml_path = base_dir.join("data").join("sources").join("21_pois.yaml");
         let raw = fs::read_to_string(&yaml_path).unwrap_or_default();
         let mut map: BTreeMap<String, serde_yaml::Value> = if raw.trim().is_empty() {
@@ -147,12 +147,12 @@ impl AppliableAddition for NewPoi {
         let out = serde_yaml::to_string(&map)?;
         fs::write(&yaml_path, out)?;
 
-        Ok(format!(
+        Ok(AppliedAddition::created(format!(
             "new POI `{key}` ({name}, usage `{usage}`, parent `{parent}`)",
             name = self.name,
             usage = self.usage_name,
             parent = self.parent,
-        ))
+        )))
     }
 
     fn kind_label(&self) -> &'static str {
@@ -263,7 +263,8 @@ mod tests {
 
         let summary = sample_poi()
             .apply("validierungsautomat-99", dir.path(), "branch")
-            .unwrap();
+            .unwrap()
+            .summary;
         assert_snapshot!(
             summary,
             @"new POI `validierungsautomat-99` (Validierungsautomat 99, usage `Validierungsautomat`, parent `5101.EG.917`)"

--- a/server/src/routes/feedback/proposed_edits/addition/room.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/room.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use super::super::coordinate::Coordinate;
 use super::areatree::AreatreeKind;
-use super::{AppliableAddition, AppliedAddition};
 use super::validation::{AdditionError, AdditionVariant, CollisionSource, RepoSnapshot};
+use super::{AppliableAddition, AppliedAddition};
 
 #[derive(Debug, Deserialize, Serialize, Clone, utoipa::ToSchema)]
 pub struct RoomLink {

--- a/server/src/routes/feedback/proposed_edits/addition/room.rs
+++ b/server/src/routes/feedback/proposed_edits/addition/room.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use super::super::coordinate::Coordinate;
-use super::AppliableAddition;
 use super::areatree::AreatreeKind;
+use super::{AppliableAddition, AppliedAddition};
 use super::validation::{AdditionError, AdditionVariant, CollisionSource, RepoSnapshot};
 
 #[derive(Debug, Deserialize, Serialize, Clone, utoipa::ToSchema)]
@@ -156,7 +156,7 @@ impl AppliableAddition for NewRoom {
         Ok(())
     }
 
-    fn apply(&self, key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<String> {
+    fn apply(&self, key: &str, base_dir: &Path, _branch: &str) -> anyhow::Result<AppliedAddition> {
         let yaml_path = base_dir
             .join("data")
             .join("sources")
@@ -185,13 +185,13 @@ impl AppliableAddition for NewRoom {
 
         self.coords.apply_to_csv(key, base_dir)?;
 
-        Ok(format!(
+        Ok(AppliedAddition::created(format!(
             "new room `{key}` ({alt}, arch_name `{arch}`, usage_id {uid}) @ {coords:?}",
             alt = self.alt_name,
             arch = self.arch_name,
             uid = self.usage_id,
             coords = self.coords,
-        ))
+        )))
     }
 
     fn kind_label(&self) -> &'static str {
@@ -331,7 +331,8 @@ mod tests {
         let dir = setup_apply_dir();
         let summary = sample_room()
             .apply("5117.EG.103", dir.path(), "branch")
-            .unwrap();
+            .unwrap()
+            .summary;
         assert_snapshot!(
             summary,
             @"new room `5117.EG.103` (Testraum, arch_name `EG103@5117`, usage_id 12) @ Coordinate { lat: 48.262, lon: 11.668 }"

--- a/server/src/routes/feedback/proposed_edits/description.rs
+++ b/server/src/routes/feedback/proposed_edits/description.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -12,6 +12,8 @@ use crate::limited::hash_map::LimitedHashMap;
 pub struct Description {
     pub title: String,
     pub body: String,
+    /// Event keys whose submission replaced an existing event (titled "update", not "add").
+    pub updated_event_keys: BTreeSet<String>,
 }
 
 impl Description {
@@ -72,6 +74,11 @@ impl Description {
         }
         for (kind, mut entries) in by_kind {
             entries.sort_by_key(|(k, _)| k.to_string());
+            // Events key off an opaque hash with no `/view/` page, so they render name-first.
+            if kind == "event" {
+                self.apply_event_additions(&entries, base_dir, branch)?;
+                continue;
+            }
             let plural = if entries.len() == 1 {
                 "addition"
             } else {
@@ -93,6 +100,7 @@ impl Description {
                         .apply(key, base_dir, branch)
                         .inspect_err(|e| error!(error=?e, %key, %kind, "addition apply failed"))?;
                     let indented = result
+                        .summary
                         .lines()
                         .map(|line| format!("    {line}"))
                         .collect::<Vec<_>>()
@@ -111,10 +119,57 @@ impl Description {
                         .inspect_err(|e| error!(error=?e, %key, %kind, "addition apply failed"))?;
                     writeln!(
                         self.body,
-                        "| [`{key}`](https://nav.tum.de/view/{key}) | {result} |"
+                        "| [`{key}`](https://nav.tum.de/view/{key}) | {summary} |",
+                        summary = result.summary
                     )?;
                 }
             }
+        }
+        Ok(())
+    }
+
+    /// Renders event additions as an `event | image` table and records which were updates.
+    fn apply_event_additions(
+        &mut self,
+        entries: &[(&str, &Addition)],
+        base_dir: &Path,
+        branch: &str,
+    ) -> anyhow::Result<()> {
+        let mut applied = Vec::with_capacity(entries.len());
+        for (key, addition) in entries {
+            let result = addition
+                .apply(key, base_dir, branch)
+                .inspect_err(|e| error!(error=?e, %key, "event addition apply failed"))?;
+            if result.replaced {
+                self.updated_event_keys.insert((*key).to_string());
+            }
+            applied.push(result);
+        }
+
+        let updated = applied.iter().filter(|a| a.replaced).count();
+        let added = applied.len() - updated;
+        let fragment = event_title_fragment(added, updated);
+        if self.title.is_empty() {
+            self.title = fragment;
+        } else {
+            write!(self.title, " and {fragment}")?;
+        }
+
+        writeln!(self.body, "\nThe following events were added or updated:")?;
+        self.body += "| event | image |\n";
+        self.body += "| ---   | ---   |\n";
+        for result in &applied {
+            // Cap the width so the poster renders as a thumbnail, not full-bleed.
+            let image = result
+                .image_url
+                .as_deref()
+                .map(|url| format!("<img src=\"{url}\" width=\"200\" alt=\"event poster\">"))
+                .unwrap_or_default();
+            writeln!(
+                self.body,
+                "| {summary} | {image} |",
+                summary = escape_table_cell(&result.summary)
+            )?;
         }
         Ok(())
     }
@@ -159,6 +214,31 @@ impl Description {
     }
 }
 
+/// Commit-subject fragment for event additions, e.g. "2 event additions and 1 event update".
+fn event_title_fragment(added: usize, updated: usize) -> String {
+    let noun = |n: usize, singular: &str| {
+        if n == 1 {
+            singular.to_string()
+        } else {
+            format!("{singular}s")
+        }
+    };
+    match (added, updated) {
+        (a, 0) => format!("{a} event {}", noun(a, "addition")),
+        (0, u) => format!("{u} event {}", noun(u, "update")),
+        (a, u) => format!(
+            "{a} event {} and {u} event {}",
+            noun(a, "addition"),
+            noun(u, "update")
+        ),
+    }
+}
+
+/// Escapes a value for a Markdown table cell (pipes split columns, newlines end the row).
+fn escape_table_cell(value: &str) -> String {
+    value.replace('|', r"\|").replace(['\n', '\r'], " ")
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(
@@ -180,6 +260,7 @@ mod tests {
         let mut description = Description {
             title: "title".to_string(),
             body: "body\n".to_string(),
+            ..Default::default()
         };
         description.add_context("context");
         description.add_context(""); // should be a noop

--- a/server/src/routes/feedback/proposed_edits/image.rs
+++ b/server/src/routes/feedback/proposed_edits/image.rs
@@ -144,7 +144,10 @@ impl Image {
         Ok(Self::summary_markdown(key, branch, &filename))
     }
     fn summary_markdown(key: &str, branch: &str, filename: &str) -> String {
-        format!("![image showing {key}]({})", Self::raw_url(branch, filename))
+        format!(
+            "![image showing {key}]({})",
+            Self::raw_url(branch, filename)
+        )
     }
     fn raw_url(branch: &str, filename: &str) -> String {
         format!(

--- a/server/src/routes/feedback/proposed_edits/image.rs
+++ b/server/src/routes/feedback/proposed_edits/image.rs
@@ -144,9 +144,17 @@ impl Image {
         Ok(Self::summary_markdown(key, branch, &filename))
     }
     fn summary_markdown(key: &str, branch: &str, filename: &str) -> String {
+        format!("![image showing {key}]({})", Self::raw_url(branch, filename))
+    }
+    fn raw_url(branch: &str, filename: &str) -> String {
         format!(
-            "![image showing {key}](https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/{branch}/data/sources/img/lg/{filename})"
+            "https://raw.githubusercontent.com/TUM-Dev/NavigaTUM/refs/heads/{branch}/data/sources/img/lg/{filename}"
         )
+    }
+    /// Raw URL of the canonical (slot-0) image for `key` on `branch`.
+    pub(super) fn raw_lg_url(key: &str, branch: &str) -> anyhow::Result<String> {
+        let safe_key = sanitize_key(key)?;
+        Ok(Self::raw_url(branch, &format!("{safe_key}_0.webp")))
     }
     fn image_should_be_saved_at(key: &str, image_dir: &Path) -> anyhow::Result<PathBuf> {
         // Sanitize the key to prevent path traversal attacks

--- a/server/src/routes/feedback/proposed_edits/mod.rs
+++ b/server/src/routes/feedback/proposed_edits/mod.rs
@@ -470,9 +470,7 @@ pub async fn propose_edits(
             if let Some(pr_number) = pr_number_opt {
                 // Update metadata for batch PR (including appending description)
                 if let Err(e) = super::batch_processor::update_batch_pr_metadata(
-                    pr_number,
-                    &req_data,
-                    &desc.body,
+                    pr_number, &req_data, &desc.body,
                 )
                 .await
                 {

--- a/server/src/routes/feedback/proposed_edits/mod.rs
+++ b/server/src/routes/feedback/proposed_edits/mod.rs
@@ -99,7 +99,7 @@ impl EditRequest {
         repo_pool: &repo_pool::RepoPool,
         branch_name: &str,
         branch_is_new: bool,
-    ) -> Result<String, ApplyError> {
+    ) -> Result<description::Description, ApplyError> {
         let worktree = repo_pool
             .create_worktree(branch_name, branch_is_new)
             .await?;
@@ -142,7 +142,7 @@ impl EditRequest {
         let desc = worktree.apply_and_gen_description(self, branch_name)?;
         worktree.commit(&desc.title).await?;
         worktree.push().await?;
-        Ok(desc.body)
+        Ok(desc)
     }
     fn edits_for<T: AppliableEdit>(&self, extractor: fn(Edit) -> Option<T>) -> HashMap<String, T> {
         self.edits
@@ -224,7 +224,7 @@ impl EditRequest {
         labels
     }
 
-    fn extract_subject(&self) -> String {
+    fn extract_subject(&self, updated_event_keys: &BTreeSet<String>) -> String {
         use itertools::Itertools as _;
         let coordinate_edits = self.edits_for(|edit| edit.coordinate);
         let image_edits = self.edits_for(|edit| edit.image);
@@ -276,6 +276,10 @@ impl EditRequest {
 
         let mut keys_by_kind: BTreeMap<&'static str, Vec<&str>> = BTreeMap::new();
         for (key, addition) in &self.additions.0 {
+            // Events render by name (add/update) in a separate pass below.
+            if addition.event_name().is_some() {
+                continue;
+            }
             keys_by_kind
                 .entry(addition.kind_label())
                 .or_default()
@@ -286,7 +290,6 @@ impl EditRequest {
                 "room" => "rooms",
                 "building" => "buildings",
                 "poi" => "POIs",
-                "event" => "events",
                 _ => "entries",
             };
             let singular = match kind {
@@ -304,11 +307,41 @@ impl EditRequest {
             }
         }
 
+        parts.extend(self.event_subject_parts(updated_event_keys));
+
         if parts.is_empty() {
             "no edits".to_string()
         } else {
             parts.join(" and ")
         }
+    }
+
+    /// Subject fragments for event additions, by name, distinguishing "add" from "update".
+    fn event_subject_parts(&self, updated_event_keys: &BTreeSet<String>) -> Vec<String> {
+        let mut added = Vec::new();
+        let mut updated = Vec::new();
+        for (key, addition) in &self.additions.0 {
+            if let Some(name) = addition.event_name() {
+                if updated_event_keys.contains(key) {
+                    updated.push(name);
+                } else {
+                    added.push(name);
+                }
+            }
+        }
+        let mut parts = Vec::new();
+        for (verb, mut names) in [("add", added), ("update", updated)] {
+            names.sort_unstable();
+            match names.as_slice() {
+                [] => {}
+                [only] => parts.push(format!("{verb} event \"{only}\"")),
+                many if many.len() <= 5 => {
+                    parts.push(format!("{verb} events \"{}\"", many.join("\", \"")));
+                }
+                many => parts.push(format!("{verb} {} events", many.len())),
+            }
+        }
+        parts
     }
 }
 
@@ -433,13 +466,13 @@ pub async fn propose_edits(
         .apply_changes_and_generate_description(&repo_pool, &branch_to_use, branch_is_new)
         .await
     {
-        Ok(description) => {
+        Ok(desc) => {
             if let Some(pr_number) = pr_number_opt {
                 // Update metadata for batch PR (including appending description)
                 if let Err(e) = super::batch_processor::update_batch_pr_metadata(
                     pr_number,
                     &req_data,
-                    &description,
+                    &desc.body,
                 )
                 .await
                 {
@@ -462,14 +495,14 @@ pub async fn propose_edits(
                 labels.push(super::batch_processor::BATCH_LABEL.to_string());
 
                 // Use extract_subject for first PR to provide helpful context
-                let subject = req_data.extract_subject();
+                let subject = req_data.extract_subject(&desc.updated_event_keys);
                 let title = format!("chore(data): {subject}");
 
                 match GitHub::default()
                     .open_pr(
                         branch_to_use,
                         &title,
-                        &format!("## Batched Edits\n\n### Edit #1\n{description}"),
+                        &format!("<sub>Batched edits</sub>\n\n{}", desc.body),
                         labels,
                     )
                     .await
@@ -540,10 +573,28 @@ mod tests {
             "additional_context": "",
             "privacy_checked": true
         }));
-        assert_eq!(req.extract_subject(), "add event `event_9d02ddd940c43f87`");
+        assert_eq!(
+            req.extract_subject(&BTreeSet::new()),
+            "add event \"GARNIX Festival\""
+        );
         let labels = req.extract_labels();
         assert!(labels.contains(&"addition".to_string()));
         assert!(labels.contains(&"new-event".to_string()));
+    }
+
+    #[test]
+    fn extract_subject_for_event_that_replaced_an_existing_one() {
+        let req = req_with_additions(serde_json::json!({
+            "token": "x",
+            "additions": { "event_9d02ddd940c43f87": event_addition() },
+            "additional_context": "",
+            "privacy_checked": true
+        }));
+        let updated = BTreeSet::from(["event_9d02ddd940c43f87".to_string()]);
+        assert_eq!(
+            req.extract_subject(&updated),
+            "update event \"GARNIX Festival\""
+        );
     }
 
     #[test]
@@ -563,7 +614,10 @@ mod tests {
             "additional_context": "",
             "privacy_checked": true
         }));
-        assert_eq!(req.extract_subject(), "add room `5117.EG.103`");
+        assert_eq!(
+            req.extract_subject(&BTreeSet::new()),
+            "add room `5117.EG.103`"
+        );
     }
 
     #[test]
@@ -577,7 +631,7 @@ mod tests {
             "additional_context": "",
             "privacy_checked": true
         }));
-        let subj = req.extract_subject();
+        let subj = req.extract_subject(&BTreeSet::new());
         assert!(subj.starts_with("add rooms `"));
         assert!(subj.contains("5117.EG.103"));
         assert!(subj.contains("5117.EG.104"));
@@ -598,7 +652,7 @@ mod tests {
             "additional_context": "",
             "privacy_checked": true
         }));
-        assert_eq!(req.extract_subject(), "add 10 POIs");
+        assert_eq!(req.extract_subject(&BTreeSet::new()), "add 10 POIs");
     }
 
     #[test]
@@ -636,7 +690,7 @@ mod tests {
             "privacy_checked": true
         }));
         assert_eq!(
-            req.extract_subject(),
+            req.extract_subject(&BTreeSet::new()),
             "opening-hours edit for `5304.EG.001`"
         );
         assert!(req.extract_labels().contains(&"opening_hours".to_string()));
@@ -798,7 +852,7 @@ mod tests {
             "additional_context": "",
             "privacy_checked": true
         }));
-        let subj = req.extract_subject();
+        let subj = req.extract_subject(&BTreeSet::new());
         assert!(subj.contains("coordinate edit for `0101`"));
         assert!(subj.contains("add room `5117.EG.103`"));
         assert!(subj.contains(" and "));


### PR DESCRIPTION
Event submission PRs now identify events by name (distinguishing add from update) and render an `event | image` thumbnail table, dropping the 404 `/view/` link, full-bleed poster, and `#N`-autolinking per-edit headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)