### PR TITLE
feat(events): traffic-weighted appears_at lead-in replaces the pre-buffer

### DIFF
--- a/data/external/loaders/events.py
+++ b/data/external/loaders/events.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from pathlib import Path
 
 import dataframely as dy
 import polars as pl
+from processors.events_appears_at import compute_appears_at
 
 from external.schemas.events import EventsSchema
 
@@ -22,16 +24,23 @@ _CSV_RENAME = {
 }
 
 
+def _appears_at_iso(starts_at: str, ends_at: str) -> str:
+    """Return the marker's first-appearance instant as an RFC 3339 string in Europe/Berlin local time."""
+    appears_at = compute_appears_at(datetime.fromisoformat(starts_at), datetime.fromisoformat(ends_at))
+    return appears_at.isoformat()
+
+
 def load_events() -> dy.DataFrame[EventsSchema]:
     """
     Build the events frame from `data/sources/events.csv`.
 
     Renames the `event_*`-prefixed CSV columns to the parquet shape with dtypes
-    derived from `EventsSchema`. Validates against the schema so the return type
-    is statically verified by mypy.
+    derived from `EventsSchema` and derives `appears_at` from the event window.
+    Validates against the schema so the return type is statically verified by mypy.
     """
     schema = EventsSchema.to_polars_schema()
     read_schema = pl.Schema({csv: schema[parquet] for csv, parquet in _CSV_RENAME.items()})
 
-    df = pl.read_csv(EVENTS_CSV, schema=read_schema)
-    return EventsSchema.validate(df.rename(_CSV_RENAME))
+    df = pl.read_csv(EVENTS_CSV, schema=read_schema).rename(_CSV_RENAME)
+    appears_at = [_appears_at_iso(s, e) for s, e in zip(df["starts_at"], df["ends_at"], strict=True)]
+    return EventsSchema.validate(df.with_columns(pl.Series("appears_at", appears_at, dtype=pl.String)))

--- a/data/external/schemas/events.py
+++ b/data/external/schemas/events.py
@@ -20,6 +20,8 @@ class EventsSchema(dy.Schema):
     name = dy.String(nullable=False)
     starts_at = dy.String(nullable=False)
     ends_at = dy.String(nullable=False)
+    # Derived server-side visibility gate (processors.events_appears_at); never reaches the client.
+    appears_at = dy.String(nullable=False)
     description = dy.String(nullable=False)
     organising_org_id = dy.Int32(nullable=False)
     image_author = dy.String(nullable=False)
@@ -48,6 +50,11 @@ class EventsSchema(dy.Schema):
     def ends_at_is_rfc3339(cls) -> pl.Expr:
         """`ends_at` must be an RFC 3339 timestamp with a timezone offset."""
         return pl.col("ends_at").str.contains(_ISO8601_TZ_REGEX)
+
+    @dy.rule()
+    def appears_at_is_rfc3339(cls) -> pl.Expr:
+        """`appears_at` must be an RFC 3339 timestamp with a timezone offset."""
+        return pl.col("appears_at").str.contains(_ISO8601_TZ_REGEX)
 
     @dy.rule()
     def ends_at_not_before_starts_at(cls) -> pl.Expr:

--- a/data/external/schemas/test_schemas_events.py
+++ b/data/external/schemas/test_schemas_events.py
@@ -15,6 +15,7 @@ def _valid_row() -> dict[str, list[object]]:
         "name": ["Sample"],
         "starts_at": ["2026-06-15T10:00:00+02:00"],
         "ends_at": ["2026-06-15T18:00:00+02:00"],
+        "appears_at": ["2026-06-13T10:00:00+02:00"],
         "description": ["x"],
         "organising_org_id": [14146],
         "image_author": ["Studi"],

