### PR TITLE
feat(navigate): host preferences in the navigation pane

### DIFF
--- a/tests/specs/navigation.ui.spec.ts
+++ b/tests/specs/navigation.ui.spec.ts
@@ -293,6 +293,22 @@ test.describe("Navigation Page - Error Handling", () => {
   });
 });
 
+test.describe("Navigation Page - Preferences", () => {
+  test("opens the preferences dialog from the routing pane", async ({ page }) => {
+    await page.goto("/navigate", { waitUntil: "networkidle" });
+
+    // The navigation view has no global header, so the gear lives in the pane, not `#preferences`.
+    await expect(page.locator("#preferences")).toHaveCount(0);
+    await page.getByRole("button", { name: "Präferenzen" }).click();
+
+    await expect(page.getByRole("heading", { name: "Präferenzen" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Sprache" })).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("heading", { name: "Präferenzen" })).toHaveCount(0);
+  });
+});
+
 test.describe("Navigation Page - SEO and Meta", () => {
   test("should have proper page title and meta description", async ({ page }) => {
     await page.goto("/navigate?from=mi&to=mw", { waitUntil: "networkidle" });

--- a/webclient/app/components/PreferencesPopup.vue
+++ b/webclient/app/components/PreferencesPopup.vue
@@ -37,16 +37,18 @@ async function updateLocale(value: "de" | "en") {
 
 <template>
   <div>
-    <!-- Trigger Button -->
-    <button
-      id="preferences"
-      class="focusable relative flex rounded-full bg-transparent p-2 text-sm ring-2 ring-white/0 dark:ring-white/0 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:ring-white/20 dark:hover:ring-white/20 focus:outline-none focus:ring-white/100 dark:focus:ring-white/100"
-      @click="isOpen = true"
-    >
-      <span class="absolute -inset-1.5" />
-      <span class="sr-only">{{ t("open") }}</span>
-      <MdiIcon :path="mdiTune" :size="28" class="text-zinc-900 dark:text-zinc-50" />
-    </button>
+    <!-- Trigger button; overridable via the `trigger` slot. -->
+    <slot name="trigger" :open="() => (isOpen = true)">
+      <button
+        id="preferences"
+        class="focusable relative flex rounded-full bg-transparent p-2 text-sm ring-2 ring-white/0 dark:ring-white/0 hover:bg-zinc-200 dark:hover:bg-zinc-700 hover:ring-white/20 dark:hover:ring-white/20 focus:outline-none focus:ring-white/100 dark:focus:ring-white/100"
+        @click="isOpen = true"
+      >
+        <span class="absolute -inset-1.5" />
+        <span class="sr-only">{{ t("open") }}</span>
+        <MdiIcon :path="mdiTune" :size="28" class="text-zinc-900 dark:text-zinc-50" />
+      </button>
+    </slot>
 
     <!-- Modal Dialog -->
     <ClientOnly>

--- a/webclient/app/layouts/navigation.vue
+++ b/webclient/app/layouts/navigation.vue
@@ -24,14 +24,11 @@ const { t } = useI18n({ useScope: "local" });
   >
     {{ t("skip_to_content") }}
   </a>
-  <AppNavHeader />
-
-  <!-- Page content container -->
-  <main id="main-content" tabindex="-1" class="mx-auto mt-[60px] min-h-[calc(100vh-150px)] transition-opacity">
+  <!-- Full-viewport navigation view: no global header or footer. -->
+  <main id="main-content" tabindex="-1" class="h-[100dvh] overflow-hidden">
     <slot />
   </main>
 
-  <AppFooter />
   <ClientOnly>
     <LazyFeedbackModal v-if="feedback.open" />
     <LazyAddProposalModal v-if="editProposal.addOpen" />

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { mdiChevronLeft } from "@mdi/js";
+import { mdiChevronLeft, mdiTune } from "@mdi/js";
 import { refDebounced } from "@vueuse/core";
 import { useRouteQuery } from "@vueuse/router";
 import { useTemplateRef } from "vue";
@@ -238,9 +238,7 @@ function handleSelectItinerary(itineraryIndex: number) {
 </script>
 
 <template>
-  <div
-    class="flex max-h-[calc(100vh-60px)] min-h-[calc(100vh-60px)] flex-col lg:max-h-[calc(100vh-150px)] lg:min-h-[calc(100vh-150px)] lg:flex-row-reverse"
-  >
+  <div class="flex h-full flex-col lg:flex-row-reverse">
     <div class="min-h-96 grow">
       <ClientOnly>
         <IndoorMap ref="indoorMap" type="room" :coords="{ lat: 0, lon: 0, source: 'navigatum' }" />
@@ -258,7 +256,16 @@ function handleSelectItinerary(itineraryIndex: number) {
           <span class="text-xs font-semibold uppercase">{{ t("back") }}</span>
         </div>
       </NuxtLinkLocale>
-      <NavigationModeSelector v-model:mode="mode" />
+      <div class="flex flex-row items-center gap-2">
+        <NavigationModeSelector v-model:mode="mode" class="grow" />
+        <PreferencesPopup>
+          <template #trigger="{ open }">
+            <Btn variant="secondary" size="md" :title="t('preferences')" :aria-label="t('preferences')" @click="open">
+              <MdiIcon :path="mdiTune" :size="24" />
+            </Btn>
+          </template>
+        </PreferencesPopup>
+      </div>
       <form
         action="/navigate"
         autocomplete="off"
@@ -312,6 +319,7 @@ function handleSelectItinerary(itineraryIndex: number) {
 <i18n lang="yaml">
 de:
   back: zurück
+  preferences: Präferenzen
   calculating best route: Berechnet optimale Route
   navigate_from_to: Navigiere von {from} nach {to}
   navigate_from: Navigiere von {from}
@@ -327,6 +335,7 @@ de:
   kilometers: "{0} Kilometer"
 en:
   back: back
+  preferences: Preferences
   calculating best route: Calculating best route
   navigate_from_to: Navigating from {from} to {to}
   navigate_from: Navigating from {from}


### PR DESCRIPTION
Move the navigation view to a left routing pane + right map with no global header/footer, and relocate the preferences menu into the pane (compact gear beside the mode selector) via a new `trigger` slot on `PreferencesPopup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)