### PR TITLE
feat(search): init Meilisearch from parquet instead of JSON

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -246,9 +246,7 @@ def export_for_search(data: dict[str, Entry]) -> None:
 
     export.extend(event_search_documents(load_events(), ImageSource.load_all()))
 
-    search_bytes = orjson.dumps(export)
-    _make_sure_is_safe(search_bytes)
-    (OUTPUT_DIR_PATH / "search_data.json").write_bytes(search_bytes)
+    _make_sure_is_safe(orjson.dumps(export))
     search_df = pl.DataFrame(export, infer_schema_length=None)
     search_df.write_parquet(OUTPUT_DIR_PATH / "search_data.parquet", use_pyarrow=True, compression_level=3)
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,7 +28,6 @@ COPY data/output output
 RUN python3 compile.py \
     && test -f "./output/status_data.json" \
     && test -f "./output/status_data.parquet" \
-    && test -f "./output/search_data.json" \
     && test -f "./output/search_data.parquet" \
     && test -f "./output/api_data.json" \
     && test -f "./output/alias_data.parquet"

--- a/server/README.md
+++ b/server/README.md
@@ -79,7 +79,7 @@ The following files are loaded during server setup:
 - `alias_data.parquet` - Alias mappings for locations (baked into Docker image)
 - `api_data.json` - Main location data for the API (baked into Docker image)
 - `status_data.parquet` - Status information for locations (baked into Docker image)
-- `search_data.json` - Search index data for MeiliSearch (baked into Docker image)
+- `search_data.parquet` - Search index data for MeiliSearch (baked into Docker image)
 - `public_transport.parquet` - Public transportation station data (baked into Docker image)
 
 ### Environment Variables

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -209,7 +209,7 @@ pub struct GeoPoint {
 /// A campus event surfaced as the sixth search facet.
 ///
 /// One document per `events.csv` row, exported by the data pipeline into
-/// `search_data.json`. Carries everything a client needs to pre-fill the event
+/// `search_data.parquet`. Carries everything a client needs to pre-fill the event
 /// proposal form, so picking a search hit needs no second round-trip.
 ///
 /// Every field is required, with one exception: the pipeline always writes the

--- a/server/src/setup/file_loader.rs
+++ b/server/src/setup/file_loader.rs
@@ -1,7 +1,11 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use bytes::Bytes;
+use parquet::file::reader::{FileReader as _, SerializedFileReader};
+use parquet::record::{Field, Row};
 use serde::de::DeserializeOwned;
+use serde_json::{Map, Number, Value};
 use tokio::fs;
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
@@ -172,6 +176,70 @@ where
     Ok(value)
 }
 
