### PR TITLE
fix(webclient): keep search bar focused so iOS Safari taps navigate (#3324)

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -61,6 +61,14 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
       },
     },
+    {
+      // Reproduces Safari/iOS focus races that Chromium can't (#3324); not yet in CI.
+      name: "ui-tests-webkit",
+      testMatch: /.*\.ui\.spec\.ts/,
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/tests/specs/search.ui.spec.ts
+++ b/tests/specs/search.ui.spec.ts
@@ -94,6 +94,26 @@ test.describe("Search Bar - Interactive Search", () => {
     await expect(page).toHaveURL("/search?q=MI");
   });
 
+  // #3324: tapping a dropdown result did nothing on Mobile Safari; Chromium focuses the link and can't reproduce it.
+  test.describe("dropdown result navigation (#3324)", () => {
+    test.skip(({ browserName }) => browserName !== "webkit", "WebKit/iOS-only focus race");
+
+    test("clicking a dropdown result navigates to its details page", async ({ page }) => {
+      await page.goto("/", { waitUntil: "networkidle" });
+
+      const searchInput = page.getByRole("textbox", { name: "Suchfeld" }).first();
+      await searchInput.fill("MI");
+
+      const firstResult = page
+        .locator('a[href*="/building/"], a[href*="/room/"], a[href*="/site/"], a[href*="/campus/"]')
+        .first();
+      await expect(firstResult).toBeVisible();
+      await firstResult.click();
+
+      await expect(page).toHaveURL(/\/(building|room|site|campus)\//);
+    });
+  });
+
   test("should not focus search bar when typing on search results page", async ({ page }) => {
     await page.goto("/search?q=MI", { waitUntil: "networkidle" });
 

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -220,7 +220,8 @@ const { data, error } = useFetch<SearchResponse>(url, {
             <SearchSortControl :filters="filters" />
           </div>
         </div>
-        <ul v-if="shortcutCategories.length" class="flex flex-col gap-2">
+        <!-- Keep the bar focused on tap so iOS Safari doesn't swallow the click (#3324). -->
+        <ul v-if="shortcutCategories.length" class="flex flex-col gap-2" @mousedown.prevent>
           <SearchCategoryShortcut
             v-for="category in shortcutCategories"
             :key="category"
@@ -268,6 +269,7 @@ const { data, error } = useFetch<SearchResponse>(url, {
             v-cloak
             :key="s.facet"
             class="flex flex-col gap-2"
+            @mousedown.prevent
           >
             <template v-if="s.estimatedTotalHits > 0">
               <div class="flex items-center">


### PR DESCRIPTION
Fixes #3324: `@mousedown.prevent` on the autocomplete result/shortcut lists keeps the search bar focused so WebKit/iOS doesn't tear the tapped link out mid-tap and swallow the click.