--- a/data/processors/events_appears_at.py
+++ b/data/processors/events_appears_at.py
@@ -1,0 +1,82 @@
+"""
+Compute an event's map lead-in: when its marker should first appear.
+
+`appears_at` answers "this is worth surfacing now" by walking backward from
+`starts_at`, spending a fixed budget at a traffic rate that drains slower when
+fewer people look at the map (nights, weekends), so quiet-time events ride
+longer. It is a pure function of `(starts_at, ends_at)`, evaluated in
+Europe/Berlin wall-clock time and DST-aware, and is consumed only as a
+server-side visibility gate - it never reaches the client.
+"""
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+_BERLIN = ZoneInfo("Europe/Berlin")
+
+_BUDGET_FLOOR_HOURS = 8.0
+_WINDOW_CAP_HOURS = 48.0
+# Wall-clock hours bounding weekday daytime, the baseline (fastest-draining) rate.
+_DAY_START_HOUR = 10
+_DAY_END_HOUR = 18
+
+
+def _traffic_rate(local: datetime) -> float:
+    """
+    Budget drained per real hour at Berlin wall-clock `local`.
+
+    1.0 is the weekday-daytime baseline; quieter periods drain slower so the
+    marker rides longer. Night (0.5) and weekend (0.5) stack multiplicatively,
+    so a weekend night is 0.25.
+    """
+    rate = 1.0 if _DAY_START_HOUR <= local.hour < _DAY_END_HOUR else 0.5
+    if local.weekday() >= 5:  # Saturday or Sunday.
+        rate *= 0.5
+    return rate
+
+
+def _previous_boundary(local: datetime) -> datetime:
+    """
+    Return the latest traffic-rate boundary strictly before `local` (Berlin wall-clock).
+
+    The rate only changes at 00:00, 10:00 and 18:00, so the half-open segment
+    `[boundary, local)` carries one constant rate. Classifying by the boundary
+    rather than `local` keeps a Friday-night segment a weekday when it is reached
+    by walking back through Saturday 00:00.
+    """
+    midnight = local.replace(hour=0, minute=0, second=0, microsecond=0)
+    for hour in (_DAY_END_HOUR, _DAY_START_HOUR, 0):
+        boundary = midnight.replace(hour=hour)
+        if boundary < local:
+            return boundary
+    # `local` is exactly midnight: step back to 18:00 the previous day.
+    return (midnight - timedelta(days=1)).replace(hour=_DAY_END_HOUR)
+
+
+def compute_appears_at(starts_at: datetime, ends_at: datetime) -> datetime:
+    """
+    When the event's marker should first appear, returned in Europe/Berlin time.
+
+    `starts_at`/`ends_at` must be timezone-aware; the result is the same instant
+    whatever input offset is used. See the module docstring for the algorithm.
+    """
+    if starts_at.tzinfo is None or ends_at.tzinfo is None:
+        raise ValueError("compute_appears_at requires timezone-aware datetimes")
+
+    duration_hours = (ends_at - starts_at).total_seconds() / 3600
+    budget = max(duration_hours, _BUDGET_FLOOR_HOURS)
+
+    # Walk in UTC so timedelta steps are real elapsed time across DST; Berlin only classifies the rate.
+    instant = starts_at.astimezone(UTC)
+    cap = instant - timedelta(hours=_WINDOW_CAP_HOURS)
+    while budget > 1e-9 and instant > cap:
+        boundary_local = _previous_boundary(instant.astimezone(_BERLIN))
+        rate = _traffic_rate(boundary_local)
+        segment_start = max(boundary_local.astimezone(UTC), cap)
+        cost = rate * (instant - segment_start).total_seconds() / 3600
+        if cost >= budget:
+            instant -= timedelta(hours=budget / rate)
+            break
+        budget -= cost
+        instant = segment_start
+    return max(instant, cap).astimezone(_BERLIN)

