### PR TITLE
fix(map): base martin on :nightly so style rendering is compiled in

### DIFF
--- a/map/martin/Dockerfile
+++ b/map/martin/Dockerfile
@@ -1,4 +1,9 @@
-FROM ghcr.io/maplibre/martin:main
+FROM ghcr.io/maplibre/martin:nightly
+
+# :nightly is the Ubuntu rendering build and ships without unzip.
+RUN apt-get update && \
+    apt-get install --no-install-recommends --yes unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # -- fonts --
 RUN wget -q -O /tmp/roboto-android.zip https://github.com/googlefonts/roboto/releases/download/v2.138/roboto-android.zip && \


### PR DESCRIPTION
The `:main`/`:latest` images are musl builds without the `rendering` feature, so `styles.rendering` was silently ignored and #3277's static-image previews 404'd; `:nightly` is the Ubuntu rendering build (verified rendering locally).