### PR TITLE
fix(webclient): close search dropdown after navigating between details pages

### DIFF
--- a/tests/specs/search.ui.spec.ts
+++ b/tests/specs/search.ui.spec.ts
@@ -114,8 +114,7 @@ test.describe("Search Bar - Interactive Search", () => {
     });
   });
 
-  // #3324 follow-up: details pages share one persistent search bar, so a result tap left
-  // the dropdown stuck open. The TYPE chip only renders while the dropdown is open.
+  // #3324: the persistent details-page bar kept the dropdown open after a result tap.
   test("clicking a dropdown result closes the dropdown on a details page", async ({ page }) => {
     await page.goto("/building/mi", { waitUntil: "networkidle" });
 

--- a/tests/specs/search.ui.spec.ts
+++ b/tests/specs/search.ui.spec.ts
@@ -114,6 +114,27 @@ test.describe("Search Bar - Interactive Search", () => {
     });
   });
 
+  // #3324 follow-up: details pages share one persistent search bar, so a result tap left
+  // the dropdown stuck open. The TYPE chip only renders while the dropdown is open.
+  test("clicking a dropdown result closes the dropdown on a details page", async ({ page }) => {
+    await page.goto("/building/mi", { waitUntil: "networkidle" });
+
+    const searchInput = page.getByRole("textbox", { name: "Suchfeld" }).first();
+    await searchInput.fill("garching");
+
+    const typeChip = page.getByRole("button", { name: TYPE_CHIP }).first();
+    await expect(typeChip).toBeVisible();
+
+    const firstResult = page
+      .locator('a[href*="/building/"], a[href*="/room/"], a[href*="/site/"], a[href*="/campus/"]')
+      .first();
+    await expect(firstResult).toBeVisible();
+    await firstResult.click();
+
+    await expect(page).toHaveURL(/\/(building|room|site|campus)\//);
+    await expect(typeChip).not.toBeVisible();
+  });
+
   test("should not focus search bar when typing on search results page", async ({ page }) => {
     await page.goto("/search?q=MI", { waitUntil: "networkidle" });
 

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -100,8 +100,8 @@ async function goToCategory(category: FilterId): Promise<void> {
   searchInput.value?.blur();
 }
 
-// The shortcut's own link handles mouse navigation; only reset the bar here.
-function onShortcutFollowed(): void {
+// The links navigate themselves; reset the bar so #3324's retained focus still closes it.
+function onResultFollowed(): void {
   query.value = "";
   searchInput.value?.blur();
 }
@@ -227,7 +227,7 @@ const { data, error } = useFetch<SearchResponse>(url, {
             :key="category"
             :category="category"
             :highlighted="shortcutHighlighted(category)"
-            @click="onShortcutFollowed"
+            @click="onResultFollowed"
             @mouseover="highlighted = undefined"
           />
         </ul>
@@ -282,6 +282,7 @@ const { data, error } = useFetch<SearchResponse>(url, {
                   v-if="expandedFacets.has(s.facet) || i < s.n_visible"
                   :highlighted="resultHighlighted(e)"
                   :item="e"
+                  @click="onResultFollowed"
                   @mouseover="highlighted = undefined"
                 />
               </template>

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -100,7 +100,7 @@ async function goToCategory(category: FilterId): Promise<void> {
   searchInput.value?.blur();
 }
 
-// The links navigate themselves; reset the bar so #3324's retained focus still closes it.
+// #3324's retained focus otherwise keeps the dropdown open after navigation.
 function onResultFollowed(): void {
   query.value = "";
   searchInput.value?.blur();


### PR DESCRIPTION
After #3324, tapping a search result on a details page navigated but left the dropdown stuck open (the bar persists across the shared fullscreen layout), blocking further navigation; this resets the bar on result/shortcut clicks so it closes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)