### PR TITLE
feat(webclient): show the indoor room popup on the location detail map

### DIFF
--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -33,6 +33,14 @@ const { activeEvent, markerScreenPos, closeActiveEvent } = useEventMarkers(map, 
   sources: ["events_active"],
 });
 
+// The floor control's active OSM level, fed to the room popup's OSM edit link; `0` while no floor.
+const currentLevel = ref<number | null>(null);
+const { popupTarget, roomPopup, closeRoomPopup, resolveRoomPopupFromClick, attachHoverCursor } =
+  useIndoorRoomPopup(map, {
+    getZoom: () => map.value?.getZoom() ?? zoom.value,
+    getLevel: () => currentLevel.value ?? 0,
+  });
+
 const initialLoaded = ref(false);
 
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
@@ -147,12 +155,19 @@ function initMap(containerId: string): MapLibreMap {
         floorControl.value.setLevel(availableFloorIds[0] ?? null);
       }
     }
+
+    // Clicking a room polygon or toilet/shower node opens the shared indoor popup.
+    mapInstance.on("click", resolveRoomPopupFromClick);
+    attachHoverCursor(mapInstance, INDOOR_INTERACTIVE_LAYERS);
   });
 
   mapInstance.addControl(floorControl.value, "top-left");
 
   // Listen for floor level changes and adjust zoom if needed
   floorControl.value.on("level-changed", (event: { level: number | null }) => {
+    currentLevel.value = event.level;
+    // The open popup belongs to the floor that was visible; drop it when the floor switches.
+    closeRoomPopup();
     if (event.level !== null && mapInstance) {
       const currentMapZoom = mapInstance.getZoom();
       // Our floors are only visible at zoom level 17+
@@ -173,6 +188,10 @@ onMounted(async () => {
   await until(mapContainer).toBeTruthy();
   loadInteractiveMap();
   window.scrollTo({ top: 0, behavior: "auto" });
+});
+
+onBeforeUnmount(() => {
+  closeRoomPopup();
 });
 </script>
 
@@ -197,11 +216,20 @@ onMounted(async () => {
     <LazyMapGLNotSupported v-else />
 
     <EventPopupOverlay :event="activeEvent" :screen-pos="markerScreenPos" @close="closeActiveEvent" />
+    <Teleport v-if="popupTarget && roomPopup" :to="popupTarget">
+      <IndoorRoomPopup v-bind="roomPopup" />
+    </Teleport>
   </div>
 </template>
 
 <style lang="postcss">
 @import "maplibre-gl/dist/maplibre-gl.css";
+
+/* Popup stays white in both themes; pin dark text so nightwind cannot invert it. */
+.maplibregl-popup-content {
+  background: var(--color-white);
+  color: var(--color-zinc-800);
+}
 
 /* --- Interactive map display --- */
 #interactive-legacy-map-container {

--- a/webclient/app/composables/useIndoorRoomPopup.ts
+++ b/webclient/app/composables/useIndoorRoomPopup.ts
@@ -1,0 +1,149 @@
+import type { LngLatLike, Map as MapLibreMap, MapMouseEvent } from "maplibre-gl";
+import { Popup } from "maplibre-gl";
+import type { MaybeRefOrGetter, Ref } from "vue";
+import type { IndoorRoomPopupProps } from "~/components/IndoorRoomPopup.vue";
+
+// The room fill layer; merged with the POIs into one unified popup on click.
+export const ROOM_LAYER = "indoor-rooms";
+// The combined POI layer whose markers open a popup.
+export const POI_LAYER = "indoor-pois";
+// Both indoor layers a click is resolved against, and that show a pointer cursor on hover.
+export const INDOOR_INTERACTIVE_LAYERS = [ROOM_LAYER, POI_LAYER] as const;
+
+export interface UseIndoorRoomPopupOptions {
+  /** Read when a popup opens, so its OSM edit link deep-links the right scale. */
+  readonly getZoom: () => number;
+  /** Read when a popup opens; `0` when no floor is selected. */
+  readonly getLevel: () => number;
+}
+
+export interface UseIndoorRoomPopup {
+  /** Teleport host for the popup body; `null` when no room popup is open. */
+  readonly popupTarget: Ref<HTMLElement | null>;
+  /** Props for the teleported `IndoorRoomPopup`; `null` when none is open. */
+  readonly roomPopup: Ref<IndoorRoomPopupProps | null>;
+  /** Tear down whichever popup (room or raw-DOM) is open. */
+  readonly closeRoomPopup: () => void;
+  /** Anchor a room popup and teleport the Vue body into it. */
+  readonly openRoomPopup: (state: IndoorRoomPopupProps) => void;
+  /** Reuse the single popup instance for raw-DOM content (e.g. the card-validator popup). */
+  readonly openDomPopup: (lngLat: LngLatLike, content: HTMLElement) => void;
+  /** Merge the room and POI under the cursor into one popup; close it when nothing matches. */
+  readonly resolveRoomPopupFromClick: (event: MapMouseEvent) => void;
+  /** Show a pointer cursor while hovering the given layers. */
+  readonly attachHoverCursor: (target: MapLibreMap, layers: readonly string[]) => void;
+}
+
+function truthy(value: unknown): boolean {
+  return value === true || value === 1 || value === "true";
+}
+
+/**
+ * The shared indoor room/POI popup: clicking a room polygon or toilet/shower node anchors a
+ * MapLibre popup whose body is the Vue `IndoorRoomPopup`, teleported into `popupTarget`. A single
+ * popup instance is reused, so opening a new one (or a raw-DOM popup via `openDomPopup`) replaces
+ * any open one. Shared by `/map` and the location detail map.
+ */
+export function useIndoorRoomPopup(
+  map: MaybeRefOrGetter<MapLibreMap | undefined>,
+  options: UseIndoorRoomPopupOptions
+): UseIndoorRoomPopup {
+  // `shallowRef`: MapLibre owns the popup's deep state; Vue must not track it reactively.
+  const popupInstance = shallowRef<Popup | undefined>(undefined);
+  const popupTarget = shallowRef<HTMLElement | null>(null);
+  const roomPopup = shallowRef<IndoorRoomPopupProps | null>(null);
+
+  function closeRoomPopup(): void {
+    popupInstance.value?.remove();
+    popupInstance.value = undefined;
+    roomPopup.value = null;
+    popupTarget.value = null;
+  }
+
+  function openRoomPopup(state: IndoorRoomPopupProps): void {
+    const m = toValue(map);
+    if (!m) return;
+    popupInstance.value?.remove();
+    const container = document.createElement("div");
+    roomPopup.value = state;
+    popupTarget.value = container;
+    const popup = new Popup({ closeButton: true, closeOnClick: false })
+      .setLngLat([state.lng, state.lat])
+      .setDOMContent(container)
+      .addTo(m);
+    // The close button removes the popup imperatively; drop the Vue body so the teleport unmounts.
+    popup.on("close", () => {
+      roomPopup.value = null;
+      popupTarget.value = null;
+    });
+    popupInstance.value = popup;
+  }
+
+  function openDomPopup(lngLat: LngLatLike, content: HTMLElement): void {
+    const m = toValue(map);
+    if (!m) return;
+    closeRoomPopup();
+    popupInstance.value = new Popup({ closeButton: true, closeOnClick: false })
+      .setLngLat(lngLat)
+      .setDOMContent(content)
+      .addTo(m);
+  }
+
+  function resolveRoomPopupFromClick(event: MapMouseEvent): void {
+    const m = toValue(map);
+    if (!m) return;
+
+    const queryLayers = INDOOR_INTERACTIVE_LAYERS.filter((layer) => m.getLayer(layer));
+    const features = m.queryRenderedFeatures(event.point, { layers: queryLayers });
+    const room = features.find((f) => f.layer.id === ROOM_LAYER);
+    const poi = features.find((f) => f.layer.id === POI_LAYER);
+
+    const refTumRaw = room?.properties?.ref_tum;
+    const refTum = typeof refTumRaw === "string" && refTumRaw.length > 0 ? refTumRaw : null;
+    const indoor = poi?.properties?.indoor ?? room?.properties?.indoor;
+    const isToilet = indoor === "toilet";
+    const isShower = indoor === "shower";
+
+    // Untagged, non-toilet features identify nothing and have no fix to offer - leave them inert.
+    if (!refTum && !isToilet && !isShower) {
+      closeRoomPopup();
+      return;
+    }
+
+    const flag = (key: string): boolean =>
+      truthy(poi?.properties?.[key] ?? room?.properties?.[key]);
+    openRoomPopup({
+      refTum,
+      lat: event.lngLat.lat,
+      lng: event.lngLat.lng,
+      zoom: options.getZoom(),
+      level: options.getLevel(),
+      isToilet,
+      isShower,
+      isMale: flag("is_male_toilet"),
+      isFemale: flag("is_female_toilet"),
+      isWheelchair: flag("is_wheelchair_toilet"),
+    });
+  }
+
+  function attachHoverCursor(target: MapLibreMap, layers: readonly string[]): void {
+    for (const layer of layers) {
+      target.on("mouseenter", layer, () => {
+        target.getCanvas().style.cursor = "pointer";
+      });
+      target.on("mouseleave", layer, () => {
+        target.getCanvas().style.cursor = "";
+      });
+    }
+  }
+
+  return {
+    popupTarget,
+    roomPopup,
+    closeRoomPopup,
+    openRoomPopup,
+    openDomPopup,
+    resolveRoomPopupFromClick,
+    attachHoverCursor,
+  };
+}

--- a/webclient/app/pages/map.vue
+++ b/webclient/app/pages/map.vue
@@ -7,8 +7,7 @@ import type {
   MapGeoJSONFeature,
   MapMouseEvent,
 } from "maplibre-gl";
-import { GeolocateControl, Map as MapLibreMap, NavigationControl, Popup } from "maplibre-gl";
-import type { IndoorRoomPopupProps } from "~/components/IndoorRoomPopup.vue";
+import { GeolocateControl, Map as MapLibreMap, NavigationControl } from "maplibre-gl";
 import { FloorControl } from "~/composables/FloorControl";
 import {
   ACTIVE_FILTERS_STORAGE_KEY,
@@ -39,6 +38,7 @@ import {
   wcsAttributeConditions,
 } from "~/composables/mapLayers";
 import { useEventMarkers } from "~/composables/useEventMarkers";
+import { INDOOR_INTERACTIVE_LAYERS, useIndoorRoomPopup } from "~/composables/useIndoorRoomPopup";
 import { useWebglGuard } from "~/composables/webglSupport";
 
 definePageMeta({ layout: "browse-map" });
@@ -58,12 +58,6 @@ const DIM = 0.2;
 // Translucent white wash over the basemap; lighter than the indoor dim so it reads as "a bit".
 const BASEMAP_SCRIM = "rgba(255, 255, 255, 0.45)";
 const SCRIM_LAYER = "filter-basemap-dim";
-// The combined POI layer whose markers open a popup.
-const POI_LAYER = "indoor-pois";
-// The room fill layer; merged with the POIs into one unified popup on click.
-const ROOM_LAYER = "indoor-rooms";
-// Both indoor layers a click is resolved against, and that show a pointer cursor on hover.
-const INDOOR_INTERACTIVE_LAYERS = [ROOM_LAYER, POI_LAYER] as const;
 // MapLibre v6 tightened {set,get}PaintProperty signatures: the property name must be a literal
 // key of AllPaintProperties, and the value matches that key's spec. The three opacity props
 // below all resolve to DataDrivenPropertyValueSpecification<number>.
@@ -91,10 +85,6 @@ const FLAT_TARGETS = [
 
 // `shallowRef`: MapLibre owns its own deep state; Vue must not track it reactively.
 const map = shallowRef<MapLibreMap | undefined>(undefined);
-// The anchored MapLibre popup; its body is the Vue `IndoorRoomPopup` teleported into `popupTarget`.
-const popupInstance = shallowRef<Popup | undefined>(undefined);
-const popupTarget = shallowRef<HTMLElement | null>(null);
-const roomPopup = shallowRef<IndoorRoomPopupProps | null>(null);
 const mapContainer = ref<HTMLElement | undefined>(undefined);
 const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 const initialLoaded = ref(false);
@@ -117,6 +107,11 @@ const { activeEvent, markerScreenPos, closeActiveEvent } = useEventMarkers(map, 
   sources: ["events_active", "events_upcoming"],
   visibleSources: eventsVisibleSources,
 });
+const { popupTarget, roomPopup, closeRoomPopup, openDomPopup, resolveRoomPopupFromClick } =
+  useIndoorRoomPopup(map, {
+    getZoom: () => currentZoom.value,
+    getLevel: () => currentLevel.value ?? 0,
+  });
 
 // Original paint values captured before the first dim, so toggling a filter off restores them.
 const originalPaint = new Map<string, OpacityValue | undefined>();
@@ -245,47 +240,12 @@ watch(panelCollapsed, (collapsed) => {
   localStorage.setItem(PANEL_COLLAPSED_STORAGE_KEY, collapsed ? "1" : "0");
 });
 
-function truthy(value: unknown): boolean {
-  return value === true || value === 1 || value === "true";
-}
-
-function closeRoomPopup(): void {
-  popupInstance.value?.remove();
-  popupInstance.value = undefined;
-  roomPopup.value = null;
-  popupTarget.value = null;
-}
-
-/** Anchor a fresh MapLibre popup and teleport the Vue body into its content element. */
-function openRoomPopup(state: IndoorRoomPopupProps): void {
-  const m = map.value;
-  if (!m) return;
-  popupInstance.value?.remove();
-  const container = document.createElement("div");
-  roomPopup.value = state;
-  popupTarget.value = container;
-  const popup = new Popup({ closeButton: true, closeOnClick: false })
-    .setLngLat([state.lng, state.lat])
-    .setDOMContent(container)
-    .addTo(m);
-  // The close button removes the popup imperatively; drop the Vue body so the teleport unmounts.
-  popup.on("close", () => {
-    roomPopup.value = null;
-    popupTarget.value = null;
-  });
-  popupInstance.value = popup;
-}
-
-/**
- * Merge the topmost room fill and POI under the cursor into one popup: the room polygon
- * carries `ref_tum`, the toilet/shower flags ride on whichever feature has them. A bare
- * toilet/shower node without a room keeps the link-less popup; anything else closes it.
- */
+// Card validators own a separate popup; route their clicks here before falling back to the
+// shared room/POI popup.
 function onIndoorClick(event: MapMouseEvent): void {
   const m = map.value;
   if (!m) return;
 
-  // Card validators own a separate popup; hand the click off before merging rooms and POIs.
   if (m.getLayer(CARD_VALIDATORS_STYLE_LAYER)) {
     const validator = m.queryRenderedFeatures(event.point, {
       layers: [CARD_VALIDATORS_STYLE_LAYER],
@@ -296,36 +256,7 @@ function onIndoorClick(event: MapMouseEvent): void {
     }
   }
 
-  const queryLayers = INDOOR_INTERACTIVE_LAYERS.filter((layer) => m.getLayer(layer));
-  const features = m.queryRenderedFeatures(event.point, { layers: queryLayers });
-  const room = features.find((f) => f.layer.id === ROOM_LAYER);
-  const poi = features.find((f) => f.layer.id === POI_LAYER);
-
-  const refTumRaw = room?.properties?.ref_tum;
-  const refTum = typeof refTumRaw === "string" && refTumRaw.length > 0 ? refTumRaw : null;
-  const indoor = poi?.properties?.indoor ?? room?.properties?.indoor;
-  const isToilet = indoor === "toilet";
-  const isShower = indoor === "shower";
-
-  // Untagged, non-toilet features identify nothing and have no fix to offer - leave them inert.
-  if (!refTum && !isToilet && !isShower) {
-    closeRoomPopup();
-    return;
-  }
-
-  const flag = (key: string): boolean => truthy(poi?.properties?.[key] ?? room?.properties?.[key]);
-  openRoomPopup({
-    refTum,
-    lat: event.lngLat.lat,
-    lng: event.lngLat.lng,
-    zoom: currentZoom.value,
-    level: currentLevel.value ?? 0,
-    isToilet,
-    isShower,
-    isMale: flag("is_male_toilet"),
-    isFemale: flag("is_female_toilet"),
-    isWheelchair: flag("is_wheelchair_toilet"),
-  });
+  resolveRoomPopupFromClick(event);
 }
 
 function buildValidatorPopupContent(
@@ -359,22 +290,13 @@ function buildValidatorPopupContent(
   return root;
 }
 
-// Shares the single popup instance with the room popup so only one is ever open; the unified
-// click handler routes validator features here before considering rooms or POIs.
+// Reuses the shared popup instance so a validator and a room popup are never open at once.
 function openValidatorPopup(feature: MapGeoJSONFeature, lngLat: LngLat): void {
-  const m = map.value;
-  if (!m) return;
-
   const [lng, lat] =
     feature.geometry.type === "Point"
       ? (feature.geometry.coordinates as [number, number])
       : [lngLat.lng, lngLat.lat];
-
-  closeRoomPopup();
-  popupInstance.value = new Popup({ closeButton: true, closeOnClick: false })
-    .setLngLat([lng, lat])
-    .setDOMContent(buildValidatorPopupContent(feature, lng, lat))
-    .addTo(m);
+  openDomPopup([lng, lat], buildValidatorPopupContent(feature, lng, lat));
 }
 
 function initMap(): MapLibreMap {


### PR DESCRIPTION
Clicking a room (or toilet/shower node) on a location's detail map now opens the same indoor popup as the browse map, by extracting the shared logic into a `useIndoorRoomPopup` composable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)