### PR TITLE
feat(compose): add Prometheus scrape labels and a Postgres exporter

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,7 @@ services:
       - "prometheus.scrape=true"
       - "prometheus.port=3000"
       - "prometheus.path=/metrics"
+      - "prometheus.job=navigatum-webclient"
     networks:
       - traefik_traefik
     expose:
@@ -33,6 +34,7 @@ services:
       - "prometheus.scrape=true"
       - "prometheus.port=3003"
       - "prometheus.path=/api/metrics"
+      - "prometheus.job=navigatum-api"
     networks:
       - traefik_traefik
     expose:
@@ -114,6 +116,7 @@ services:
       - "prometheus.scrape=true"
       - "prometheus.port=9187"
       - "prometheus.path=/metrics"
+      - "prometheus.job=navigatum-postgres"
     depends_on:
       db:
         condition: service_healthy
@@ -284,6 +287,7 @@ services:
       - "prometheus.scrape=true"
       - "prometheus.port=3001"
       - "prometheus.path=/_/metrics"
+      - "prometheus.job=navigatum-martin"
     networks:
       - traefik_traefik
     expose:

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,9 @@ services:
       - "traefik.http.routers.navigatum-webclient.tls.certresolver=leacme"
       - "traefik.http.routers.navigatum-webclient.rule=Host(`nav.tum.de`)"
       - "traefik.http.services.navigatum-webclient.loadbalancer.server.port=3000"
+      - "prometheus.scrape=true"
+      - "prometheus.port=3000"
+      - "prometheus.path=/metrics"
     networks:
       - traefik_traefik
     expose:
@@ -27,6 +30,9 @@ services:
       - "traefik.http.routers.navigatum-server.tls.certresolver=leacme"
       - "traefik.http.routers.navigatum-server.rule=Host(`nav.tum.de`) && (PathPrefix(`/api`) || PathPrefix(`/cdn`))"
       - "traefik.http.services.navigatum-server.loadbalancer.server.port=3003"
+      - "prometheus.scrape=true"
+      - "prometheus.port=3003"
+      - "prometheus.path=/api/metrics"
     networks:
       - traefik_traefik
     expose:
@@ -94,6 +100,23 @@ services:
       interval: 10s
       start_interval: 500ms
       start_period: 20s
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.17.1
+    restart: unless-stopped
+    environment:
+      TZ: Europe/Berlin
+      DATA_SOURCE_NAME: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable
+    networks:
+      - traefik_traefik
+    expose:
+      - "9187"
+    labels:
+      - "prometheus.scrape=true"
+      - "prometheus.port=9187"
+      - "prometheus.path=/metrics"
+    depends_on:
+      db:
+        condition: service_healthy
   download-data:
     image: alpine:latest
     command: sh /map/download.sh europe/germany/bayern/oberbayern
@@ -258,6 +281,9 @@ services:
       - "traefik.http.routers.navigatum-martin.middlewares=navigatum-martin-cache-headers@docker"
       - "traefik.http.middlewares.navigatum-martin-cache-headers.headers.customresponseheaders.Cache-Control=public, max-age 86400, stale-if-error 86400" # 1 day
       - "traefik.http.services.navigatum-martin.loadbalancer.server.port=3001"
+      - "prometheus.scrape=true"
+      - "prometheus.port=3001"
+      - "prometheus.path=/_/metrics"
     networks:
       - traefik_traefik
     expose:


### PR DESCRIPTION
Expose metrics for Prometheus scraping via `prometheus.*` container labels, matching the label-discovery contract Alloy already runs in the deployment (`prometheus.scrape` / `port` / `path` / `job`). Each is pointed at its real endpoint:

| service | job | metrics source | port | path |
|---|---|---|---|---|
| webclient | `navigatum-webclient` | native (`prom-client`, `server/routes/metrics.get.ts`) | 3000 | `/metrics` |
| server | `navigatum-api` | native (`actix_web_prom`) | 3003 | `/api/metrics` |
| martin | `navigatum-martin` | native (already exposed via the `/_/` router) | 3001 | `/_/metrics` |
| db | `navigatum-postgres` | new `postgres_exporter` sidecar | 9187 | `/metrics` |

### Notes

- Ports/paths are each service's real endpoint rather than a single generic value, so scrapes actually resolve.
- Explicit `prometheus.job` labels keep targets grouped per service (otherwise Alloy defaults them all to `job="discovered"`).
- Postgres has no built-in Prometheus endpoint, so a `postgres_exporter` sidecar is added against `db` (internal only, no Traefik route).
- **Nominatim** has no maintained native exporter, but it's already covered by Traefik's per-router metrics (`addRoutersLabels`), so no change is needed for it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)