### PR TITLE
fix(webclient): show fallback instead of console errors when WebGL2 is unavailable

### DIFF
--- a/webclient/app/components/DetailsInteractiveMap.vue
+++ b/webclient/app/components/DetailsInteractiveMap.vue
@@ -186,9 +186,11 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
 
 // --- Loading components ---
 onMounted(async () => {
+  window.scrollTo({ top: 0, behavior: "auto" });
+  // Without WebGL2 the map container is never rendered, so `until` below would wait forever.
+  if (!webglSupport.value) return;
   await until(mapContainer).toBeTruthy();
   loadInteractiveMap();
-  window.scrollTo({ top: 0, behavior: "auto" });
 });
 
 onBeforeUnmount(() => {

--- a/webclient/app/components/LocationPickerInline.vue
+++ b/webclient/app/components/LocationPickerInline.vue
@@ -108,6 +108,8 @@ watch(
 );
 
 onMounted(async () => {
+  // Without WebGL2 the map container is never rendered, so `until` below would wait forever.
+  if (!webglSupport.value) return;
   await until(mapContainer).toBeTruthy();
   await initMap();
 });

--- a/webclient/app/components/LocationPickerModal.vue
+++ b/webclient/app/components/LocationPickerModal.vue
@@ -150,6 +150,8 @@ watch(
 );
 
 onMounted(async () => {
+  // Without WebGL2 the map container is never rendered, so `until` below would wait forever.
+  if (!webglSupport.value) return;
   await until(mapContainer).toBeTruthy();
   await initMap();
 });

--- a/webclient/app/composables/webglSupport.ts
+++ b/webclient/app/composables/webglSupport.ts
@@ -1,18 +1,19 @@
-// MapLibre GL v6 surfaces unavailable GPU contexts (no WebGL2 etc.) through the map's `error`
-// event as a `GPUInitializationError`, instead of letting consumers probe support up-front. We
-// keep an optimistic ref, attach to a constructed map, and flip the ref on the first such error
-// so the calling component can render the not-supported fallback.
+// MapLibre v6 initialises WebGL2 inside the `Map` constructor and, when it fails, synchronously fires
+// and logs a `GPUInitializationError` before any `map.on("error")` handler can exist. Probe up-front
+// so callers skip building (and logging errors for) a doomed map; the listener covers a runtime loss.
 import { GPUInitializationError, type Map as MapLibreMap } from "maplibre-gl";
 
 export interface WebglGuard {
-  /** Optimistic; flips to false once a `GPUInitializationError` is observed on the map. */
   readonly supported: Readonly<Ref<boolean>>;
-  /** Wire up the guard against a freshly-constructed map. Safe to call once per map. */
   attach(map: MapLibreMap): void;
 }
 
+function hasWebgl2(): boolean {
+  return document.createElement("canvas").getContext("webgl2") !== null;
+}
+
 export function useWebglGuard(): WebglGuard {
-  const supported = ref(true);
+  const supported = ref(import.meta.client ? hasWebgl2() : true);
   return {
     supported,
     attach(map) {

--- a/webclient/app/composables/webglSupport.ts
+++ b/webclient/app/composables/webglSupport.ts
@@ -1,6 +1,3 @@
-// MapLibre v6 initialises WebGL2 inside the `Map` constructor and, when it fails, synchronously fires
-// and logs a `GPUInitializationError` before any `map.on("error")` handler can exist. Probe up-front
-// so callers skip building (and logging errors for) a doomed map; the listener covers a runtime loss.
 import { GPUInitializationError, type Map as MapLibreMap } from "maplibre-gl";
 
 export interface WebglGuard {


### PR DESCRIPTION
## Problem

On the MapLibre v6 upgrade, browsers without WebGL2 get a broken blank map plus two console errors instead of the not-supported fallback:

```
GPUInitializationError: WebGL2 is required to display this map. ...
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at ... marker.addTo (DetailsInteractiveMap.vue)
```

**Root cause.** MapLibre v6 creates its WebGL2 context *synchronously inside the `Map` constructor*. When the context can't be created it does `this.fire(new ErrorEvent(new GPUInitializationError(...)))` and returns a map with no `painter`, all before the constructor returns:

```js
this._setupContainer(), this._setupPainter(), !this.painter) return;
```

So the `map.on("error")` handler we attached *after* `new Map()` never observes it — MapLibre logs it as unhandled, and the code then calls `marker.addTo(brokenMap)`, which throws. A post-construction listener fundamentally cannot catch (or silence) an error fired inside the constructor.

## Fix

Probe WebGL2 up-front (`canvas.getContext("webgl2")`) so the map is never constructed when unsupported. No error is fired or logged, and the existing `webglSupport` guards render `MapGLNotSupported`. The `error` listener is kept for a GPU context that is lost and fails to restore at runtime. Mount hooks that `await until(mapContainer)` now bail early, since that container is never rendered when unsupported.

## Notes

- Touches the five map surfaces sharing `useWebglGuard` (`DetailsInteractiveMap`, `IndoorMap`, both `LocationPicker*`, `map.vue`); the composable change fixes them centrally, with mount-hook bails added where a container wait would otherwise hang.
- I validated the new MapLibre v6 API usage against the `6.0.0-20` type definitions, but could not run the full `nuxt typecheck` locally: the working tree's `node_modules` still has maplibre `5.24.0` while `package.json` pins `6.0.0-20`, so a local typecheck fails on the pre-existing v6 import rather than this change. **Please confirm CI runs against a fresh install.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)