### PR TITLE
fix(ci): request martin tiles under the /martin route prefix in render-e2e

### DIFF
--- a/map/martin/test/render-e2e.sh
+++ b/map/martin/test/render-e2e.sh
@@ -25,6 +25,10 @@ FIXTURE_PBF="${FIXTURE_PBF:-/tmp/navigatum-e2e-fixture.osm.pbf}"
 MBTILES_OUT="${MBTILES_OUT:-/tmp/navigatum-e2e-output.mbtiles}"
 OSM2PGSQL_IMAGE="iboates/osm2pgsql:latest"   # same image as compose.yml
 MARTIN_PORT=3001
+# config.yaml serves every source under /martin (route_prefix), which prod no longer strips
+# (compose.yml dropped the traefik stripprefix), so tile/style requests must keep the prefix.
+# /health stays at the root; martin serves it there regardless of route_prefix.
+MARTIN_BASE="http://localhost:${MARTIN_PORT}/martin"
 DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}"
 export PGPASSWORD
 
@@ -101,10 +105,10 @@ wget -q -O /tmp/maki.zip https://github.com/mapbox/maki/zipball/main
 rm -rf /tmp/maki && mkdir -p /tmp/maki "$RUNDIR/sprites/maki" && unzip -q /tmp/maki.zip -d /tmp/maki
 mv /tmp/maki/mapbox-maki-*/icons/* "$RUNDIR/sprites/maki/"
 # The style's martin sources are absolute prod URLs; the renderer fetches tiles over HTTP, so
-# point them at this martin (root base path) instead of production. localhost:3001 works both
-# from the runner (curl) and inside the container (the renderer self-fetches). The /cdn
-# natural-earth raster is low-zoom only and unused at z18, so it's left alone.
-sed -i "s#https://nav.tum.de/martin#http://localhost:${MARTIN_PORT}#g" "$RUNDIR/styles/navigatum-basemap.json"
+# point them at this martin instead of production, keeping the /martin prefix it serves under.
+# localhost:3001 works both from the runner (curl) and inside the container (the renderer
+# self-fetches). The /cdn natural-earth raster is low-zoom only and unused at z18, so it's left alone.
+sed -i "s#https://nav.tum.de/martin#${MARTIN_BASE}#g" "$RUNDIR/styles/navigatum-basemap.json"
 endlog
 
 log "run martin"
@@ -156,11 +160,11 @@ read -r tx ty < <(awk -v lon="$clon" -v lat="$clat" -v z="$czoom" 'BEGIN {
   printf "%d %d\n", int((lon + 180) / 360 * n), int((1 - log(sin(rad)/cos(rad) + 1/cos(rad)) / pi) / 2 * n)
 }')
 log "assert indoor tile $czoom/$tx/$ty"
-assert_serves "http://localhost:${MARTIN_PORT}/indoor_rooms,indoor_pois,indoor_walls,indoor_doors/${czoom}/${tx}/${ty}?level=0.0"
+assert_serves "${MARTIN_BASE}/indoor_rooms,indoor_pois,indoor_walls,indoor_doors/${czoom}/${tx}/${ty}?level=0.0"
 endlog
 
 log "assert static basemap render"
-assert_serves "http://localhost:${MARTIN_PORT}/style/navigatum-basemap/static/${RENDER_CAMERA}/${RENDER_SIZE}.png" /tmp/render.png
+assert_serves "${MARTIN_BASE}/style/navigatum-basemap/static/${RENDER_CAMERA}/${RENDER_SIZE}.png" /tmp/render.png
 [ -s /tmp/render.png ] || { echo "ERROR: render returned an empty image" >&2; exit 1; }
 endlog
 


### PR DESCRIPTION
## What

The `map / render-e2e` gate has been failing on `main` and on **every open PR** (including the Renovate lockfile/bump PRs #3401, #3395, #3394) since #3384/#3385. Those PRs moved the tileserver behind a `/martin` route prefix in production — `config.yaml` set `base_path`/`route_prefix: /martin` and `compose.yml` dropped traefik's `stripprefix` — but `render-e2e.sh` still requested tiles at the **root** path.

Martin now serves every source under `/martin`, so the indoor-tile and static-render assertions returned `404` on every run:

```
attempt 1: http=404
...
ERROR: http://localhost:3001/indoor_rooms,indoor_pois,indoor_walls,indoor_doors/18/139568/90838?level=0.0 never succeeded
```

`/health` kept passing because martin serves it at the root regardless of the route prefix, which is why the failure looked like a tile/data problem rather than a path problem.

## Fix

Point the tile request, the static-render request, and the style-URL rewrite the renderer self-fetches at `${MARTIN_BASE}` (`localhost:3001/martin`) so the gate exercises the real production path. The health probe stays at the root, matching martin's behaviour.

No product code changes — this only corrects the test harness to match the config #3384/#3385 shipped.

## Verification

Test-harness-only change with no local runtime surface; the `render-e2e` job on this PR is the real validation. The causal chain is confirmed from the failing run's logs: all four indoor functions register as published sources, `/health` succeeds at the root, and root-path tile requests `404` — consistent with the `/martin` prefix added in #3384/#3385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtFfBpparG57iiCJ3jeNAu