### PR TITLE
ci: path-gate CI via a single ci.yaml orchestrator

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,7 +1,4 @@
 name: Create and publish a Docker image
-# Keyed on image_suffix, not github.workflow: every caller now runs under the same
-# orchestrator (ci.yaml), so a workflow-name-based group would make the server,
-# webclient, and martin builds cancel one another.
 concurrency:
   group: docker-${{ inputs.image_suffix }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -1,6 +1,9 @@
 name: Create and publish a Docker image
+# Keyed on image_suffix, not github.workflow: every caller now runs under the same
+# orchestrator (ci.yaml), so a workflow-name-based group would make the server,
+# webclient, and martin builds cancel one another.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: docker-${{ inputs.image_suffix }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,134 @@
+name: CI
+
+# Single entry point for component CI. A `changes` job decides which components a
+# pull request touches, and each component runs as a reusable workflow gated on that
+# decision, so unrelated changes skip irrelevant CI. `ci-passed` aggregates them into
+# the one status check the branch ruleset requires.
+#
+# Gating applies to pull requests only. Pushes to main and manual dispatches run
+# everything (safety net + keeps every `:main` image fresh).
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      webclient: ${{ steps.filter.outputs.webclient }}
+      data: ${{ steps.filter.outputs.data }}
+      map: ${{ steps.filter.outputs.map }}
+      e2e: ${{ steps.filter.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { persist-credentials: false }
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          # A change under .github/** re-exercises every component, so a CI edit can
+          # never skip the CI it changes. e2e brings up server + webclient + db +
+          # meilisearch via compose, so any component or the harness must trigger it.
+          filters: |
+            server: &server
+              - 'server/**'
+              - 'motis-openapi-progenitor/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/**'
+            webclient: &webclient
+              - 'webclient/**'
+              - '.github/**'
+            data: &data
+              - 'data/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/**'
+            map: &map
+              - 'map/**'
+              - '.github/**'
+            e2e:
+              - *server
+              - *webclient
+              - *data
+              - *map
+              - 'tests/**'
+              - 'compose.yml'
+              - 'compose.local.yml'
+
+  server:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.server == 'true' }}
+    uses: ./.github/workflows/server-cicd.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+
+  webclient:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.webclient == 'true' }}
+    uses: ./.github/workflows/webclient-cicd.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+
+  data:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.data == 'true' }}
+    uses: ./.github/workflows/data-cicd.yml
+    permissions:
+      contents: read
+
+  map:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.map == 'true' }}
+    uses: ./.github/workflows/martin-cicd.yml
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+
+  e2e:
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.e2e == 'true' }}
+    uses: ./.github/workflows/e2e-tests.yml
+    permissions:
+      contents: read
+
+  # The single required status check. Gated-out components report `skipped`, which is a
+  # pass here; only `failure`/`cancelled` block. `changes` is included so a filter failure
+  # (which would silently skip every component) still fails the check.
+  # `map` is intentionally omitted: martin was never a required check, so its validation
+  # stays advisory (it still runs and reports, but does not block merges). Add it to
+  # `needs` to make map failures merge-blocking.
+  # Don't change its name - it is used by the merge protection rules.
+  ci-passed:
+    name: Finished CI
+    runs-on: ubuntu-latest
+    needs: [ changes, server, webclient, data, e2e ]
+    if: always()
+    permissions: {}
+    steps:
+      - name: Result of the needed jobs
+        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        name: CI Result
+        run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,11 +40,15 @@ jobs:
               - '.github/**'
             webclient: &webclient
               - 'webclient/**'
+              # webclient/biome.jsonc extends the root config, so lint results depend on it.
+              - 'biome.jsonc'
               - '.github/**'
             data: &data
               - 'data/**'
               - 'pyproject.toml'
               - 'uv.lock'
+              # uv sync --frozen selects the interpreter from .python-version.
+              - '.python-version'
               - '.github/**'
             map: &map
               - 'map/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,5 @@
 name: CI
 
-# Single entry point for component CI. A `changes` job decides which components a
-# pull request touches, and each component runs as a reusable workflow gated on that
-# decision, so unrelated changes skip irrelevant CI. `ci-passed` aggregates them into
-# the one status check the branch ruleset requires.
-#
-# Gating applies to pull requests only. Pushes to main and manual dispatches run
-# everything (safety net + keeps every `:main` image fresh).
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -39,9 +31,6 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
-          # A change under .github/** re-exercises every component, so a CI edit can
-          # never skip the CI it changes. e2e brings up server + webclient + db +
-          # meilisearch via compose, so any component or the harness must trigger it.
           filters: |
             server: &server
               - 'server/**'
@@ -113,12 +102,7 @@ jobs:
     permissions:
       contents: read
 
-  # The single required status check. Gated-out components report `skipped`, which is a
-  # pass here; only `failure`/`cancelled` block. `changes` is included so a filter failure
-  # (which would silently skip every component) still fails the check.
-  # `map` is intentionally omitted: martin was never a required check, so its validation
-  # stays advisory (it still runs and reports, but does not block merges). Add it to
-  # `needs` to make map failures merge-blocking.
+  # `map` is excluded so martin stays advisory (non-blocking), as before.
   # Don't change its name - it is used by the merge protection rules.
   ci-passed:
     name: Finished CI

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,12 +102,11 @@ jobs:
     permissions:
       contents: read
 
-  # `map` is excluded so martin stays advisory (non-blocking), as before.
   # Don't change its name - it is used by the merge protection rules.
   ci-passed:
     name: Finished CI
     runs-on: ubuntu-latest
-    needs: [ changes, server, webclient, data, e2e ]
+    needs: [ changes, server, webclient, data, map, e2e ]
     if: always()
     permissions: {}
     steps:

--- a/.github/workflows/data-cicd.yml
+++ b/.github/workflows/data-cicd.yml
@@ -1,16 +1,8 @@
 name: Data CI/CD
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-data
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, reopened, synchronize ]
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   data-test:
@@ -42,18 +34,3 @@ jobs:
         run: uv sync --frozen
       - name: Run mypy
         run: uv run mypy data
-
-  # This final step is needed to mark the whole workflow as successful
-  # Don't change its name - it is used by the merge protection rules
-  done:
-    name: Finished data CI
-    runs-on: ubuntu-latest
-    needs: [ data-test, type-check ]
-    if: always()
-    permissions: {}
-    steps:
-      - name: Result of the needed steps
-        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        name: CI Result
-        run: exit 1

--- a/.github/workflows/data-cicd.yml
+++ b/.github/workflows/data-cicd.yml
@@ -1,6 +1,5 @@
 name: Data CI/CD
 
-# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
   workflow_call:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,5 @@
 name: E2E Tests
 
-# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
   workflow_call:
 permissions: {}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,8 @@
 name: E2E Tests
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-server
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-  workflow_dispatch:
+  workflow_call:
 permissions: {}
 
 jobs:
@@ -228,18 +221,3 @@ jobs:
       - name: Database logs on failure
         if: failure()
         run: docker compose -f compose.local.yml logs db
-
-  # This final step is needed to mark the whole workflow as successful
-  # Don't change its name - it is used by the merge protection rules
-  done:
-    name: Finished e2e-tests
-    runs-on: ubuntu-latest
-    needs: [ ui-tests-desktop, api-tests ]
-    if: always()
-    permissions: {}
-    steps:
-      - name: Result of the needed steps
-        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        name: CI Result
-        run: exit 1

--- a/.github/workflows/martin-cicd.yml
+++ b/.github/workflows/martin-cicd.yml
@@ -1,6 +1,5 @@
 name: Martin CI/CD
 
-# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
   workflow_call:
 

--- a/.github/workflows/martin-cicd.yml
+++ b/.github/workflows/martin-cicd.yml
@@ -1,16 +1,8 @@
 name: Martin CI/CD
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-data
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, reopened, synchronize ]
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_call:
 
 permissions: {}
 
@@ -71,18 +63,3 @@ jobs:
       contents: read
       packages: write
       attestations: write
-
-  # This final step is needed to mark the whole workflow as successful
-  # Don't change its name - it is used by the merge protection rules
-  done:
-    name: Finished martin CI
-    runs-on: ubuntu-latest
-    needs: [ build, validate-style, validate-planetiler-custommap ]
-    if: always()
-    permissions: {}
-    steps:
-      - name: Result of the needed steps
-        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        name: CI Result
-        run: exit 1

--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -1,16 +1,8 @@
 name: Server CI/CD
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-server
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, reopened, synchronize ]
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   shear:
@@ -86,18 +78,3 @@ jobs:
       contents: read
       packages: write
       attestations: write
-
-  # This final step is needed to mark the whole workflow as successful
-  # Don't change its name - it is used by the merge protection rules
-  done:
-    name: Finished server CI
-    runs-on: ubuntu-latest
-    needs: [ shear, tests, linting, build ]
-    if: always()
-    permissions: {}
-    steps:
-      - name: Result of the needed steps
-        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        name: CI Result
-        run: exit 1

--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -1,6 +1,5 @@
 name: Server CI/CD
 
-# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
   workflow_call:
 

--- a/.github/workflows/webclient-cicd.yml
+++ b/.github/workflows/webclient-cicd.yml
@@ -1,6 +1,5 @@
 name: Webclient CI/CD
 
-# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
   workflow_call:
 

--- a/.github/workflows/webclient-cicd.yml
+++ b/.github/workflows/webclient-cicd.yml
@@ -1,16 +1,8 @@
 name: Webclient CI/CD
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-webclient
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
+# Reusable workflow: orchestrated by ci.yaml, which path-gates and aggregates it.
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, reopened, synchronize ]
-  push:
-    branches: [ main ]
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   lint:
@@ -45,18 +37,3 @@ jobs:
       contents: read
       packages: write
       attestations: write
-
-  # This final step is needed to mark the whole workflow as successful
-  # Don't change its name - it is used by the merge protection rules
-  done:
-    name: Finished webclient CI
-    runs-on: ubuntu-latest
-    needs: [ build, lint ]
-    if: always()
-    permissions: {}
-    steps:
-      - name: Result of the needed steps
-        run: echo "${{ toJSON(needs) }}" # zizmor: ignore[template-injection]
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        name: CI Result
-        run: exit 1

--- a/webclient/app/composables/mapLayers.ts
+++ b/webclient/app/composables/mapLayers.ts
@@ -230,8 +230,7 @@ const WCS_GENDER_FLAG = {
  * is encoded as both male and female, so the unisex selection matches that pair.
  */
 function wcsGenderCondition(gender: WcsGender): JsonExpression {
-  if (gender === "unisex")
-    return ["all", ["get", "is_male_toilet"], ["get", "is_female_toilet"]];
+  if (gender === "unisex") return ["all", ["get", "is_male_toilet"], ["get", "is_female_toilet"]];
   return ["get", WCS_GENDER_FLAG[gender]];
 }
 


### PR DESCRIPTION
Consolidate the per-component CI workflows into one `ci.yaml` that path-gates each component (via a `dorny/paths-filter` `changes` job and reusable-workflow calls, aggregated into one `Finished CI` check) so a pull request only runs the CI it actually touches, while pushes to `main` and manual dispatches still run everything.

> [!IMPORTANT]
> Requires updating the `main` ruleset's required status checks to **`Finished CI`** + **`Finished security scan`** (replacing the old five `Finished … CI` contexts), or PRs will deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)