--- a/data/processors/test_events_appears_at.py
+++ b/data/processors/test_events_appears_at.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from processors.events_appears_at import compute_appears_at
+
+_BERLIN = ZoneInfo("Europe/Berlin")
+
+
+def _window_hours(starts_at: datetime) -> float:
+    """Lead-in length: real hours between the computed appears_at and starts_at."""
+    return (starts_at - compute_appears_at(starts_at, starts_at)).total_seconds() / 3600
+
+
+def test_eight_hour_floor_reaches_a_short_weekday_talk() -> None:
+    """A 40-minute Wednesday-daytime talk still earns the 8h budget, drained at the 1.0/0.5 rates."""
+    starts_at = datetime(2026, 6, 17, 14, 0, tzinfo=_BERLIN)  # Wednesday.
+    ends_at = starts_at + timedelta(minutes=40)
+
+    # 4h daytime (10:00-14:00) spends 4 of the 8h budget; the remaining 4 drains at
+    # the 0.5 night rate, reaching back 8 real hours to 02:00.
+    assert compute_appears_at(starts_at, ends_at) == datetime(2026, 6, 17, 2, 0, tzinfo=_BERLIN)
+
+
+def test_same_talk_on_saturday_rides_longer() -> None:
+    """The identical talk on a Saturday sees less traffic, so its window stretches well past the weekday one."""
+    weekday = datetime(2026, 6, 17, 14, 0, tzinfo=_BERLIN)  # Wednesday.
+    saturday = datetime(2026, 6, 20, 14, 0, tzinfo=_BERLIN)  # Saturday.
+    forty_min = timedelta(minutes=40)
+
+    assert _window_hours(saturday) > _window_hours(weekday)
+    # Sat 14:00 -> Sat 10:00 (weekend day, 0.5) spends 2; Sat 10:00 -> Sat 00:00
+    # (weekend night, 0.25) spends 2.5; Fri 18:00-00:00 (weekday night, 0.5) spends
+    # 3; the last 0.5 drains over 1 real hour of Friday daytime (1.0) to Fri 17:30.
+    assert compute_appears_at(saturday, saturday + forty_min) == datetime(2026, 6, 19, 17, 30, tzinfo=_BERLIN)
+
+
+def test_friday_to_saturday_straddle_switches_rate_at_midnight() -> None:
+    """Walking back across Saturday 00:00 flips the weekend factor, so the Friday side drains at the weekday rate."""
+    # Sat 02:00 start, 40 min: Sat 00:00-02:00 is weekend night (0.25) spending 0.5;
+    # the budget then crosses into Friday, where night is the weekday rate (0.5).
+    starts_at = datetime(2026, 6, 20, 2, 0, tzinfo=_BERLIN)  # Saturday.
+    ends_at = starts_at + timedelta(minutes=40)
+
+    appears_at = compute_appears_at(starts_at, ends_at)
+    # 0.25*2h = 0.5 spent on the weekend side; 7.5 budget left drains over Friday's
+    # 18:00-00:00 night (0.5 -> 3) then back into 10:00-18:00 daytime (1.0) for the
+    # remaining 4.5, reaching Fri 13:30.
+    assert appears_at == datetime(2026, 6, 19, 13, 30, tzinfo=_BERLIN)
+    assert appears_at.weekday() == 4  # Friday: the straddle crossed midnight.
+
+
+def test_forty_eight_hour_cap_bites_on_a_multi_day_event() -> None:
+    """A multi-day event's budget would reach back days, but the window is capped at 48h before starts_at."""
+    starts_at = datetime(2026, 6, 15, 16, 0, tzinfo=_BERLIN)
+    ends_at = datetime(2026, 6, 19, 23, 59, tzinfo=_BERLIN)  # ~4.3 days, budget >> 48h.
+
+    assert compute_appears_at(starts_at, ends_at) == starts_at - timedelta(hours=48)
+
+
+def test_dst_spring_forward_night_counts_only_real_hours() -> None:
+    """The spring-forward night is 9 real hours, not 10 wall-clock hours, so the budget drains accordingly."""
+    # 2026-03-29 02:00 -> 03:00 local; clocks before the gap run at +01:00.
+    starts_at = datetime(2026, 3, 29, 12, 0, tzinfo=_BERLIN)  # Sunday, +02:00.
+    ends_at = starts_at + timedelta(minutes=40)
+
+    # Sun 12:00->10:00 weekend day (0.5) spends 1; the 00:00-10:00 weekend night
+    # (0.25) costs only 0.25*9=2.25 because that night is 9 real hours; Sat
+    # 18:00-00:00 (0.25) spends 1.5; the last 3.25 drains over Sat daytime (0.5)
+    # for 6.5 real hours, reaching Sat 11:30 (+01:00).
+    assert compute_appears_at(starts_at, ends_at) == datetime(2026, 3, 28, 11, 30, tzinfo=_BERLIN)
+
+
+def test_result_is_independent_of_input_offset() -> None:
+    """The same instant expressed in UTC or in Berlin local yields the same appears_at."""
+    berlin = datetime(2026, 6, 17, 14, 0, tzinfo=_BERLIN)
+    as_utc = berlin.astimezone(ZoneInfo("UTC"))
+
+    assert compute_appears_at(berlin, berlin) == compute_appears_at(as_utc, as_utc)
+
+
+def test_naive_datetimes_are_rejected() -> None:
+    """Wall-clock classification is meaningless without an offset, so naive inputs raise."""
+    naive = datetime(2026, 6, 17, 14, 0)  # noqa: DTZ001 - the missing tzinfo is the point of this test.
+    try:
+        compute_appears_at(naive, naive)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for naive datetime")

--- a/data/processors/test_export_search_events.py
+++ b/data/processors/test_export_search_events.py
@@ -15,6 +15,7 @@ def _events(rows: list[dict[str, object]]) -> dy.DataFrame[EventsSchema]:
         "name": "GARNIX Festival",
         "starts_at": "2026-06-15T16:00:00+02:00",
         "ends_at": "2026-06-19T23:59:00+02:00",
