### PR TITLE
feat(map): card-validators overlay on /map

### DIFF
--- a/webclient/app/components/MapLayerPanel.vue
+++ b/webclient/app/components/MapLayerPanel.vue
@@ -73,10 +73,12 @@ de:
   filters:
     wcs: Toiletten & Duschen
     events: Veranstaltungen
+    card_validators: Validierungsautomaten
 en:
   panel_title: Filter
   zoom_hint: Zoom in to see {name}
   filters:
     wcs: Toilets & showers
     events: Events
+    card_validators: Card validators
 </i18n>

--- a/webclient/app/composables/mapLayers.ts
+++ b/webclient/app/composables/mapLayers.ts
@@ -1,4 +1,4 @@
-import { mdiCalendarStar, mdiToilet } from "@mdi/js";
+import { mdiCalendarStar, mdiCreditCardCheckOutline, mdiToilet } from "@mdi/js";
 
 interface FilterDefBase {
   /** Stable key used in the `?filter=` query and in `localStorage`. */
@@ -31,10 +31,18 @@ export interface EventsFilterDef extends FilterDefBase {
   readonly kind: "events";
 }
 
-export type FilterDef = IndoorFilterDef | EventsFilterDef;
+/** An overlay that flips pre-baked basemap layers (shipped hidden) visible while active. */
+export interface OverlayFilterDef extends FilterDefBase {
+  readonly kind: "overlay";
+  readonly styleLayers: readonly string[];
+}
+
+export type FilterDef = IndoorFilterDef | EventsFilterDef | OverlayFilterDef;
 
 /** The events entry in the filter registry; its time window only applies while it is active. */
 export const EVENTS_FILTER_ID = "events";
+export const CARD_VALIDATORS_FILTER_ID = "card_validator";
+export const CARD_VALIDATORS_STYLE_LAYER = "card-validators";
 /** The WCs entry in the filter registry; its attribute filters only apply while it is active. */
 export const WCS_FILTER_ID = "wcs";
 /** The `indoor` values the WCs filter covers, shared with its attribute-filter expression. */
@@ -78,6 +86,24 @@ export const FILTER_REGISTRY = [
     // Markers only render from zoom 15; hint below that.
     hintBelowZoom: 15,
     keywords: ["event", "events", "veranstaltung", "veranstaltungen"],
+  },
+  {
+    id: CARD_VALIDATORS_FILTER_ID,
+    kind: "overlay",
+    labelKey: "filters.card_validators",
+    icon: mdiCreditCardCheckOutline,
+    styleLayers: [CARD_VALIDATORS_STYLE_LAYER],
+    hintBelowZoom: 13,
+    keywords: [
+      "validierungsautomat",
+      "validierungsautomaten",
+      "validierung",
+      "studentenausweis",
+      "studierendenausweis",
+      "tumcard",
+      "validator",
+      "validators",
+    ],
   },
 ] as const satisfies readonly FilterDef[];
 

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -10,6 +10,7 @@ import { GeolocateControl, Map as MapLibreMap, NavigationControl, Popup } from "
 import { FloorControl } from "~/composables/FloorControl";
 import {
   ACTIVE_FILTERS_STORAGE_KEY,
+  CARD_VALIDATORS_STYLE_LAYER,
   DEFAULT_EVENTS_WINDOW,
   EVENT_SOURCE_BY_WINDOW,
   EVENTS_FILTER_ID,
@@ -185,6 +186,18 @@ function applyFilterDim(): void {
   }
 }
 
