### PR TITLE
feat(map): card-validators tile layer

### DIFF
--- a/map/martin/config.yaml
+++ b/map/martin/config.yaml
@@ -74,3 +74,9 @@ postgres:
         minzoom: 16
         maxzoom: 30
         bounds: [ 5.98865807458, 47.3024876979, 15.0169958839, 54.983104153 ] # germany
+      card_validators:
+        schema: public
+        function: card_validators
+        minzoom: 13
+        maxzoom: 30
+        bounds: [ 5.98865807458, 47.3024876979, 15.0169958839, 54.983104153 ] # germany

--- a/map/martin/sprites/navigatum/card_validator.svg
+++ b/map/martin/sprites/navigatum/card_validator.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" id="card_validator">
+  <path fill-rule="evenodd" d="M6 2H18A4 4 0 0 1 22 6V18A4 4 0 0 1 18 22H6A4 4 0 0 1 2 18V6A4 4 0 0 1 6 2ZM9 16.17L4.83 12L3.41 13.41L9 19L21 7L19.59 5.59Z"/>
+</svg>

--- a/map/martin/styles/navigatum-basemap.json
+++ b/map/martin/styles/navigatum-basemap.json
@@ -82,6 +82,11 @@
       "url": "https://nav.tum.de/martin/events_active",
       "minzoom": 13
     },
+    "card_validators": {
+      "type": "vector",
+      "url": "https://nav.tum.de/martin/card_validators",
+      "minzoom": 13
+    },
     "nav": {
       "type": "vector",
       "url": "https://nav.tum.de/martin/shortbread"
@@ -6366,6 +6371,33 @@
         "icon-halo-color": "#ffffff",
         "icon-halo-width": 1,
         "text-color": "#E37222",
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1.2
+      }
+    },
+    {
+      "id": "card-validators",
+      "type": "symbol",
+      "source": "card_validators",
+      "source-layer": "card_validators",
+      "minzoom": 13,
+      "layout": {
+        "visibility": "none",
+        "icon-image": "card_validator",
+        "icon-size": ["interpolate", ["linear"], ["zoom"], 13, 0.9, 18, 1.5],
+        "icon-allow-overlap": true,
+        "text-field": ["get", "name"],
+        "text-font": ["Roboto Regular"],
+        "text-size": 11,
+        "text-anchor": "top",
+        "text-offset": [0, 1.1],
+        "text-optional": true
+      },
+      "paint": {
+        "icon-color": "#3070b3",
+        "icon-halo-color": "#ffffff",
+        "icon-halo-width": 1,
+        "text-color": "#3070b3",
         "text-halo-color": "#ffffff",
         "text-halo-width": 1.2
       }

--- a/map/osm2pgsql/style.lua
+++ b/map/osm2pgsql/style.lua
@@ -292,6 +292,10 @@ function osm2pgsql.process_node(object)
       object.tags.indoor = "shower"
     end
   end
+  -- Student-card validators are vending machines in OSM; lift them into their own poi category.
+  if object.tags.amenity == "vending_machine" and object.tags.vending == "student_card_validation" then
+    object.tags.indoor = "card_validator"
+  end
   if object.tags.indoor == "door" then
     -- pois should not need layers. Using them is likely a bug
     object.tags.layer = nil
@@ -327,6 +331,26 @@ function osm2pgsql.process_node(object)
           is_female_toilet = object.tags.indoor == "toilet" and object.tags.female == "yes",
           is_unisex_toilet = object.tags.indoor == "toilet" and object.tags.unisex == "yes",
           is_wheelchair_toilet = object.tags.indoor == "toilet" and object.tags.wheelchair == "yes",
+          area = 0,
+          level_min = level.min,
+          level_max = level.max,
+          geom = object:as_point()
+        }
+      )
+    end
+  elseif object.tags.indoor == "card_validator" then
+    -- Unlike toilets, these render as named markers, so carry name + ref:tum into the poi.
+    for _, level in ipairs(SantiseLevel(object.tags.level)) do
+      tables.pois:insert(
+        {
+          indoor = object.tags.indoor,
+          name = object.tags.name,
+          ref = object.tags["ref:tum"],
+          students_have_access = true,
+          is_male_toilet = false,
+          is_female_toilet = false,
+          is_unisex_toilet = false,
+          is_wheelchair_toilet = false,
           area = 0,
           level_min = level.min,
           level_max = level.max,

--- a/server/migrations/20260613120000_card_validators_mvt.sql
+++ b/server/migrations/20260613120000_card_validators_mvt.sql
@@ -1,0 +1,49 @@
+-- Student-card validators are a campus-wide overlay, not an indoor layer: they
+-- must stay visible regardless of the selected floor. So unlike `indoor_pois`,
+-- this function does not filter on `query_params->>'level'`. osm2pgsql captures
+-- the OSM `vending_machine`/`student_card_validation` nodes into `pois` with
+-- `indoor = 'card_validator'`, carrying their `name` and `ref` (from `ref:tum`).
+CREATE OR REPLACE
+    FUNCTION card_validators(z integer, x integer, y integer)
+    RETURNS bytea AS $$
+DECLARE
+  mvt bytea;
+BEGIN
+  SELECT INTO mvt ST_AsMVT(tile, 'card_validators', 4096, 'geom')
+  FROM (
+    SELECT
+      ST_AsMVTGeom(
+          geom,
+          ST_TileEnvelope(z, x, y),
+          4096, 64, true) AS geom,
+      name,
+      ref
+    FROM pois
+    WHERE indoor = 'card_validator' AND
+          geom && ST_TileEnvelope(z, x, y)
+  ) as tile
+  WHERE geom IS NOT NULL;
+
+  RETURN mvt;
+END
+$$ LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE;
+
+DO $do$ BEGIN
+    EXECUTE 'COMMENT ON FUNCTION card_validators IS $tj$' || $$
+    {
+        "description": "student-card validation machines",
+        "attribution": "<a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
+        "vector_layers": [
+            {
+                "id": "card_validators",
+                "fields": {
+                    "name": "String",
+                    "ref": "String"
+                },
+                "maxzoom": 30,
+                "minzoom": 13
+            }
+        ]
+    }
+    $$::json || '$tj$';
+END $do$;


### PR DESCRIPTION
Captures OSM student-card validators into the `pois` table and serves them as a floor-independent `card_validators` Martin layer with its own sprite and a hidden basemap symbol layer; the webclient toggle, POI-entry removal, and `/view` redirects follow in separate PRs (part of #3158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)