+        "appears_at": "2026-06-13T16:00:00+02:00",
         "description": "Open-air student festival.",
         "organising_org_id": 51897,
         "image_author": "Studentische Vertretung TUM",

--- a/map/martin/config.yaml
+++ b/map/martin/config.yaml
@@ -49,6 +49,32 @@ postgres:
         # as session-timezone text in tiles, which style expressions cannot compare.
         starts_at_epoch: int8
         ends_at_epoch: int8
+    # /map "next 2 weeks" toggle; superset of events_active, same appears_at-free projection.
+    events_upcoming:
+      schema: public
+      table: events_upcoming
+      srid: 4326
+      geometry_column: geometry
+      geometry_type: POINT
+      id_column: id
+      minzoom: 10
+      maxzoom: 22
+      bounds: [ 5.98865807458, 47.3024876979, 15.0169958839, 54.983104153 ] # germany
+      properties:
+        name: text
+        description: text
+        image: text
+        image_author: text
+        starts_at: timestamptz
+        ends_at: timestamptz
+        organising_org_id: int4
+        organising_org_code: text
+        organising_org_name_de: text
+        organising_org_name_en: text
+        # Epoch seconds for the /map time-window filter; the timestamptz columns render
+        # as session-timezone text in tiles, which style expressions cannot compare.
+        starts_at_epoch: int8
+        ends_at_epoch: int8
   functions:
       indoor_rooms:
         schema: public

--- a/server/.sqlx/query-503dcbc584965574b28fdda97dbf23ea6b273dfa7b34230d782fa0af007103e1.json
+++ b/server/.sqlx/query-503dcbc584965574b28fdda97dbf23ea6b273dfa7b34230d782fa0af007103e1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO events(name, description, image, image_author, coordinate, starts_at, ends_at, organising_org_id) VALUES ($1, $2, $3, $4, POINT($5, $6), $7, $8, $9)",
+  "query": "INSERT INTO events(name, description, image, image_author, coordinate, starts_at, ends_at, appears_at, organising_org_id) VALUES ($1, $2, $3, $4, POINT($5, $6), $7, $8, $9, $10)",
   "describe": {
     "columns": [],
     "parameters": {
@@ -13,10 +13,11 @@
         "Float8",
         "Timestamptz",
         "Timestamptz",
+        "Timestamptz",
         "Int4"
       ]
     },
     "nullable": []
   },
-  "hash": "bd29682a9a3978642cde23e478a098d2affc6f102ad70490e527b19d8c6e59fc"
+  "hash": "503dcbc584965574b28fdda97dbf23ea6b273dfa7b34230d782fa0af007103e1"
 }

--- a/server/migrations/20260613000000_events_appears_at.sql
+++ b/server/migrations/20260613000000_events_appears_at.sql
@@ -1,0 +1,53 @@
+-- Precomputed traffic-weighted lead-in (data/processors/events_appears_at.py); server-side gate only.
+-- Backfill existing rows to starts_at before enforcing NOT NULL; the loader reloads real values.
+ALTER TABLE events
+    ADD COLUMN appears_at TIMESTAMPTZ;
+UPDATE events
+SET appears_at = starts_at
+WHERE appears_at IS NULL;
+ALTER TABLE events
+    ALTER COLUMN appears_at SET NOT NULL;
+ALTER TABLE events
+    ADD CONSTRAINT events_appears_at_window
+        CHECK (appears_at <= starts_at AND appears_at >= starts_at - INTERVAL '48 hours');
+
+-- Unchanged projection (CREATE OR REPLACE only appends columns), so appears_at stays out of the tiles.
+CREATE OR REPLACE VIEW events_active AS
+SELECT e.id,
+       e.name,
+       e.description,
+       e.image,
+       e.starts_at,
+       e.ends_at,
+       e.organising_org_id,
+       o.code    AS organising_org_code,
+       o.name_de AS organising_org_name_de,
+       o.name_en AS organising_org_name_en,
+       ST_SetSRID(ST_MakePoint(e.coordinate[1], e.coordinate[0]), 4326)::geometry(Point, 4326) AS geometry,
+       e.image_author,
+       EXTRACT(EPOCH FROM e.starts_at)::bigint AS starts_at_epoch,
+       EXTRACT(EPOCH FROM e.ends_at)::bigint   AS ends_at_epoch
+FROM events e
+JOIN tumonline_orgs o ON o.org_id = e.organising_org_id
+WHERE now() BETWEEN e.appears_at AND e.ends_at;
+
+-- The /map "next 2 weeks" feed; superset of events_active (48h cap << 14 days), same appears_at-free projection.
+CREATE VIEW events_upcoming AS
+SELECT e.id,
+       e.name,
+       e.description,
+       e.image,
+       e.starts_at,
+       e.ends_at,
+       e.organising_org_id,
+       o.code    AS organising_org_code,
+       o.name_de AS organising_org_name_de,
+       o.name_en AS organising_org_name_en,
+       ST_SetSRID(ST_MakePoint(e.coordinate[1], e.coordinate[0]), 4326)::geometry(Point, 4326) AS geometry,
+       e.image_author,
+       EXTRACT(EPOCH FROM e.starts_at)::bigint AS starts_at_epoch,
+       EXTRACT(EPOCH FROM e.ends_at)::bigint   AS ends_at_epoch
+FROM events e
+JOIN tumonline_orgs o ON o.org_id = e.organising_org_id
+WHERE now() <= e.ends_at
+  AND e.starts_at <= now() + INTERVAL '14 days';

