### PR TITLE
ci: gate docker image publish on the pipeline's own checks

### DIFF
--- a/.github/workflows/martin-cicd.yml
+++ b/.github/workflows/martin-cicd.yml
@@ -147,6 +147,8 @@ jobs:
         run: bash map/martin/test/render-e2e.sh
 
   build:
+    # Don't publish until the checks that guard what the image bakes in pass (render-e2e boots the baked config).
+    needs: [ validate-planetiler-custommap, validate-planetiler-schema, validate-style, render-e2e ]
     uses: ./.github/workflows/_docker-build.yml
     with:
       image_suffix: martin

--- a/.github/workflows/server-cicd.yml
+++ b/.github/workflows/server-cicd.yml
@@ -67,6 +67,8 @@ jobs:
           CARGO_NET_RETRY: 10
           CARGO_HTTP_MULTIPLEXING: false
   build:
+    # Don't publish until tests and lints pass, so a red build never reaches :main.
+    needs: [ shear, tests, linting ]
     uses: ./.github/workflows/_docker-build.yml
     with:
       image_suffix: server

--- a/.github/workflows/webclient-cicd.yml
+++ b/.github/workflows/webclient-cicd.yml
@@ -26,6 +26,8 @@ jobs:
       - run: pnpm run test
         working-directory: webclient
   build:
+    # Don't publish until lint, type-check, and tests pass, so a red build never reaches :main.
+    needs: [ lint ]
     uses: ./.github/workflows/_docker-build.yml
     with:
       image_suffix: webclient


### PR DESCRIPTION
## What

Each `*-cicd` `build` job calls `_docker-build.yml` with **no `needs`**, so the image build+push ran in parallel with — and independently of — that pipeline's own tests, lints, and validation. On a push to `main`, the image was published to `:main` regardless of whether those checks passed.

For **martin** this is how the broken config shipped: `render-e2e` boots martin against the baked `config.yaml`, so it *did* fail on the unescaped `${DATABASE_URL:...}` default — but because `build` didn't depend on it, the broken image was published anyway. That's the mismatch #3384 chased and #3385 (7cf4a4d9) finally corrected. The end-to-end guard existed but gated nothing.

## Change

Add `needs` so each `build` publishes only after its own checks are green:

- **martin** → `validate-planetiler-custommap`, `validate-planetiler-schema`, `validate-style`, `render-e2e`
- **server** → `shear`, `tests`, `linting`
- **webclient** → `lint` (lint + type-check + test)

Trades a little pipeline parallelism for the guarantee that a red build never reaches `:main`. Build cache (`:buildcache`) keeps the now-gated builds cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)