### PR TITLE
docs(server,webclient): surface the blind-profile public-transit fallback

### DIFF
--- a/server/src/routes/maps/route/mod.rs
+++ b/server/src/routes/maps/route/mod.rs
@@ -228,11 +228,6 @@ struct RoutingRequest {
 }
 
 /// Does the user have specific walking needs?
-///
-/// **Note:** For public transit routes, `blind` currently falls back to standard walking
-/// because the routing engine ([MOTIS](https://github.com/motis-project/motis)) does not
-/// offer a blind-specific pedestrian profile yet.
-/// Walking routes honour the profile via more detailed route instructions.
 #[derive(Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 enum PedestrianTypeRequest {

--- a/server/src/routes/maps/route/mod.rs
+++ b/server/src/routes/maps/route/mod.rs
@@ -228,6 +228,11 @@ struct RoutingRequest {
 }
 
 /// Does the user have specific walking needs?
+///
+/// **Note:** For public transit routes, `blind` currently falls back to standard walking
+/// because the routing engine ([MOTIS](https://github.com/motis-project/motis)) does not
+/// offer a blind-specific pedestrian profile yet.
+/// Walking routes honour the profile via more detailed route instructions.
 #[derive(Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 enum PedestrianTypeRequest {
@@ -249,6 +254,7 @@ impl From<PedestrianTypeRequest> for PedestrianType {
 impl From<PedestrianTypeRequest> for PedestrianProfile {
     fn from(value: PedestrianTypeRequest) -> Self {
         match value {
+            // MOTIS does not offer a blind-specific pedestrian profile yet.
             PedestrianTypeRequest::Standard | PedestrianTypeRequest::Blind => Self::Foot,
             PedestrianTypeRequest::Wheelchair => Self::Wheelchair,
         }

--- a/webclient/app/components/PreferencesPopup.vue
+++ b/webclient/app/components/PreferencesPopup.vue
@@ -273,6 +273,13 @@ async function updateLocale(value: "de" | "en") {
                 </Tab>
               </TabList>
             </TabGroup>
+            <Toast
+              v-if="preferences.pedestrian_type === 'blind'"
+              id="pedestrian-blind-fallback"
+              level="info"
+              class="mt-3"
+              :msg="t('pedestrian.blindFallback')"
+            />
           </div>
 
           <!-- Bicycle Type Setting -->
@@ -375,6 +382,7 @@ de:
   pedestrianType.help: Wählen Sie dies, falls Sie Barrierefreiheit benötigen wie Ansagen oder Aufzüge.
   pedestrian.standard: Standard
   pedestrian.blind: Blind
+  pedestrian.blindFallback: Für öffentliche Verkehrsmittel unterstützt die Routing-Engine noch kein blindengerechtes Routing. Diese Routen werden derzeit wie normales Gehen berechnet.
   pedestrian.wheelchair: Rollstuhl
   bicycleType: Fahrrad-Typ
   bicycleType.help: Dies beeinflusst welche Wege für Sie ausgewählt werden. Rennräder meiden unbefestigte Wege.
@@ -412,6 +420,7 @@ en:
   pedestrianType.help: Select this if you need accessibility features like narration or elevators.
   pedestrian.standard: Standard
   pedestrian.blind: Blind
+  pedestrian.blindFallback: The routing engine does not support blind-specific routing for public transit yet. Those routes are currently calculated as standard walking.
   pedestrian.wheelchair: Wheelchair
   bicycleType: Bicycle Type
   bicycleType.help: This affects which paths are selected for you. Road bikes avoid unpaved paths.


### PR DESCRIPTION
Closes #3454 — states in the OpenAPI schema description and a bilingual preferences-popup hint that the blind pedestrian profile falls back to standard walking on public transit routes (only the MOTIS path collapses it; walking routes via Valhalla honour the profile), leaving routing behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)