### PR TITLE
test(server): move znn from bad to good queries

### DIFF
--- a/server/src/search_executor/test-queries.bad.yaml
+++ b/server/src/search_executor/test-queries.bad.yaml
@@ -75,9 +75,3 @@
   comment: >-
     H.003 is the correct room, but people have problems remembering how many
     zeroes are in the room number
-- target: '5115'
-  query: znn
-  comment: >-
-    '5115' (ZNN) no longer surfaces in the top result for 'znn' as the index
-    evolved; recorded as a known non-match rather than chasing live-CDN ranking
-    drift.

--- a/server/src/search_executor/test-queries.good.yaml
+++ b/server/src/search_executor/test-queries.good.yaml
@@ -69,6 +69,11 @@
 - target: 5115.01.010
   query: 1010 znn
   comment: Not sure about target here
+- target: '5115'
+  query: znn
+  comment: >-
+    '5115' (ZNN) surfaces as the top result again; previously parked in the .bad
+    list while the index temporarily ranked it lower.
 - target: 5433.EG.092
   query: 0092@5433
 - target: 5510.EG.026M


### PR DESCRIPTION
The `znn` search-benchmark query now reliably surfaces `5115` at rank 1 against current index data, so it moves from the known-non-match list to the good list.