### PR TITLE
fix(search): make buildings findable by their own short_name (utg)

### DIFF
--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -226,7 +226,6 @@ def export_for_search(data: dict[str, Entry]) -> None:
                 "room_code": _id,
                 "room_code_normalised": normalise_id(_id),
                 "name": _de(entry["name"]),
-                # Own short_name; without this only rooms borrow it (via parent_building_names), not the entry itself.
                 "short_name": _de(entry.get("short_name")),
                 "arch_name": entry.get("arch_name"),
                 "arch_name_normalised": normalise_id(entry.get("arch_name", "")),

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -226,6 +226,8 @@ def export_for_search(data: dict[str, Entry]) -> None:
                 "room_code": _id,
                 "room_code_normalised": normalise_id(_id),
                 "name": _de(entry["name"]),
+                # Own short_name; without this only rooms borrow it (via parent_building_names), not the entry itself.
+                "short_name": _de(entry.get("short_name")),
                 "arch_name": entry.get("arch_name"),
                 "arch_name_normalised": normalise_id(entry.get("arch_name", "")),
                 "aliases": entry.get("aliases", []),

--- a/data/processors/test_export_search.py
+++ b/data/processors/test_export_search.py
@@ -1,0 +1,63 @@
+"""Regression tests for the /search export document (TUM-Dev/NavigaTUM#3399)."""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+from pipeline_types import Entry
+from utils import TranslatableStr
+
+import processors.export as export_mod
+from processors.export import export_for_search
+from processors.images import ImageSource
+
+
+def _data() -> dict[str, Entry]:
+    """Minimal chain root -> garching -> 5204 (short_name UTG), mirroring the real areatree line."""
+    return {
+        "root": {"id": "root", "type": "root", "name": TranslatableStr("Standorte", "Sites"), "parents": []},
+        "garching": {
+            "id": "garching",
+            "type": "site",
+            "name": TranslatableStr("Garching", "Garching"),
+            "type_common_name": TranslatableStr("Standort", "Site"),
+            "parents": ["root"],
+            "ranking_factors": {"rank_combined": 100},
+        },
+        "5204": {
+            "id": "5204",
+            "type": "building",
+            "name": TranslatableStr("Umformtechnik und Gießereiwesen (MW25)", "Metal Forming and Casting"),
+            "short_name": "UTG",
+            "visible_id": "utg",
+            "type_common_name": TranslatableStr("Gebäude", "Building"),
+            "parents": ["root", "garching"],
+            "ranking_factors": {"rank_combined": 100},
+        },
+    }
+
+
+def _search_docs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> pl.DataFrame:
+    """Run the real search export against `_data()` in isolation and read back the documents."""
+    monkeypatch.setattr(export_mod, "OUTPUT_DIR_PATH", tmp_path)
+    monkeypatch.setattr(export_mod, "load_events", list)
+    monkeypatch.setattr(export_mod, "event_search_documents", lambda *_a, **_k: [])
+    monkeypatch.setattr(ImageSource, "load_all", classmethod(lambda _cls: {}))
+    export_for_search(_data())
+    return pl.read_parquet(tmp_path / "search_data.parquet")
+
+
+def test_building_own_short_name_is_indexed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A building's own short_name reaches its search document, so `utg` finds building 5204 itself (#3399)."""
+    df = _search_docs(tmp_path, monkeypatch)
+    building = next(r for r in df.to_dicts() if r["room_code"] == "5204")
+
+    assert building["short_name"] == "UTG"
+
+
+def test_entries_without_a_short_name_index_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Entries lacking a short_name emit null (not an empty string), matching other optional fields."""
+    df = _search_docs(tmp_path, monkeypatch)
+    garching = next(r for r in df.to_dicts() if r["room_code"] == "garching")
+
+    assert garching["short_name"] is None

--- a/server/src/setup/meilisearch.rs
+++ b/server/src/setup/meilisearch.rs
@@ -86,6 +86,7 @@ pub async fn setup(client: &Client) -> anyhow::Result<()> {
             "room_code",
             "room_code_normalised",
             "name",
+            "short_name",
             "arch_name",
             "arch_name_normalised",
             "aliases",


### PR DESCRIPTION
Index an entry's own short_name so buildings are findable by it (e.g. `utg` → building 5204), not just their rooms.

Resolves #3399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C68SFW5SzGt8mJBkbee1DG