### PR TITLE
fix(server): normalise leading zeros in letter-prefixed room-code searches

### DIFF
--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -415,7 +415,7 @@ pub async fn do_geoentry_search(
         .clone()
         .into_iter()
         .map(|s| match s {
-            TextToken::Text(t) => t,
+            TextToken::Text(t) => parser::strip_room_code_leading_zeros(&t),
             TextToken::SplittableText((t1, t2)) => format!("{t1} {t2} {t1}{t2}"),
         })
         .collect::<Vec<String>>()

--- a/server/src/search_executor/parser.rs
+++ b/server/src/search_executor/parser.rs
@@ -23,6 +23,33 @@ impl Debug for ParsedQuery {
     }
 }
 
+/// Normalises a room code like `H.003` that was typed with a mis-remembered number
+/// of leading zeros (`H.03`, `H.0003`) to the zero-stripped form Meilisearch treats as
+/// canonical (`H.3`). Purely numeric tokens are left untouched, because leading zeros
+/// are significant in architect names (`00.01.001`) and ids (`5604.00.011`) - stripping
+/// them there loses the match.
+pub fn strip_room_code_leading_zeros(token: &str) -> String {
+    if !token.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        return token.to_string();
+    }
+    let mut out = String::with_capacity(token.len());
+    let mut chars = token.chars().peekable();
+    while let Some(c) = chars.next() {
+        if !c.is_ascii_digit() {
+            out.push(c);
+            continue;
+        }
+        let mut run = String::from(c);
+        while chars.peek().is_some_and(char::is_ascii_digit) {
+            run.push(chars.next().expect("peeked digit is present"));
+        }
+        // an all-zero run keeps a single digit so the code stays well-formed.
+        let trimmed = run.trim_start_matches('0');
+        out.push_str(if trimmed.is_empty() { "0" } else { trimmed });
+    }
+    out
+}
+
 impl ParsedQuery {
     pub fn relevant_enough_for_room_highligting(&self) -> bool {
         if self.tokens.len() == 1 {
@@ -63,6 +90,24 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn room_code_leading_zeros() {
+        // letter-prefixed room codes drop insignificant leading zeros per digit run
+        assert_eq!(strip_room_code_leading_zeros("H.03"), "H.3");
+        assert_eq!(strip_room_code_leading_zeros("H.0003"), "H.3");
+        assert_eq!(strip_room_code_leading_zeros("H.003"), "H.3");
+        assert_eq!(strip_room_code_leading_zeros("H.3"), "H.3");
+        // no leading zeros -> unchanged
+        assert_eq!(strip_room_code_leading_zeros("C.3202"), "C.3202");
+        assert_eq!(strip_room_code_leading_zeros("N-1406"), "N-1406");
+        // an all-zero run collapses to a single zero
+        assert_eq!(strip_room_code_leading_zeros("H.00"), "H.0");
+        // purely numeric architect names and ids keep their significant zeros
+        assert_eq!(strip_room_code_leading_zeros("00.01.001"), "00.01.001");
+        assert_eq!(strip_room_code_leading_zeros("5604.00.011"), "5604.00.011");
+        assert_eq!(strip_room_code_leading_zeros("0092@5433"), "0092@5433");
+    }
 
     #[test]
     fn text_token() {

--- a/server/src/search_executor/test-queries.bad.yaml
+++ b/server/src/search_executor/test-queries.bad.yaml
@@ -62,14 +62,3 @@
 - target: 0104.01.406
   query: N1406
   comment: Architects names should be matchable literally
-# leading zeros are normalised on the query side as well
-- target: 2910.EG.003
-  query: H.03
-  comment: >-
-    H.003 is the correct room, but people have problems remembering how many
-    zeroes are in the room number
-- target: 2910.EG.003
-  query: H.0003
-  comment: >-
-    H.003 is the correct room, but people have problems remembering how many
-    zeroes are in the room number

--- a/server/src/search_executor/test-queries.good.yaml
+++ b/server/src/search_executor/test-queries.good.yaml
@@ -106,9 +106,19 @@
   query: n1403
   among: 2
   comment: "This is 'N-1403@0104', but 'N1403@0104' can be before this"
-# leading zeros are normalised
+# leading zeros are normalised on the query side, so any zero-count matches
 - target: 2910.EG.003
   query: H.3
+  comment: >-
+    H.003 is the correct room, but people have problems remembering how many
+    zeroes are in the room number
+- target: 2910.EG.003
+  query: H.03
+  comment: >-
+    H.003 is the correct room, but people have problems remembering how many
+    zeroes are in the room number
+- target: 2910.EG.003
+  query: H.0003
   comment: >-
     H.003 is the correct room, but people have problems remembering how many
     zeroes are in the room number


### PR DESCRIPTION
Strip insignificant leading zeros from digit runs in letter-prefixed search tokens so mis-remembered zero counts like `H.03` and `H.0003` resolve to room `2910.EG.003`, while purely numeric architect names and ids keep their significant zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYC2GLjAjPE3DDZMCoaEBZ