### PR TITLE
feat(server): observe calendar-scraper health via Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,6 +3106,7 @@ dependencies = [
  "octocrab",
  "parquet",
  "pretty_assertions",
+ "prometheus",
  "rand 0.10.1",
  "regex",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ octocrab = { version = "0.53", default-features = false, features = ["default-cl
 parquet = { version = "59.0.0", default-features = false, features = ["zstd"] }
 pretty_assertions = "1.4.1"
 progenitor-client = "0.14.0"
+prometheus = { version = "0.14", default-features = false }
 rand = "0.10.0"
 regex = "1.12.3"
 reqwest = { version = "0.13", default-features = false, features = ["gzip", "hickory-dns", "http2", "json", "rustls"] }

--- a/server/.sqlx/query-235a5e3acb687d12c0bd436c9235bd97e49641d2be28a9ad7f1b58004f29996d.json
+++ b/server/.sqlx/query-235a5e3acb687d12c0bd436c9235bd97e49641d2be28a9ad7f1b58004f29996d.json
@@ -6,47 +6,56 @@
       {
         "ordinal": 0,
         "name": "key_title_de!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 1,
         "name": "key_title_en!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 2,
         "name": "key_stp_type!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 3,
         "name": "title_de!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 4,
         "name": "title_en!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 5,
         "name": "stp_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "next_occurrence_at!",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "room_codes!",
-        "type_info": "VarcharArray"
+        "type_info": "VarcharArray",
+        "origin": "Expression"
       },
       {
         "ordinal": 8,
         "name": "upcoming!: Json<Vec<UpcomingEventRaw>>",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-2668c0418c9e4853fe9f65d84d59d6216530909e31c417d5234ac270e4d851c8.json
+++ b/server/.sqlx/query-2668c0418c9e4853fe9f65d84d59d6216530909e31c417d5234ac270e4d851c8.json
@@ -6,47 +6,101 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "room_code",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "room_code"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "start_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "start_at"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "end_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "end_at"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "title_de",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "title_de"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "title_en",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "title_en"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "stp_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "stp_type"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "entry_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "entry_type"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "detailed_entry_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar",
+            "name": "detailed_entry_type"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-276d6e7a6dc07680e5a4a3241c1e60006f1ddb5d2b1beb00841b23a1a72deb4c.json
+++ b/server/.sqlx/query-276d6e7a6dc07680e5a4a3241c1e60006f1ddb5d2b1beb00841b23a1a72deb4c.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "key!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {
@@ -16,7 +17,7 @@
       ]
     },
     "nullable": [
-      null
+      true
     ]
   },
   "hash": "276d6e7a6dc07680e5a4a3241c1e60006f1ddb5d2b1beb00841b23a1a72deb4c"

--- a/server/.sqlx/query-649f553a2379b1c67d36ec6d45be716e01bd0443ee11e11dfc30791c6477c7a6.json
+++ b/server/.sqlx/query-649f553a2379b1c67d36ec6d45be716e01bd0443ee11e11dfc30791c6477c7a6.json
@@ -6,67 +6,145 @@
       {
         "ordinal": 0,
         "name": "last_calendar_scrape_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "last_calendar_scrape_at"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "lat",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "lat"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "lon",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "lon"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "type_common_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "type_common_name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "type"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "calendar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "calendar_url"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "tumonline_room_nr",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "tumonline_room_nr"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "coordinate_accuracy",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "coordinate_accuracy"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "coordinate_source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "coordinate_source"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "comment",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "comment"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "usage_id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "usage_id"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "operator_id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "operator_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-7126010cb55400bde96bf5fafaa8607ea86d26fb437f71701ac98eef77d77516.json
+++ b/server/.sqlx/query-7126010cb55400bde96bf5fafaa8607ea86d26fb437f71701ac98eef77d77516.json
@@ -6,32 +6,53 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "transportation_stations",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "transportation_stations",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "modes!: Vec<String>",
-        "type_info": "TextArray"
+        "type_info": "TextArray",
+        "origin": {
+          "Table": {
+            "table": "transportation_stations",
+            "name": "modes"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "lat",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 4,
         "name": "lon",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 5,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-7cda9051e4f9220648ebaf4f675296dc9d5eed8498a8b225b213fd9bdbc0f996.json
+++ b/server/.sqlx/query-7cda9051e4f9220648ebaf4f675296dc9d5eed8498a8b225b213fd9bdbc0f996.json
@@ -6,67 +6,145 @@
       {
         "ordinal": 0,
         "name": "last_calendar_scrape_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "last_calendar_scrape_at"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "lat",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "lat"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "lon",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "lon"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "type_common_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "type_common_name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "type"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "calendar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "calendar_url"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "tumonline_room_nr",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "tumonline_room_nr"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "coordinate_accuracy",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "coordinate_accuracy"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "coordinate_source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "coordinate_source"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "comment",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "comment"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "usage_id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "usage_id"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "operator_id",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "operator_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-9f518183559171969ae448a0f3f0de7a221ce7d9bb8378028c695e1b665c55c5.json
+++ b/server/.sqlx/query-9f518183559171969ae448a0f3f0de7a221ce7d9bb8378028c695e1b665c55c5.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "data",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "data"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-9fb457eebb8c6092e999001e07af811afed672ab35dae0724d7e2bd129c13b3d.json
+++ b/server/.sqlx/query-9fb457eebb8c6092e999001e07af811afed672ab35dae0724d7e2bd129c13b3d.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "key"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-a16d239da728e396e283aea0782d9b32f08c86626db9f4d63249dfc2cd77b80c.json
+++ b/server/.sqlx/query-a16d239da728e396e283aea0782d9b32f08c86626db9f4d63249dfc2cd77b80c.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "data",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "en",
+            "name": "data"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-b56cb85b6f198418f241265104ae2ecc99b8bc8514a5732b52bc76333d5b5e65.json
+++ b/server/.sqlx/query-b56cb85b6f198418f241265104ae2ecc99b8bc8514a5732b52bc76333d5b5e65.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "visible_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "visible_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "type"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-ba4dddc4721fa4798febd4aee6794ef7cd8e0ccde51092e543e5ca01e7867393.json
+++ b/server/.sqlx/query-ba4dddc4721fa4798febd4aee6794ef7cd8e0ccde51092e543e5ca01e7867393.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "lat",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "lat"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "lon",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "lon"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-c76a20f4df953be9afcab6409a0434b86b92725b37511ea1df10e848a3e344f4.json
+++ b/server/.sqlx/query-c76a20f4df953be9afcab6409a0434b86b92725b37511ea1df10e848a3e344f4.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "last_calendar_scrape_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "last_calendar_scrape_at"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "calendar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "calendar_url"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "type"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "type_common_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "de",
+            "name": "type_common_name"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/.sqlx/query-d2a811be4504220ed820201be7bd6277bd194aa7411e717e1255b61976d4d968.json
+++ b/server/.sqlx/query-d2a811be4504220ed820201be7bd6277bd194aa7411e717e1255b61976d4d968.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nSELECT\n    COUNT(*) FILTER (WHERE last_calendar_scrape_at >= DATE_SUBTRACT(NOW(), '60 minutes'::INTERVAL, 'Europe/Berlin'))   AS \"under_60m!\",\n    COUNT(*) FILTER (WHERE last_calendar_scrape_at <  DATE_SUBTRACT(NOW(), '60 minutes'::INTERVAL, 'Europe/Berlin')\n                      AND  last_calendar_scrape_at >= DATE_SUBTRACT(NOW(), '24 hours'::INTERVAL, 'Europe/Berlin'))     AS \"within_24h!\",\n    COUNT(*) FILTER (WHERE last_calendar_scrape_at <  DATE_SUBTRACT(NOW(), '24 hours'::INTERVAL, 'Europe/Berlin'))     AS \"over_24h!\",\n    COUNT(*) FILTER (WHERE last_calendar_scrape_at IS NULL)                                                            AS \"never!\"\nFROM de\nWHERE calendar_url IS NOT NULL",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "under_60m!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      },
+      {
+        "ordinal": 1,
+        "name": "within_24h!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      },
+      {
+        "ordinal": 2,
+        "name": "over_24h!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      },
+      {
+        "ordinal": 3,
+        "name": "never!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "d2a811be4504220ed820201be7bd6277bd194aa7411e717e1255b61976d4d968"
+}

--- a/server/.sqlx/query-e2c20ca8f6c7924335e607304f6849a24a29fad1ce6d6041ee8a0aa91c6ff375.json
+++ b/server/.sqlx/query-e2c20ca8f6c7924335e607304f6849a24a29fad1ce6d6041ee8a0aa91c6ff375.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "visible_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "visible_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "aliases",
+            "name": "type"
+          }
+        }
       }
     ],
     "parameters": {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 # logging/obeservability
 actix-web-prom = { workspace=true, default-features = false, features = [] }
+prometheus = { workspace=true, default-features = false }
 tracing-subscriber = { workspace=true, features = ["env-filter", "json", "fmt"] }
 tracing.workspace=true
 tracing-log = { workspace=true, features = ["std", "log-tracer", "interest-cache"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -239,7 +239,7 @@ async fn run_maintenance_work(
     set.spawn(async move { refresh::calendar::all_entries(&cal_pool, scrape_metrics).await });
     let freshness_pool = pool.clone();
     set.spawn(async move {
-        refresh::calendar::record_freshness(&freshness_pool, calendar_metrics).await
+        refresh::calendar::record_freshness(&freshness_pool, calendar_metrics).await;
     });
     // The lecture facet is derived from the (continuously scraped) calendar, so
     // it only makes sense when Meilisearch is the destination. It builds its own

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -153,12 +153,19 @@ pub fn setup_logging() {
         .expect("the tracing subscriber to be set as the global default");
 }
 
-#[tracing::instrument(skip(pool, meilisearch_initialised, initialisation_started, repo_pool))]
+#[tracing::instrument(skip(
+    pool,
+    meilisearch_initialised,
+    initialisation_started,
+    repo_pool,
+    calendar_metrics
+))]
 async fn run_maintenance_work(
     pool: Pool<Postgres>,
     meilisearch_initialised: Arc<RwLock<()>>,
     initialisation_started: Arc<Barrier>,
     repo_pool: Arc<feedback::proposed_edits::repo_pool::RepoPool>,
+    calendar_metrics: refresh::calendar::CalendarMetrics,
 ) {
     let meilisearch_enabled = env::var("SKIP_MS_SETUP") != Ok("true".to_string());
     if meilisearch_enabled {
@@ -228,7 +235,12 @@ async fn run_maintenance_work(
     }
     let mut set = JoinSet::new();
     let cal_pool = pool.clone();
-    set.spawn(async move { refresh::calendar::all_entries(&cal_pool).await });
+    let scrape_metrics = calendar_metrics.clone();
+    set.spawn(async move { refresh::calendar::all_entries(&cal_pool, scrape_metrics).await });
+    let freshness_pool = pool.clone();
+    set.spawn(async move {
+        refresh::calendar::record_freshness(&freshness_pool, calendar_metrics).await
+    });
     // The lecture facet is derived from the (continuously scraped) calendar, so
     // it only makes sense when Meilisearch is the destination. It builds its own
     // client because the setup client above is scoped to initial loading.
@@ -262,14 +274,17 @@ async fn main() -> anyhow::Result<()> {
 
     // without this barrier an external client might race the RWLock for meilisearch_initialised and gain the read lock before it is allowed
     let initialisation_started = Arc::new(Barrier::new(2));
+    let prometheus = build_metrics();
+    let calendar_metrics = refresh::calendar::CalendarMetrics::new(&prometheus.registry)
+        .expect("calendar metrics to register with the prometheus registry");
     let maintenance_thread = tokio::spawn(run_maintenance_work(
         data.pool.clone(),
         Arc::clone(&data.meilisearch_initialised),
         Arc::clone(&initialisation_started),
         Arc::clone(&repo_pool),
+        calendar_metrics,
     ));
 
-    let prometheus = build_metrics();
     let shutdown_pool_clone = data.pool.clone();
     initialisation_started.wait().await;
     // feedback specific initialisation

--- a/server/src/refresh/calendar.rs
+++ b/server/src/refresh/calendar.rs
@@ -3,6 +3,7 @@ use crate::external::connectum::APIRequestor;
 use crate::limited::vec::LimitedVec;
 use futures::StreamExt as _;
 use futures::stream::FuturesUnordered;
+use prometheus::{IntCounterVec, IntGaugeVec, Opts, Registry};
 use serde::{Deserialize, Serialize, Serializer as _};
 use sqlx::PgPool;
 use std::env;
@@ -12,6 +13,118 @@ use tokio::time::sleep;
 use tracing::{debug, error};
 
 const NUMBER_OF_CONCURRENT_SCRAPES: usize = 3;
+
+/// How often the freshness gauge is recomputed; a cheap aggregate over `de`.
+const FRESHNESS_RECOMPUTE_INTERVAL: Duration = Duration::from_mins(1);
+
+/// Outcome of a single calendar scrape, used as the bounded `result` label.
+#[derive(Clone, Copy)]
+enum ScrapeResult {
+    Success,
+    FetchError,
+    DecodeError,
+    StoreError,
+}
+
+impl ScrapeResult {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::FetchError => "fetch_error",
+            Self::DecodeError => "decode_error",
+            Self::StoreError => "store_error",
+        }
+    }
+}
+
+/// Prometheus handles for calendar-scraper health, shared with the scraper tasks.
+///
+/// The metric vectors are `Arc`-backed, so cloning hands out shared handles.
+#[derive(Clone)]
+pub struct CalendarMetrics {
+    scrape_total: IntCounterVec,
+    rooms_by_freshness: IntGaugeVec,
+}
+
+impl CalendarMetrics {
+    pub fn new(registry: &Registry) -> anyhow::Result<Self> {
+        let scrape_total = IntCounterVec::new(
+            Opts::new(
+                "navigatum_api_calendar_scrape_total",
+                "Calendar scrape attempts partitioned by outcome.",
+            ),
+            &["result"],
+        )?;
+        let rooms_by_freshness = IntGaugeVec::new(
+            Opts::new(
+                "navigatum_api_calendar_rooms_by_freshness",
+                "Scrapeable rooms bucketed by how long ago their calendar was last scraped.",
+            ),
+            &["bucket"],
+        )?;
+        registry.register(Box::new(scrape_total.clone()))?;
+        registry.register(Box::new(rooms_by_freshness.clone()))?;
+        Ok(Self {
+            scrape_total,
+            rooms_by_freshness,
+        })
+    }
+
+    fn record_scrape(&self, result: ScrapeResult) {
+        self.scrape_total.with_label_values(&[result.label()]).inc();
+    }
+}
+
+/// Distribution of scrapeable rooms over freshness buckets, mirroring the
+/// scheduler's 60-minute staleness threshold in [`entries_which_need_scraping`].
+struct FreshnessBuckets {
+    under_60m: i64,
+    within_24h: i64,
+    over_24h: i64,
+    never: i64,
+}
+
+#[tracing::instrument(skip(pool))]
+async fn freshness_buckets(pool: &PgPool) -> anyhow::Result<FreshnessBuckets> {
+    let row = sqlx::query!(
+        r#"
+SELECT
+    COUNT(*) FILTER (WHERE last_calendar_scrape_at >= DATE_SUBTRACT(NOW(), '60 minutes'::INTERVAL, 'Europe/Berlin'))   AS "under_60m!",
+    COUNT(*) FILTER (WHERE last_calendar_scrape_at <  DATE_SUBTRACT(NOW(), '60 minutes'::INTERVAL, 'Europe/Berlin')
+                      AND  last_calendar_scrape_at >= DATE_SUBTRACT(NOW(), '24 hours'::INTERVAL, 'Europe/Berlin'))     AS "within_24h!",
+    COUNT(*) FILTER (WHERE last_calendar_scrape_at <  DATE_SUBTRACT(NOW(), '24 hours'::INTERVAL, 'Europe/Berlin'))     AS "over_24h!",
+    COUNT(*) FILTER (WHERE last_calendar_scrape_at IS NULL)                                                            AS "never!"
+FROM de
+WHERE calendar_url IS NOT NULL"#
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(FreshnessBuckets {
+        under_60m: row.under_60m,
+        within_24h: row.within_24h,
+        over_24h: row.over_24h,
+        never: row.never,
+    })
+}
+
+/// Recompute the freshness gauge on a timer until cancelled; `over_24h` and
+/// `never` are the scraper-falling-behind / frozen-rooms signal.
+#[tracing::instrument(skip(pool, metrics))]
+pub async fn record_freshness(pool: &PgPool, metrics: CalendarMetrics) {
+    loop {
+        match freshness_buckets(pool).await {
+            Ok(b) => {
+                let gauge = &metrics.rooms_by_freshness;
+                gauge.with_label_values(&["under_60m"]).set(b.under_60m);
+                gauge.with_label_values(&["1h_24h"]).set(b.within_24h);
+                gauge.with_label_values(&["over_24h"]).set(b.over_24h);
+                gauge.with_label_values(&["never"]).set(b.never);
+            }
+            Err(e) => error!(error = ?e, "could not recompute calendar freshness metrics"),
+        }
+        sleep(FRESHNESS_RECOMPUTE_INTERVAL).await;
+    }
+}
 
 #[derive(Serialize, Deserialize, sqlx::Type)]
 struct LocationKey {
@@ -73,8 +186,8 @@ fn can_never_succeed() -> bool {
     false
 }
 
-#[tracing::instrument(skip(pool))]
-pub async fn all_entries(pool: &PgPool) {
+#[tracing::instrument(skip(pool, metrics))]
+pub async fn all_entries(pool: &PgPool, metrics: CalendarMetrics) {
     if can_never_succeed() {
         return;
     }
@@ -96,12 +209,17 @@ pub async fn all_entries(pool: &PgPool) {
             sleep(Duration::from_mins(1)).await;
         }
 
-        refresh_events(pool, &api, ids).await;
+        refresh_events(pool, &api, &metrics, ids).await;
     }
 }
 
-#[tracing::instrument(skip(api, pool))]
-async fn refresh_events(pool: &PgPool, api: &APIRequestor, mut ids: LimitedVec<LocationKey>) {
+#[tracing::instrument(skip(api, pool, metrics))]
+async fn refresh_events(
+    pool: &PgPool,
+    api: &APIRequestor,
+    metrics: &CalendarMetrics,
+    mut ids: LimitedVec<LocationKey>,
+) {
     debug!(requested_ids_cnt = ids.len(), "downloading room-calendars");
     // we want to scrape all ~2k rooms once per hour
     // 1 thread is 15..20 per minute => we need at least 2 threads
@@ -109,19 +227,24 @@ async fn refresh_events(pool: &PgPool, api: &APIRequestor, mut ids: LimitedVec<L
     let mut work_queue = FuturesUnordered::new();
     for _ in 0..NUMBER_OF_CONCURRENT_SCRAPES {
         if let Some(id) = ids.pop() {
-            work_queue.push(refresh_single(pool, api.clone(), id.key));
+            work_queue.push(refresh_single(pool, api.clone(), metrics, id.key));
         }
     }
 
     while work_queue.next().await.is_some() {
         if let Some(id) = ids.pop() {
-            work_queue.push(refresh_single(pool, api.clone(), id.key));
+            work_queue.push(refresh_single(pool, api.clone(), metrics, id.key));
         }
     }
 }
 
-#[tracing::instrument(skip(pool, api))]
-async fn refresh_single(pool: &PgPool, mut api: APIRequestor, id: String) -> anyhow::Result<()> {
+#[tracing::instrument(skip(pool, api, metrics))]
+async fn refresh_single(
+    pool: &PgPool,
+    mut api: APIRequestor,
+    metrics: &CalendarMetrics,
+    id: String,
+) -> anyhow::Result<()> {
     let sync_start = chrono::Utc::now();
     if let Err(e) = Event::update_last_calendar_scrape_at(pool, &id, &sync_start).await {
         error!(error = ?e, "could not update last_calendar_scrape_at");
@@ -140,11 +263,13 @@ async fn refresh_single(pool: &PgPool, mut api: APIRequestor, id: String) -> any
         Err(e) => {
             // TODO: this measure is to temporarily make the log usefully again until CO accepts my fix
             if e.to_string() == *"error decoding response body" {
+                metrics.record_scrape(ScrapeResult::DecodeError);
                 debug!(
                     error = "https://gitlab.campusonline.community/tum/connectum/-/issues/118",
                     "Cannot download calendar"
                 );
             } else {
+                metrics.record_scrape(ScrapeResult::FetchError);
                 error!(error = ?e, "Could not download calendar");
             }
             return Err(e);
@@ -159,6 +284,122 @@ async fn refresh_single(pool: &PgPool, mut api: APIRequestor, id: String) -> any
         })
         .map(Event::from)
         .collect::<LimitedVec<_>>();
-    Event::store_all(pool, events, &id).await?;
+    if let Err(e) = Event::store_all(pool, events, &id).await {
+        metrics.record_scrape(ScrapeResult::StoreError);
+        return Err(e);
+    }
+    metrics.record_scrape(ScrapeResult::Success);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        reason = "tests assert via unwrap on fixtures and infallible metric setup"
+    )]
+    use super::*;
+    use crate::setup::tests::PostgresTestContainer;
+    use chrono::{DateTime, Duration as TimeDelta, Utc};
+
+    /// Minimal `de` row payload; `de.calendar_url` is generated from `props.calendar_url`,
+    /// so a missing `calendar_url` makes the room unscrapeable.
+    fn room_data(key: &str, calendar_url: Option<&str>) -> serde_json::Value {
+        let mut props = serde_json::Map::new();
+        if let Some(url) = calendar_url {
+            props.insert("calendar_url".into(), url.into());
+        }
+        serde_json::json!({
+            "coords": {"lat": 48.1, "lon": 11.5, "source": "inferred"},
+            "name": key,
+            "type": "room",
+            "type_common_name": "Serverraum",
+            "props": props,
+        })
+    }
+
+    async fn insert_room(
+        pool: &PgPool,
+        key: &str,
+        calendar_url: Option<&str>,
+        scraped_at: Option<DateTime<Utc>>,
+    ) {
+        sqlx::query("INSERT INTO de(key, data, last_calendar_scrape_at) VALUES ($1, $2, $3)")
+            .bind(key)
+            .bind(room_data(key, calendar_url))
+            .bind(scraped_at)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn freshness_buckets_partition_scrapeable_rooms() {
+        let pg = PostgresTestContainer::new().await;
+        let now = Utc::now();
+        let url = Some("https://campus.tum.de/x");
+        insert_room(
+            &pg.pool,
+            "fresh.10m",
+            url,
+            Some(now - TimeDelta::minutes(10)),
+        )
+        .await;
+        insert_room(
+            &pg.pool,
+            "fresh.30m",
+            url,
+            Some(now - TimeDelta::minutes(30)),
+        )
+        .await;
+        insert_room(&pg.pool, "mid.3h", url, Some(now - TimeDelta::hours(3))).await;
+        insert_room(&pg.pool, "old.30h", url, Some(now - TimeDelta::hours(30))).await;
+        insert_room(&pg.pool, "never.scraped", url, None).await;
+        // unscrapeable (no calendar_url) => excluded from every bucket.
+        insert_room(&pg.pool, "no.url", None, Some(now - TimeDelta::hours(30))).await;
+
+        let b = freshness_buckets(&pg.pool).await.unwrap();
+        assert_eq!(b.under_60m, 2);
+        assert_eq!(b.within_24h, 1);
+        assert_eq!(b.over_24h, 1);
+        assert_eq!(b.never, 1);
+    }
+
+    #[test]
+    fn scrape_outcomes_increment_their_bounded_label() {
+        let metrics = CalendarMetrics::new(&Registry::new()).unwrap();
+        metrics.record_scrape(ScrapeResult::Success);
+        metrics.record_scrape(ScrapeResult::Success);
+        metrics.record_scrape(ScrapeResult::DecodeError);
+
+        let total = &metrics.scrape_total;
+        assert_eq!(total.with_label_values(&["success"]).get(), 2);
+        assert_eq!(total.with_label_values(&["decode_error"]).get(), 1);
+        assert_eq!(total.with_label_values(&["fetch_error"]).get(), 0);
+        assert_eq!(total.with_label_values(&["store_error"]).get(), 0);
+    }
+
+    /// Mirrors the `registry.gather()` text-encode path that `actix-web-prom`
+    /// serves on `/api/metrics`, asserting the series surface under their names.
+    #[test]
+    fn metrics_surface_on_the_shared_registry() {
+        use prometheus::{Encoder as _, TextEncoder};
+
+        let registry = Registry::new();
+        let metrics = CalendarMetrics::new(&registry).unwrap();
+        metrics.record_scrape(ScrapeResult::Success);
+        metrics
+            .rooms_by_freshness
+            .with_label_values(&["never"])
+            .set(3);
+
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&registry.gather(), &mut buf)
+            .unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        assert!(text.contains(r#"navigatum_api_calendar_scrape_total{result="success"} 1"#));
+        assert!(text.contains(r#"navigatum_api_calendar_rooms_by_freshness{bucket="never"} 3"#));
+    }
 }


### PR DESCRIPTION
Adds two bounded-cardinality Prometheus series to the existing public `/api/metrics` endpoint so calendar-scraper health is observable directly.