### PR TITLE
feat(map): render OSM building parts in the basemap

### DIFF
--- a/.github/workflows/martin-cicd.yml
+++ b/.github/workflows/martin-cicd.yml
@@ -29,6 +29,34 @@ jobs:
         run: java -Xmx1g -jar planetiler.jar verify shortbread_custom.yml
         working-directory: map/planetiler
 
+  validate-planetiler-schema:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            map
+      - name: Setup | Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+      - name: Setup | Install dependencies
+        run: npm ci
+        working-directory: map/planetiler
+      - name: Setup | Download planetiler schemas
+        # planetiler.schema.json $refs planetilerspec.schema.json, so both are needed to compile.
+        run: |
+          base=https://raw.githubusercontent.com/onthegomap/planetiler/main/planetiler-custommap
+          wget -q "$base/planetiler.schema.json" "$base/planetilerspec.schema.json"
+        working-directory: map/planetiler
+      - name: Validate config against schema
+        run: node --experimental-strip-types validate-schema.ts shortbread_custom.yml
+        working-directory: map/planetiler
+
   validate-style:
     runs-on: ubuntu-latest
     permissions:

--- a/map/.gitignore
+++ b/map/.gitignore
@@ -5,3 +5,7 @@ tmp/
 data/
 martin/fonts/
 martin/sprites/maki
+planetiler/node_modules/
+# Fetched at build/CI time, never committed.
+planetiler/planetiler.jar
+planetiler/*.schema.json

--- a/map/README.md
+++ b/map/README.md
@@ -171,6 +171,17 @@ To run tests, we recommend downloading the jar file from the [Planetiler release
 java -jar planetiler.jar verify ./map/planetiler/shortbread_custom.yml --watch
 ```
 
+CI additionally validates `shortbread_custom.yml` against the upstream
+[`planetiler.schema.json`](https://github.com/onthegomap/planetiler/blob/main/planetiler-custommap/planetiler.schema.json).
+To run that check locally from within `map/planetiler`:
+
+```bash
+npm ci
+base=https://raw.githubusercontent.com/onthegomap/planetiler/main/planetiler-custommap
+wget "$base/planetiler.schema.json" "$base/planetilerspec.schema.json"
+node --experimental-strip-types validate-schema.ts shortbread_custom.yml
+```
+
 ## Indoor data (osm2pgsql)
 
 The indoor overlay is a separate pipeline from the planetiler basemap above. `osm2pgsql` reads the

--- a/map/planetiler/package-lock.json
+++ b/map/planetiler/package-lock.json
@@ -1,0 +1,106 @@
+{
+  "name": "planetiler",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
+        "yaml": "2.9.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/map/planetiler/package.json
+++ b/map/planetiler/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
+    "yaml": "2.9.0"
+  }
+}

--- a/map/planetiler/shortbread_custom.spec.yml
+++ b/map/planetiler/shortbread_custom.spec.yml
@@ -245,6 +245,44 @@ examples:
     geometry: polygon
     min_zoom: 13
 
+- name: building:part=yes
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      building:part: yes
+  output:
+  - layer: buildings
+    geometry: polygon
+    min_zoom: 13
+
+- name: building:part with levels derives height and min_height
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      building:part: yes
+      building:levels: "5"
+      building:min_level: "2"
+  output:
+  - layer: buildings
+    geometry: polygon
+    min_zoom: 13
+    at_zoom: 14
+    allow_extra_tags: false
+    tags:
+      height: 15
+      min_height: 6
+      hide_3d: false
+
+- name: building:part=no is excluded
+  input:
+    source: osm
+    geometry: polygon
+    tags:
+      building:part: no
+  output: []
+
 - name: address polygon with house number
   input:
     source: osm

--- a/map/planetiler/shortbread_custom.yml
+++ b/map/planetiler/shortbread_custom.yml
@@ -465,10 +465,13 @@ layers:
   - source: osm
     geometry: polygon
     min_zoom: 13
+    # Emit building:part alongside building outlines, the same way OMT does.
     include_when:
       building: __any__
+      building:part: __any__
     exclude_when:
       building: no
+      building:part: no
     attributes:
     - key: height
       type: integer
@@ -487,6 +490,11 @@ layers:
         - if: { "building:min_level": __any__ }
           value: '${ feature.tags["building:min_level"].matches(r"^\d+$") ? uint(feature.tags["building:min_level"]) * 3u : 4u }'
         - else: 0
+      min_zoom: 14
+    # Always false until sibling-aware post-processing can flag outlines covered by parts (S3DB).
+    - key: hide_3d
+      type: boolean
+      value: false
       min_zoom: 14
   tile_post_process:
     merge_polygons:

--- a/map/planetiler/validate-schema.ts
+++ b/map/planetiler/validate-schema.ts
@@ -1,0 +1,27 @@
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import {parse} from "yaml";
+import {readFileSync} from "node:fs";
+
+const config: string | undefined = process.argv[2];
+if (!config) {
+  console.error("Usage: node validate-schema.ts <config.yml>");
+  process.exit(1);
+}
+
+// planetiler.schema.json $refs planetilerspec.schema.json for the `examples` key,
+// so the spec schema must be registered before the config schema can compile.
+const ajv = new Ajv2020({allErrors: true, strict: false});
+addFormats.default(ajv);
+ajv.addSchema(JSON.parse(readFileSync("planetilerspec.schema.json", "utf8")));
+const schema: object = JSON.parse(readFileSync("planetiler.schema.json", "utf8"));
+
+const doc: unknown = parse(readFileSync(config, "utf8"));
+const validate = ajv.compile(schema);
+if (!validate(doc)) {
+  for (const error of validate.errors ?? []) {
+    console.error(`${error.instancePath || "/"} ${error.message}`);
+  }
+  process.exit(1);
+}
+console.log(`${config} is valid against planetiler.schema.json`);


### PR DESCRIPTION
Include `building:part` polygons alongside building outlines in the `buildings` layer and emit a constant-`false` `hide_3d` flag, so the schema already carries the full Simple 3D Buildings attribute set (`height`, `min_height`, `hide_3d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)