### PR TITLE
chore(deps): bump martin back to latest

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,7 +23,7 @@ services:
       NUXT_PUBLIC_API_URL: https://nav.tum.de
       NUXT_PUBLIC_CALENDAR_URL: https://nav.tum.de
   server:
-    image: ghcr.io/tum-dev/navigatum-server:main
+    image: ghcr.io/tum-dev/navigatum-server:latest
     restart: unless-stopped
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
This pull request updates the `server` service configuration in `compose.yml` to use the `latest` image tag instead of `main`. This ensures that the deployment always uses the most recent version of the server image.