### PR TITLE
feat(webclient): floor-aware route display on /navigate

### DIFF
--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -2,12 +2,14 @@
 import type { GeoJSONSource } from "maplibre-gl";
 import { GeolocateControl, Map as MapLibreMap, Marker, NavigationControl } from "maplibre-gl";
 import type { components } from "~/api_types";
+import { FloorControl } from "~/composables/FloorControl";
 import { useSharedGeolocation } from "~/composables/geolocation";
 import { useWebglGuard } from "~/composables/webglSupport";
 import { zoomForLocationType } from "~/utils/map";
 import {
   calculateItineraryBounds,
   calculateLegBounds,
+  calculateStepBounds,
   decodeMotisGeometry,
   extractPlatformChangeMarkers,
   getTransitModeStyle,
@@ -16,6 +18,7 @@ import {
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
 type Coordinate = components["schemas"]["Coordinate"];
 type ItineraryResponse = components["schemas"]["ItineraryResponse"];
+type StepInstructionResponse = components["schemas"]["StepInstructionResponse"];
 
 // Simplified GeoJSON Feature type to avoid deep type inference
 interface SimpleGeoJSONFeature {
@@ -36,6 +39,7 @@ const map = shallowRef<MapLibreMap | undefined>(undefined);
 const marker = shallowRef<Marker | undefined>(undefined);
 const afterLoaded = ref<() => void>(() => {});
 const geolocateControl = ref<GeolocateControl | undefined>(undefined);
+const floorControl = shallowRef<FloorControl | undefined>(undefined);
 const { supported: webglSupport, attach: attachWebglGuard } = useWebglGuard();
 
 // Geolocation state
@@ -146,6 +150,17 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
 
     mapInstance.addControl(location);
     geolocateControl.value = location;
+
+    // Not at setup: the FloorControl constructor touches `document`, absent on the server.
+    const floors = new FloorControl();
+    mapInstance.addControl(floors, "top-left");
+    // Floors only render from zoom 17, so picking one while zoomed out would show nothing.
+    floors.on("level-changed", (event: { level: number | null }) => {
+      if (event.level !== null && mapInstance.getZoom() < 17) {
+        mapInstance.easeTo({ zoom: 17, duration: 2000 });
+      }
+    });
+    floorControl.value = floors;
 
     // Add Valhalla route source and layers
     mapInstance.addSource("route", {
@@ -454,6 +469,23 @@ function focusOnMotisLeg(legIndex: number, itinerary: ItineraryResponse) {
 }
 
 /**
+ * Focus map on a single step of a leg, falling back to the whole leg when the
+ * step's polyline cannot be decoded.
+ */
+function focusOnMotisStep(
+  step: StepInstructionResponse,
+  legIndex: number,
+  itinerary: ItineraryResponse
+) {
+  const bounds = calculateStepBounds(step);
+  if (bounds) {
+    fitBounds([bounds.minLon, bounds.maxLon], [bounds.minLat, bounds.maxLat]);
+  } else {
+    focusOnMotisLeg(legIndex, itinerary);
+  }
+}
+
+/**
  * Clear all Motis routes and symbols
  */
 function clearMotisRoutes() {
@@ -488,6 +520,11 @@ function triggerGeolocation() {
   geolocateControl.value?.trigger();
 }
 
+/** Switch the floor selector (and thus the indoor layers) to the given level. */
+function setFloor(level: number | null) {
+  floorControl.value?.setLevel(level);
+}
+
 defineExpose({
   drawRoute,
   fitBounds,
@@ -495,8 +532,10 @@ defineExpose({
   drawMotisItinerary,
   highlightMotisLeg,
   focusOnMotisLeg,
+  focusOnMotisStep,
   clearMotisRoutes,
   triggerGeolocation,
+  setFloor,
 });
 </script>
 
@@ -549,6 +588,89 @@ defineExpose({
     height: 24px;
     top: -20px;
     left: -12px;
+  }
+}
+
+.maplibregl-ctrl-group.floor-ctrl {
+  max-width: 100%;
+  display: block;
+  overflow: hidden;
+
+  &.closed #floor-list {
+    display: none !important;
+  }
+
+  & button {
+    &.active {
+      background: #ececec;
+    }
+
+    & .arrow {
+      font-weight: normal;
+      font-size: 0.3rem;
+      line-height: 0.9rem;
+      vertical-align: top;
+    }
+  }
+
+  &.reduced > .vertical-oc,
+  &.reduced > .horizontal-oc {
+    display: none !important;
+  }
+
+  & > .vertical-oc,
+  & > .horizontal-oc {
+    font-weight: bold;
+    background: #ececec;
+  }
+
+  &.closed {
+    & > .vertical-oc,
+    & > .horizontal-oc {
+      background: #fff;
+    }
+
+    &:hover > .vertical-oc,
+    &:hover > .horizontal-oc {
+      background: #f2f2f2;
+    }
+  }
+
+  /* vertical is default layout */
+
+  & > .horizontal-oc {
+    display: none;
+  }
+
+  &.horizontal {
+    & > .horizontal-oc {
+      display: inline-block;
+    }
+
+    & > .vertical-oc {
+      display: none;
+    }
+
+    & #floor-list {
+      display: inline-block;
+      width: calc(100% - var(--map-ctrl-button-size));
+    }
+
+    & button {
+      display: inline-block;
+      border-top: 0;
+      border-left: 1px solid #ddd;
+
+      &.arrow {
+        font-size: 0.4rem;
+        vertical-align: bottom;
+        line-height: 1.1rem;
+      }
+
+      & + button {
+        border-top: 0;
+      }
+    }
   }
 }
 </style>

--- a/webclient/app/components/MotisDirectConnections.vue
+++ b/webclient/app/components/MotisDirectConnections.vue
@@ -11,6 +11,7 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{
   selectLeg: [itineraryIndex: number, legIndex: number];
+  selectStep: [itineraryIndex: number, legIndex: number, stepIndex: number];
 }>();
 
 const { t } = useI18n({ useScope: "local" });
@@ -35,14 +36,6 @@ const formatDuration = (seconds: number) => {
   }
   return t("seconds", seconds);
 };
-
-// Helper function to format distance
-const formatDistance = (meters: number) => {
-  if (meters >= 1000) {
-    return t("kilometers", [(meters / 1000).toFixed(1)]);
-  }
-  return t("meters", Math.round(meters));
-};
 </script>
 
 <template>
@@ -56,24 +49,17 @@ const formatDistance = (meters: number) => {
           {{ formatDuration(itinerary.duration) }}
         </span>
       </div>
-      <div
-        v-for="(leg, j) in itinerary.legs"
-        :key="`direct-leg-${j}`"
-        class="group cursor-pointer py-1"
-        @click="emit('selectLeg', i, j)"
-      >
-        <div
-          class="bg-white dark:bg-black flex flex-row items-center gap-3 overflow-auto rounded-md border p-3 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800"
-        >
-          <MotisTransitModeIcon :mode="leg.mode" />
-          <div class="flex-grow">
-            <div class="text-zinc-900 dark:text-zinc-50 font-medium">{{ leg.from.name }} → {{ leg.to.name }}</div>
-            <div class="text-zinc-600 dark:text-zinc-300 text-sm">
-              {{ formatDuration(leg.duration) }}
-              <span v-if="leg.distance"> • {{ formatDistance(leg.distance) }}</span>
-            </div>
-          </div>
-        </div>
+      <div class="divide-y">
+        <MotisTransitLeg
+          v-for="(leg, j) in itinerary.legs"
+          :key="`direct-leg-${j}`"
+          :leg="leg"
+          :itinerary="itinerary"
+          :leg-index="j"
+          :itinerary-index="i"
+          @select-leg="(itineraryIndex, legIndex) => emit('selectLeg', itineraryIndex, legIndex)"
+          @select-step="(itineraryIndex, legIndex, stepIndex) => emit('selectStep', itineraryIndex, legIndex, stepIndex)"
+        />
       </div>
     </div>
   </div>
@@ -84,13 +70,9 @@ de:
   direct_connections: Direkte Verbindungen
   minutes: "sofort | eine Minute | {count} Minuten"
   seconds: "sofort | eine Sekunde | {count} Sekunden"
-  meters: "hier | einen Meter | {count} Meter"
-  kilometers: "{0} Kilometer"
 
 en:
   direct_connections: Direct connections
   minutes: "instant | one minute | {count} minutes"
   seconds: "instant | one second | {count} seconds"
-  meters: "here | one meter | {count} meters"
-  kilometers: "{0} kilometers"
 </i18n>

--- a/webclient/app/components/MotisNavigationRoutingResults.vue
+++ b/webclient/app/components/MotisNavigationRoutingResults.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   selectLeg: [itineraryIndex: number, legIndex: number];
+  selectStep: [itineraryIndex: number, legIndex: number, stepIndex: number];
   selectItinerary: [itineraryIndex: number];
   loadPrevious: [cursor: string];
   loadNext: [cursor: string];
@@ -312,11 +313,15 @@ const getTransitLegs = (legs: readonly MotisLegResponse[]) => {
         <!-- Direct connection details -->
         <div v-if="selectedItineraryIndex < 0">
           <template v-if="data.direct[Math.abs(selectedItineraryIndex + 1)]">
+            <!-- The negative `-1 - i` index tells the page this is a direct connection. -->
             <MotisDirectConnections
               :connections="[data.direct[Math.abs(selectedItineraryIndex + 1)]!]"
               @select-leg="
-                (_, legIndex) =>
-                  selectedItineraryIndex !== null && emit('selectLeg', Math.abs(selectedItineraryIndex + 1), legIndex)
+                (_, legIndex) => selectedItineraryIndex !== null && emit('selectLeg', selectedItineraryIndex, legIndex)
+              "
+              @select-step="
+                (_, legIndex, stepIndex) =>
+                  selectedItineraryIndex !== null && emit('selectStep', selectedItineraryIndex, legIndex, stepIndex)
               "
             />
           </template>
@@ -329,6 +334,7 @@ const getTransitLegs = (legs: readonly MotisLegResponse[]) => {
               :itinerary="data.itineraries[selectedItineraryIndex]!"
               :itinerary-index="selectedItineraryIndex"
               @select-leg="(itineraryIndex, legIndex) => emit('selectLeg', itineraryIndex, legIndex)"
+              @select-step="(itineraryIndex, legIndex, stepIndex) => emit('selectStep', itineraryIndex, legIndex, stepIndex)"
               @select-itinerary="emit('selectItinerary', $event)"
             />
           </template>

--- a/webclient/app/components/MotisTransitItinerary.vue
+++ b/webclient/app/components/MotisTransitItinerary.vue
@@ -12,6 +12,7 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{
   selectLeg: [itineraryIndex: number, legIndex: number];
+  selectStep: [itineraryIndex: number, legIndex: number, stepIndex: number];
   selectItinerary: [itineraryIndex: number];
 }>();
 
@@ -68,6 +69,7 @@ const formatDuration = (seconds: number) => {
         :leg-index="j"
         :itinerary-index="itineraryIndex"
         @select-leg="(itineraryIndex, legIndex) => emit('selectLeg', itineraryIndex, legIndex)"
+        @select-step="(itineraryIndex, legIndex, stepIndex) => emit('selectStep', itineraryIndex, legIndex, stepIndex)"
       />
     </div>
   </div>

--- a/webclient/app/components/MotisTransitLeg.vue
+++ b/webclient/app/components/MotisTransitLeg.vue
@@ -16,6 +16,7 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{
   selectLeg: [itineraryIndex: number, legIndex: number];
+  selectStep: [itineraryIndex: number, legIndex: number, stepIndex: number];
 }>();
 
 const { t } = useI18n({ useScope: "local" });
@@ -314,14 +315,21 @@ const previousLeg = computed(() => getPreviousLegInfo(props.legIndex));
         <!-- Walking Instructions -->
         <div v-if="leg.steps && leg.steps.length > 0" class="mt-3">
           <details class="group">
+            <!-- `.stop`: opening the list must not re-select the leg. -->
             <summary
               class="text-zinc-600 dark:text-zinc-300 cursor-pointer text-sm font-medium hover:text-zinc-800 dark:hover:text-zinc-100 flex items-center gap-2"
+              @click.stop
             >
               {{ t("walking_instructions") }}
               <span class="text-zinc-400 dark:text-zinc-500 text-xs">({{ leg.steps.length }} {{ t("steps") }})</span>
             </summary>
             <div class="mt-2 space-y-2 pl-4">
-              <div v-for="(step, k) in leg.steps" :key="`step-${k}`" class="flex items-start gap-3 py-1">
+              <div
+                v-for="(step, k) in leg.steps"
+                :key="`step-${k}`"
+                class="flex items-start gap-3 rounded px-2 py-1 -mx-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                @click.stop="emit('selectStep', itineraryIndex, legIndex, k)"
+              >
                 <WalkingDirectionIcon :direction="step.relative_direction" />
                 <div class="flex-grow text-sm">
                   <div class="text-zinc-900 dark:text-zinc-50">
@@ -330,6 +338,9 @@ const previousLeg = computed(() => getPreviousLegInfo(props.legIndex));
                   </div>
                   <div class="text-zinc-600 dark:text-zinc-300 text-xs flex items-center gap-2">
                     {{ formatDistance(step.distance) }}
+                    <span v-if="step.from_level !== step.to_level" class="text-zinc-500 dark:text-zinc-400">
+                      {{ t("level") }} {{ step.from_level }} → {{ step.to_level }}
+                    </span>
                     <span v-if="step.elevation_up || step.elevation_down" class="text-zinc-500 dark:text-zinc-400">
                       <span v-if="step.elevation_up">↗ {{ step.elevation_up }}m</span>
                       <span v-if="step.elevation_down">↘ {{ step.elevation_down }}m</span>

--- a/webclient/app/pages/navigate.vue
+++ b/webclient/app/pages/navigate.vue
@@ -9,6 +9,7 @@ import Toast from "~/components/Toast.vue";
 import { clientOnlyRetries, firstOrDefault } from "~/composables/common";
 import type { TimeSelection } from "~/types/navigation";
 import { entityPath, isEntityType } from "~/utils/entityPath";
+import { floorLevelForSelection } from "~/utils/motisLevels";
 
 // Utility function to parse coordinate IDs and convert to coordinate objects
 function parseCoordinateId(value: string): { lat: number; lon: number } | string {
@@ -96,10 +97,11 @@ watch(
     if (!newData || !newMap) return;
     if (newData.router === "valhalla") newMap.drawRoute(newData.legs[0].shape);
     if (newData.router === "motis") {
-      selectedItineraryIndex.value = 0;
-      if (newData.itineraries.length > 0 && newData.itineraries[0]) {
-        newMap.drawMotisItinerary(newData.itineraries[0]);
-      }
+      // A door-to-door query often yields only a direct (walk) connection.
+      const initialIndex = newData.itineraries.length > 0 ? 0 : -1;
+      selectedItineraryIndex.value = initialIndex;
+      const itinerary = initialIndex === 0 ? newData.itineraries[0] : newData.direct[0];
+      if (itinerary) newMap.drawMotisItinerary(itinerary);
     }
   },
   { immediate: true }
@@ -209,31 +211,58 @@ function handleSelectManeuver(payload: { begin_shape_index: number; end_shape_in
   setBoundingBoxFromIndex(payload.begin_shape_index, payload.end_shape_index);
 }
 
+// Index convention: `0..` are the transit itineraries, `-1 - i` the i-th direct connection.
+function motisItineraryAt(itineraryIndex: number) {
+  if (!motisData.value) return undefined;
+  return itineraryIndex >= 0
+    ? motisData.value.itineraries[itineraryIndex]
+    : motisData.value.direct[-itineraryIndex - 1];
+}
+
 function handleSelectLeg(itineraryIndex: number, legIndex: number) {
-  if (data.value?.router === "motis" && indoorMap.value) {
-    // If selecting a different itinerary, redraw the route
-    if (selectedItineraryIndex.value !== itineraryIndex) {
-      selectedItineraryIndex.value = itineraryIndex;
-      if (data.value.itineraries[itineraryIndex]) {
-        indoorMap.value.drawMotisItinerary(data.value.itineraries[itineraryIndex]);
-      }
-    }
+  const itinerary = motisItineraryAt(itineraryIndex);
+  if (!itinerary || !indoorMap.value) return;
 
-    // Highlight the selected leg on the map
-    indoorMap.value.highlightMotisLeg(legIndex);
-
-    // Focus map on the selected leg
-    if (data.value.itineraries[itineraryIndex]) {
-      indoorMap.value.focusOnMotisLeg(legIndex, data.value.itineraries[itineraryIndex]);
-    }
+  // If selecting a different itinerary, redraw the route
+  if (selectedItineraryIndex.value !== itineraryIndex) {
+    selectedItineraryIndex.value = itineraryIndex;
+    indoorMap.value.drawMotisItinerary(itinerary);
   }
+
+  indoorMap.value.highlightMotisLeg(legIndex);
+
+  // Switch floors before fitting bounds so the fit's camera animation wins.
+  const leg = itinerary.legs[legIndex];
+  const floor = leg ? floorLevelForSelection(leg) : null;
+  if (floor !== null) indoorMap.value.setFloor(floor);
+
+  indoorMap.value.focusOnMotisLeg(legIndex, itinerary);
+}
+
+function handleSelectStep(itineraryIndex: number, legIndex: number, stepIndex: number) {
+  const itinerary = motisItineraryAt(itineraryIndex);
+  const leg = itinerary?.legs[legIndex];
+  const step = leg?.steps?.[stepIndex];
+  if (!itinerary || !leg || !step || !indoorMap.value) return;
+
+  if (selectedItineraryIndex.value !== itineraryIndex) {
+    selectedItineraryIndex.value = itineraryIndex;
+    indoorMap.value.drawMotisItinerary(itinerary);
+  }
+
+  indoorMap.value.highlightMotisLeg(legIndex);
+
+  const floor = floorLevelForSelection(leg, step);
+  if (floor !== null) indoorMap.value.setFloor(floor);
+
+  indoorMap.value.focusOnMotisStep(step, legIndex, itinerary);
 }
 
 function handleSelectItinerary(itineraryIndex: number) {
-  if (data.value?.router === "motis" && indoorMap.value && data.value.itineraries[itineraryIndex]) {
-    selectedItineraryIndex.value = itineraryIndex;
-    indoorMap.value.drawMotisItinerary(data.value.itineraries[itineraryIndex]);
-  }
+  const itinerary = motisItineraryAt(itineraryIndex);
+  if (!itinerary || !indoorMap.value) return;
+  selectedItineraryIndex.value = itineraryIndex;
+  indoorMap.value.drawMotisItinerary(itinerary);
 }
 </script>
 
@@ -300,6 +329,7 @@ function handleSelectItinerary(itineraryIndex: number) {
         :data="motisData"
         v-model:page-cursor="motisPageCursor"
         @select-leg="handleSelectLeg"
+        @select-step="handleSelectStep"
         @select-itinerary="handleSelectItinerary"
       />
       <div v-else-if="status === 'pending'" class="text-zinc-900 dark:text-zinc-50 flex flex-col items-center gap-5 py-32">

--- a/webclient/app/utils/motis.ts
+++ b/webclient/app/utils/motis.ts
@@ -5,6 +5,7 @@ type ItineraryResponse = components["schemas"]["ItineraryResponse"];
 type ModeResponse = components["schemas"]["ModeResponse"];
 type Coordinate = components["schemas"]["Coordinate"];
 type PlaceResponse = components["schemas"]["PlaceResponse"];
+type StepInstructionResponse = components["schemas"]["StepInstructionResponse"];
 
 // Platform change marker type
 export interface PlatformChangeMarker {
@@ -80,6 +81,35 @@ export function calculateLegBounds(
   let maxLat = Math.max(from.lat, to.lat);
   let minLon = Math.min(from.lon, to.lon);
   let maxLon = Math.max(from.lon, to.lon);
+
+  for (const coord of coordinates) {
+    minLat = Math.min(minLat, coord.lat);
+    maxLat = Math.max(maxLat, coord.lat);
+    minLon = Math.min(minLon, coord.lon);
+    maxLon = Math.max(maxLon, coord.lon);
+  }
+
+  return { minLat, maxLat, minLon, maxLon };
+}
+
+/**
+ * Calculate the bounding box of a single step's polyline, or `null` when the
+ * polyline cannot be decoded.
+ */
+export function calculateStepBounds(step: StepInstructionResponse): {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+} | null {
+  const coordinates = decodeMotisGeometry(step.polyline);
+  const first = coordinates[0];
+  if (!first) return null;
+
+  let minLat = first.lat;
+  let maxLat = first.lat;
+  let minLon = first.lon;
+  let maxLon = first.lon;
 
   for (const coord of coordinates) {
     minLat = Math.min(minLat, coord.lat);

--- a/webclient/app/utils/motisLevels.ts
+++ b/webclient/app/utils/motisLevels.ts
@@ -1,0 +1,31 @@
+import type { components } from "~/api_types";
+import { SELECTABLE_LEVELS } from "~/composables/mapLayers";
+
+type MotisLegResponse = components["schemas"]["MotisLegResponse"];
+type StepInstructionResponse = components["schemas"]["StepInstructionResponse"];
+
+/** All OSM levels a leg touches: its endpoints plus every step transition. */
+function legLevels(leg: MotisLegResponse): number[] {
+  const levels = [leg.from.level, leg.to.level];
+  for (const step of leg.steps ?? []) {
+    levels.push(step.from_level, step.to_level);
+  }
+  return levels;
+}
+
+/**
+ * The floor the indoor map should switch to when the user selects a leg or one of
+ * its steps, or `null` when the selection should leave the floor selector untouched.
+ *
+ * Motis reports level 0 for plain outdoor geometry too, so a leg only counts as
+ * level-aware when some part of it leaves the ground level. Levels the floor
+ * selector cannot represent (half-levels, deep basements) also yield `null`.
+ */
+export function floorLevelForSelection(
+  leg: MotisLegResponse,
+  step?: StepInstructionResponse
+): number | null {
+  if (legLevels(leg).every((touched) => touched === 0)) return null;
+  const level = step ? step.from_level : leg.from.level;
+  return SELECTABLE_LEVELS.includes(level) ? level : null;
+}

--- a/webclient/test/motis.test.ts
+++ b/webclient/test/motis.test.ts
@@ -1,0 +1,106 @@
+import { encode } from "@googlemaps/polyline-codec";
+import { describe, expect, it } from "vitest";
+import type { components } from "../app/api_types";
+import { calculateStepBounds } from "../app/utils/motis";
+import { floorLevelForSelection } from "../app/utils/motisLevels";
+
+type MotisLegResponse = components["schemas"]["MotisLegResponse"];
+type PlaceResponse = components["schemas"]["PlaceResponse"];
+type StepInstructionResponse = components["schemas"]["StepInstructionResponse"];
+
+function place(level: number): PlaceResponse {
+  return { lat: 48.26, lon: 11.67, level, name: "somewhere" };
+}
+
+function step(fromLevel: number, toLevel: number, polyline = ""): StepInstructionResponse {
+  return {
+    area: false,
+    distance: 10,
+    exit: "",
+    from_level: fromLevel,
+    to_level: toLevel,
+    polyline,
+    relative_direction: "continue",
+    stay_on: false,
+    street_name: "corridor",
+  };
+}
+
+function walkLeg(opts: {
+  fromLevel: number;
+  toLevel: number;
+  steps?: StepInstructionResponse[];
+}): MotisLegResponse {
+  return {
+    duration: 60,
+    start_time: "2026-07-15T12:00:00Z",
+    end_time: "2026-07-15T12:01:00Z",
+    scheduled_start_time: "2026-07-15T12:00:00Z",
+    scheduled_end_time: "2026-07-15T12:01:00Z",
+    from: place(opts.fromLevel),
+    to: place(opts.toLevel),
+    leg_geometry: "",
+    mode: "walk",
+    real_time: false,
+    scheduled: true,
+    route_color: "FFFFFF",
+    route_text_color: "000000",
+    steps: opts.steps,
+  };
+}
+
+describe("floorLevelForSelection", () => {
+  it("leaves the floor untouched for an all-ground-level leg", () => {
+    const leg = walkLeg({ fromLevel: 0, toLevel: 0, steps: [step(0, 0)] });
+    expect(floorLevelForSelection(leg)).toBeNull();
+    expect(floorLevelForSelection(leg, step(0, 0))).toBeNull();
+  });
+
+  it("switches to the leg's starting level when the leg is level-aware", () => {
+    expect(floorLevelForSelection(walkLeg({ fromLevel: 2, toLevel: 0 }))).toBe(2);
+    // An indoor leg legitimately starting on the ground floor still selects it.
+    expect(floorLevelForSelection(walkLeg({ fromLevel: 0, toLevel: 2 }))).toBe(0);
+  });
+
+  it("treats a leg with only step-level transitions as level-aware", () => {
+    const leg = walkLeg({ fromLevel: 0, toLevel: 0, steps: [step(0, 1), step(1, 0)] });
+    expect(floorLevelForSelection(leg)).toBe(0);
+  });
+
+  it("switches to the step's starting level when a step is selected", () => {
+    const stairs = step(1, 2);
+    const leg = walkLeg({ fromLevel: 0, toLevel: 2, steps: [step(0, 1), stairs] });
+    expect(floorLevelForSelection(leg, stairs)).toBe(1);
+  });
+
+  it("skips levels the floor selector cannot represent", () => {
+    // Half-levels and deep basements have no floor selector button.
+    expect(floorLevelForSelection(walkLeg({ fromLevel: 1.5, toLevel: 2 }))).toBeNull();
+    expect(floorLevelForSelection(walkLeg({ fromLevel: -2, toLevel: 0 }))).toBeNull();
+    const basementStep = step(-2, -3);
+    const leg = walkLeg({ fromLevel: -2, toLevel: -3, steps: [basementStep] });
+    expect(floorLevelForSelection(leg, basementStep)).toBeNull();
+  });
+});
+
+describe("calculateStepBounds", () => {
+  it("spans the step's polyline", () => {
+    const polyline = encode(
+      [
+        [48.1, 11.6],
+        [48.2, 11.5],
+      ],
+      6
+    );
+    expect(calculateStepBounds(step(0, 0, polyline))).toEqual({
+      minLat: 48.1,
+      maxLat: 48.2,
+      minLon: 11.5,
+      maxLon: 11.6,
+    });
+  });
+
+  it("is null for an undecodable polyline", () => {
+    expect(calculateStepBounds(step(0, 0, ""))).toBeNull();
+  });
+});


### PR DESCRIPTION
Wires the floor selector into /navigate so selecting a Motis leg or walking step switches the indoor map to its level, and fixes direct (door-to-door) connections never being drawn due to a wrong itinerary index.

Closes #3453

🤖 Generated with [Claude Code](https://claude.com/claude-code)