--- a/server/src/setup/events.rs
+++ b/server/src/setup/events.rs
@@ -14,6 +14,7 @@ pub struct RawEvent {
     lon: f64,
     starts_at: String,
     ends_at: String,
+    appears_at: String,
     organising_org_id: i32,
 }
 
@@ -37,6 +38,7 @@ impl Loader for Events {
             ("lon", Field::Double(v)) => r.lon = *v,
             ("starts_at", Field::Str(v)) => r.starts_at.clone_from(v),
             ("ends_at", Field::Str(v)) => r.ends_at.clone_from(v),
+            ("appears_at", Field::Str(v)) => r.appears_at.clone_from(v),
             ("organising_org_id", Field::Int(v)) => r.organising_org_id = *v,
             _ => {}
         }
@@ -48,9 +50,10 @@ impl Loader for Events {
         }
         let starts_at = DateTime::parse_from_rfc3339(&r.starts_at)?.with_timezone(&Utc);
         let ends_at = DateTime::parse_from_rfc3339(&r.ends_at)?.with_timezone(&Utc);
+        let appears_at = DateTime::parse_from_rfc3339(&r.appears_at)?.with_timezone(&Utc);
         sqlx::query!(
-            "INSERT INTO events(name, description, image, image_author, coordinate, starts_at, ends_at, organising_org_id) \
-             VALUES ($1, $2, $3, $4, POINT($5, $6), $7, $8, $9)",
+            "INSERT INTO events(name, description, image, image_author, coordinate, starts_at, ends_at, appears_at, organising_org_id) \
+             VALUES ($1, $2, $3, $4, POINT($5, $6), $7, $8, $9, $10)",
             r.name,
             r.description,
             r.image,
@@ -59,6 +62,7 @@ impl Loader for Events {
             r.lon,
             starts_at,
             ends_at,
+            appears_at,
             r.organising_org_id,
         )
         .execute(&mut **tx)


### PR DESCRIPTION
Closes #3282.

The data-plane slice of #3281: replaces the `2h × days_long` pre-buffer in `events_active` with a precomputed, DST-aware `appears_at` timestamp that scales an event's map lead-in by significance (8 h budget floor) and by how many people look at the map (night/weekend drain the budget at 0.5, stacking to 0.25; 48 h window cap), computed in the Python pipeline and consumed as a server-side gate only (never shipped to the client).

- `data/processors/events_appears_at.py` — pure, segment-based walk-back in UTC (Berlin read only for wall-clock rate classification); `data/processors/test_events_appears_at.py` covers the DST-transition night, a Fri→Sat straddle, the 48 h cap, and the 8 h floor (weekday vs Saturday).
- Migration `20260613000000_events_appears_at.sql` adds `events.appears_at` (+ a `CHECK` keeping it within `[starts_at − 48h, starts_at]`), redefines `events_active` to gate `now() BETWEEN appears_at AND ends_at`, and adds `events_upcoming` (`now() ≤ ends_at AND starts_at ≤ now() + 14 days`). Both views share an identical projection with **no** `appears_at`.
- `events_upcoming` exposed as a second Martin tile source; the server loader parses + inserts `appears_at`.

No client changes in this slice (the toggle/render work stays in #3281).

Verified: data pytest + ruff + mypy clean; server `SQLX_OFFLINE` check + clippy clean; against a live postgis DB the migration applies, both views are `appears_at`-free with identical projections, active/upcoming gating and the superset property hold, and the `CHECK` rejects out-of-window values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)