### PR TITLE
chore(deps): update spin to 0.9.9 to clear the yanked-crate warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
Bumps the never-compiled `spin` lockfile entry from the yanked 0.9.8 to 0.9.9 so `cargo audit` stops reporting a yanked crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaGHo6NKeaHL8waZYuAvKe