+function applyOverlayVisibility(): void {
+  const m = map.value;
+  if (!m) return;
+  for (const filter of FILTER_REGISTRY) {
+    if (filter.kind !== "overlay") continue;
+    const visibility = activeFilters.value.has(filter.id) ? "visible" : "none";
+    for (const layer of filter.styleLayers) {
+      if (m.getLayer(layer)) m.setLayoutProperty(layer, "visibility", visibility);
+    }
+  }
+}
+
 function toggleFilter(id: string): void {
   const next = new Set(activeFilters.value);
   if (next.has(id)) next.delete(id);
@@ -198,6 +211,7 @@ watch(activeFilters, (filters) => {
   // Drop the param when nothing is active (the default), so a bare /map URL stays clean.
   setQueryParam(FILTER_QUERY_PARAM, serialized || null);
   applyFilterDim();
+  applyOverlayVisibility();
   // The popup belongs to the event markers; drop it when the filter switches them off.
   if (!filters.has(EVENTS_FILTER_ID)) closeActiveEvent();
 });
@@ -289,6 +303,54 @@ function openPoiPopup(event: MapLayerMouseEvent): void {
     .addTo(m);
 }
 
+function buildValidatorPopupContent(
+  feature: MapGeoJSONFeature,
+  lng: number,
+  lat: number
+): HTMLElement {
+  const props = feature.properties ?? {};
+  const root = document.createElement("div");
+  root.className = "flex flex-col gap-1 text-sm";
+
+  const title = document.createElement("p");
+  title.className = "font-semibold";
+  title.textContent =
+    typeof props.name === "string" && props.name ? props.name : t("validator.title");
+  root.appendChild(title);
+
+  const subtitle = document.createElement("p");
+  subtitle.className = "opacity-70";
+  subtitle.textContent = t("validator.subtitle");
+  root.appendChild(subtitle);
+
+  // Location-only OSM edit link; no element id flows through the tiles.
+  const edit = document.createElement("a");
+  edit.href = `https://www.openstreetmap.org/edit#map=21/${lat.toFixed(7)}/${lng.toFixed(7)}`;
+  edit.target = "_blank";
+  edit.rel = "noopener noreferrer";
+  edit.textContent = t("edit_in_osm");
+  root.appendChild(edit);
+
+  return root;
+}
+
+function openValidatorPopup(event: MapLayerMouseEvent): void {
+  const m = map.value;
+  const feature = event.features?.[0];
+  if (!m || !feature) return;
+
+  const [lng, lat] =
+    feature.geometry.type === "Point"
+      ? (feature.geometry.coordinates as [number, number])
+      : [event.lngLat.lng, event.lngLat.lat];
+
+  poiPopup.value?.remove();
+  poiPopup.value = new Popup({ closeButton: true, closeOnClick: true })
+    .setLngLat([lng, lat])
+    .setDOMContent(buildValidatorPopupContent(feature, lng, lat))
+    .addTo(m);
+}
+
 function initMap(): MapLibreMap {
   // Not at setup: its constructor touches `document`, absent on the server.
   const floorControl = new FloorControl();
@@ -335,14 +397,20 @@ function initMap(): MapLibreMap {
     floorControl.setLevel(resolveLevel(queryString(LEVEL_QUERY_PARAM)));
 
     applyFilterDim();
+    applyOverlayVisibility();
 
-    m.on("click", POI_LAYER, openPoiPopup);
-    m.on("mouseenter", POI_LAYER, () => {
-      m.getCanvas().style.cursor = "pointer";
-    });
-    m.on("mouseleave", POI_LAYER, () => {
-      m.getCanvas().style.cursor = "";
-    });
+    for (const [layer, handler] of [
+      [POI_LAYER, openPoiPopup],
+      [CARD_VALIDATORS_STYLE_LAYER, openValidatorPopup],
+    ] as const) {
+      m.on("click", layer, handler);
+      m.on("mouseenter", layer, () => {
+        m.getCanvas().style.cursor = "pointer";
+      });
+      m.on("mouseleave", layer, () => {
+        m.getCanvas().style.cursor = "";
+      });
+    }
   });
 
   floorControl.on("level-changed", (event: { level: number | null }) => {
@@ -471,6 +539,9 @@ de:
   poi:
     toilet: Toilette
     shower: Dusche
+  validator:
+    title: Validierungsautomat
+    subtitle: Studierendenausweis validieren
   gender:
     label: Geschlecht
     male: Herren
@@ -492,6 +563,9 @@ en:
   poi:
     toilet: Toilet
     shower: Shower
+  validator:
+    title: Card validator
+    subtitle: Validate your student card
   gender:
     label: Gender
     male: Male

--- a/webclient/test/mapLayers.test.ts
+++ b/webclient/test/mapLayers.test.ts
@@ -116,6 +116,14 @@ describe("the shipped registry", () => {
     expect(events?.kind).toBe("events");
     expect(events && "styleLayers" in events).toBe(false);
   });
+
+  it("models card validators as an overlay flipping the baked card-validators layer", () => {
+    const validators = FILTER_REGISTRY.find((f) => f.id === "card_validator");
+    expect(validators?.kind).toBe("overlay");
+    expect(validators?.kind === "overlay" && [...validators.styleLayers]).toEqual([
+      "card-validators",
+    ]);
+  });
 });
 
 describe("parseEventsWindow", () => {
@@ -274,6 +282,12 @@ describe("categoriesForQuery", () => {
   it("returns multiple matches in registry order regardless of token order", () => {
     expect(categoriesForQuery("veranstaltung toilette")).toEqual(["wcs", "events"]);
     expect(categoriesForQuery("toilette veranstaltung")).toEqual(["wcs", "events"]);
+  });
+
+  it("fires the card-validators shortcut on validator queries", () => {
+    for (const query of ["validierungsautomat", "Validator", "tumcard", "studierendenausweis"]) {
+      expect(categoriesForQuery(query)).toEqual(["card_validator"]);
+    }
   });
 });
 


### PR DESCRIPTION
## What

Adds the **card-validators overlay** to the `/map` filter panel — PR 2 of the 3-PR plan for #3158 (closes #499). It consumes the `card_validators` tile layer shipped in #3280.