+/// Loads a parquet file from disk or downloads it, then converts each row into a
+/// JSON document for Meilisearch ingestion.
+///
+/// The parquet schema is data-dependent (polars types all-null columns as `Null`),
+/// so conversion matches on [`Field`] at runtime instead of a fixed schema.
+///
+/// # Arguments
+///   * `filename` - The name of the parquet file to load
+///   * `cdn_url` - The CDN URL to use for downloading if the file is not found locally
+///
+/// # Returns
+/// One JSON object per row
+pub async fn load_parquet_as_documents_or_download(
+    filename: &str,
+    cdn_url: &str,
+) -> anyhow::Result<Vec<Value>> {
+    let bytes = load_file_or_download(filename, cdn_url).await?;
+    let reader = SerializedFileReader::new(Bytes::from(bytes))?;
+    let row_count = usize::try_from(reader.metadata().file_metadata().num_rows()).unwrap_or(0);
+    let mut documents = Vec::with_capacity(row_count);
+    for row in reader.get_row_iter(None)? {
+        documents.push(row_to_json(&row?));
+    }
+    Ok(documents)
+}
+
+/// Converts a parquet row into a JSON object, skipping null fields.
+fn row_to_json(row: &Row) -> Value {
+    let mut map = Map::new();
+    for (name, field) in row.get_column_iter() {
+        if let Some(value) = field_to_json(field) {
+            map.insert(name.clone(), value);
+        }
+    }
+    Value::Object(map)
+}
+
+/// Converts a parquet field into a JSON value, or `None` for null fields.
+///
+/// Dropping nulls also drops the `_geo` struct for rows without coordinates, which
+/// Meilisearch rejects when present as `null`.
+fn field_to_json(field: &Field) -> Option<Value> {
+    match field {
+        Field::Bool(v) => Some(Value::Bool(*v)),
+        Field::Byte(v) => Some(Value::from(*v)),
+        Field::Short(v) => Some(Value::from(*v)),
+        Field::Int(v) => Some(Value::from(*v)),
+        Field::Long(v) => Some(Value::from(*v)),
+        Field::UByte(v) => Some(Value::from(*v)),
+        Field::UShort(v) => Some(Value::from(*v)),
+        Field::UInt(v) => Some(Value::from(*v)),
+        Field::ULong(v) => Some(Value::from(*v)),
+        Field::Float(v) => Number::from_f64(f64::from(*v)).map(Value::Number),
+        Field::Double(v) => Number::from_f64(*v).map(Value::Number),
+        Field::Str(v) => Some(Value::String(v.clone())),
+        Field::Group(row) => Some(row_to_json(row)),
+        Field::ListInternal(list) => Some(Value::Array(
+            list.elements().iter().filter_map(field_to_json).collect(),
+        )),
+        // Null is dropped; Decimal/Bytes/Date/Time/Timestamp/Map are unused by the search export.
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -190,5 +258,44 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_row_to_json_reconstructs_geo_and_drops_nulls() {
+        let geo = Field::Group(Row::new(vec![
+            ("lat".to_string(), Field::Double(48.0)),
+            ("lng".to_string(), Field::Double(11.0)),
+        ]));
+        let row = Row::new(vec![
+            ("ms_id".to_string(), Field::Str("foo".to_string())),
+            ("rank".to_string(), Field::Long(42)),
+            ("address".to_string(), Field::Null),
+            ("_geo".to_string(), geo),
+        ]);
+
+        let value = row_to_json(&row);
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "ms_id": "foo",
+                "rank": 42,
+                "_geo": {"lat": 48.0, "lng": 11.0},
+            }),
+            "null fields are dropped and the _geo struct becomes a nested object"
+        );
+    }
+
+    #[test]
+    fn test_row_to_json_omits_null_geo() {
+        let row = Row::new(vec![
+            ("ms_id".to_string(), Field::Str("bar".to_string())),
+            ("_geo".to_string(), Field::Null),
+        ]);
+
+        let value = row_to_json(&row);
+
+        // Meilisearch rejects `_geo: null`, so it must be omitted entirely.
+        assert_eq!(value, serde_json::json!({"ms_id": "bar"}));
     }
 }

--- a/server/src/setup/meilisearch.rs
+++ b/server/src/setup/meilisearch.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use meilisearch_sdk::client::Client;
 use meilisearch_sdk::settings::Settings;
 use meilisearch_sdk::tasks::Task;
-use serde_json::Value;
 use tokio::time::sleep;
 use tracing::{debug, error, info};
 
@@ -117,7 +116,7 @@ pub async fn load_data(client: &Client) -> anyhow::Result<()> {
     let entries = client.index("entries");
     let cdn_url = env::var("CDN_URL").unwrap_or_else(|_| "https://nav.tum.de/cdn".to_string());
     let documents =
-        file_loader::load_json_or_download::<Vec<Value>>("search_data.json", &cdn_url).await?;
+        file_loader::load_parquet_as_documents_or_download("search_data.parquet", &cdn_url).await?;
     let res = entries
         .add_documents(&documents, Some("ms_id"))
         .await?

--- a/tests/specs/cdn.api.spec.ts
+++ b/tests/specs/cdn.api.spec.ts
@@ -15,20 +15,18 @@ test.describe("CDN Endpoints - JSON Data Files", () => {
     expect(firstEntry).toHaveProperty("id");
     expect(firstEntry).toHaveProperty("type");
   });
-
-  test("should serve search_data.json with valid array structure", async ({ request }) => {
-    const response = await request.get("/cdn/search_data.json");
-
-    expect(response.status()).toBe(200);
-    expect(response.headers()["content-type"]).toContain("application/json");
-
-    const data = await response.json();
-    expect(Array.isArray(data)).toBe(true);
-    expect(data.length).toBeGreaterThan(0);
-  });
 });
 
 test.describe("CDN Endpoints - Parquet Files", () => {
+  test("should serve search_data.parquet with valid binary content", async ({ request }) => {
+    const response = await request.get("/cdn/search_data.parquet");
+
+    expect(response.status()).toBe(200);
+
+    const buffer = await response.body();
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
   test("should serve alias_data.parquet with valid binary content", async ({ request }) => {
     const response = await request.get("/cdn/alias_data.parquet");
 


### PR DESCRIPTION
Read the already-emitted `search_data.parquet` (~1 MB) at startup instead of `search_data.json` (~24 MB), and stop writing the JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)