### PR TITLE
fix(webclient): guard calendar against null event end (#3424)

### DIFF
--- a/webclient/app/components/CalendarFull.vue
+++ b/webclient/app/components/CalendarFull.vue
@@ -172,9 +172,7 @@ function refetchEvents() {
         >
           <template v-if="arg.view.type == 'timeGridWeek' || arg.view.type == 'timeGridDay'">
             <span class="font-medium">{{ arg.event.title }}</span>
-            <span class="font-normal opacity-70"
-              >{{ arg.timeText }} - {{ arg.event.end.toLocaleTimeString("de", { timeStyle: "short" }) }}</span
-            >
+            <span class="font-normal opacity-70">{{ arg.timeText }}{{ calendarEventEndLabel(arg.event.end) }}</span>
           </template>
           <template v-else-if="arg.view.type == 'listWeek'">
             <span class="font-medium">{{ arg.event.title }}</span>

--- a/webclient/app/utils/datetime.ts
+++ b/webclient/app/utils/datetime.ts
@@ -56,3 +56,10 @@ export function formatEventDateRange(
     year: "numeric",
   }).formatRange(start, end);
 }
+
+// FullCalendar nulls `end` for zero- or negative-duration events (end <= start), so the end
+// label must tolerate null and collapse to just the start time (#3424).
+export function calendarEventEndLabel(end: Date | null): string {
+  if (end === null) return "";
+  return ` - ${end.toLocaleTimeString("de", { timeStyle: "short" })}`;
+}

--- a/webclient/test/datetime.test.ts
+++ b/webclient/test/datetime.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  calendarEventEndLabel,
   findDuplicateEventByName,
   formatEventDateRange,
   rfc3339ToWallTime,
@@ -127,5 +128,17 @@ describe("findDuplicateEventByName", () => {
   it.each(["", "   ", "a", " a "])("returns null for the too-short query %j", (query) => {
     const a = entry("a", "2026-06-19T18:00:00Z");
     expect(findDuplicateEventByName([a], query, NOW)).toBeNull();
+  });
+});
+
+describe("calendarEventEndLabel", () => {
+  // #3424: FullCalendar nulls `end` for zero-duration events (e.g. "2331.EG.113"),
+  // and the template used to call `.toLocaleTimeString` on it directly, crashing the calendar.
+  it("returns an empty string when end is null", () => {
+    expect(calendarEventEndLabel(null)).toBe("");
+  });
+
+  it("renders a ` - HH:MM` suffix for a real end", () => {
+    expect(calendarEventEndLabel(new Date("2026-07-06T08:00:00Z"))).toBe(" - 10:00");
   });
 });


### PR DESCRIPTION
Fixes #3424.

## Problem

Viewing the calendar for a room with a zero-duration event (`start_at === end_at`, e.g. `2331.EG.113`) crashed with:

```
TypeError: Cannot read properties of null (reading 'toLocaleTimeString')
```

## Root cause

FullCalendar nulls out an event's `end` whenever it is not strictly after `start` (`@fullcalendar/core/internal-common.js:3269` — `if (startMarker && endMarker <= startMarker) { endMarker = null; }`). The `timeGrid` event template in `CalendarFull.vue` dereferenced that null directly (`arg.event.end.toLocaleTimeString(...)`). Because the default view is `timeGridWeek`, any such event in the current week crashes the calendar on load; rooms without zero-duration events are unaffected.

`2331.EG.113` currently has two such events on 2026-07-10 (two ZHS *Kursball* entries with identical start/end).

## Fix

Extract a null-tolerant `calendarEventEndLabel(end: Date | null)` helper that collapses to just the start time when `end` is null, and use it in the template. Added regression tests in `test/datetime.test.ts` (verified red without the guard — reproduces the exact `TypeError` — and green with it).

Type-check and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)