### PR TITLE
fix(webclient): anchor navigate autocomplete to its own field

### DIFF
--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -15,18 +15,12 @@ const { t, locale } = useI18n({ useScope: "local" });
 const route = useRoute();
 const router = useRouter();
 const currently_actively_picking = ref(false);
-// Tracks real input focus (distinct from `currently_actively_picking`, which only governs the
-// autocomplete dropdown and is cleared as soon as an entry is picked). The search button keys off
-// this so it stays visible while the field is being edited and autohides once focus leaves.
 const isFocused = ref(false);
 
-// Use shared geolocation state
 const geolocationState = useSharedGeolocation();
 
-// Track if this search bar is currently searching for location
 const isSearchingLocation = ref(false);
 
-// Watch for location updates for this specific search bar
 watch(
   () => geolocationState.value.userLocation,
   (location) => {
@@ -35,18 +29,15 @@ watch(
       selected.value = `${location.lat},${location.lon}`;
       currently_actively_picking.value = false;
       isSearchingLocation.value = false;
-      // Clear the triggering search bar ID
       geolocationState.value.triggeringSearchBarId = null;
     }
   }
 );
 
-// Watch for when geolocation request is cleared (due to error or completion)
 watch(
   () => geolocationState.value.triggeringSearchBarId,
   (triggeringId) => {
     if (triggeringId !== props.queryId && isSearchingLocation.value) {
-      // This search bar was searching but is no longer the triggering one
       isSearchingLocation.value = false;
     }
   }
@@ -67,8 +58,6 @@ const selected = useRouteQuery<string>(props.queryId, "", {
   router,
 });
 const highlighted = ref<number>(0);
-// Per-facet expand state (sites/buildings/rooms can freeze with
-// `n_visible < entries.length`).
 const expandedFacets = ref<Set<ResultsSectionFacet>>(new Set());
 
 const visibleElements = computed<string[]>(() => {
@@ -100,14 +89,11 @@ function select(id: string) {
 }
 
 function useCurrentLocation() {
-  // Show searching message immediately
   query.value = t("gps.searching_location");
   currently_actively_picking.value = false;
   isSearchingLocation.value = true;
 
-  // Mark this search bar as the one that triggered geolocation
   geolocationState.value.triggeringSearchBarId = props.queryId;
-  // Trigger the map's geolocation control
   geolocationState.value.shouldTriggerMapGeolocation = true;
 }
 
@@ -178,126 +164,121 @@ const { data, error } = await useFetch<SearchResponse>(url, {
 </script>
 
 <template>
-  <div
-    class="bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 flex flex-grow flex-row rounded-s-sm border focus-within:outline focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-blue-600 dark:focus-within:outline-blue-300"
-  >
-    <textarea
-      :id="queryId"
-      v-model="query"
-      cols="1"
-      rows="2"
-      :title="t('input.aria-searchlabel')"
-      aria-autocomplete="both"
-      aria-haspopup="false"
-      autocapitalize="off"
-      autocomplete="off"
-      spellcheck="false"
-      maxlength="2048"
-      :name="queryId"
-      type="text"
-      class="text-zinc-800 dark:text-zinc-100 flex-grow resize-none bg-transparent py-2.5 ps-3 pe-2 text-sm font-semibold placeholder:text-zinc-800 dark:placeholder:text-zinc-100 focus-within:placeholder:text-zinc-500 dark:focus-within:placeholder:text-zinc-400 placeholder:font-normal focus:outline-0"
-      :placeholder="t('input.placeholder-' + queryId)"
-      :aria-label="t('input.aria-searchlabel')"
-      @focus="
-        isFocused = true;
-        currently_actively_picking = true;
-        highlighted = 0;
-      "
-      @blur="isFocused = false"
-      @keydown="onKeyDown"
-    />
-    <!--
-      Offer to search only while the field is focused and already holds a selected endpoint: without
-      an id there is nothing to route, and a button lingering after blur is just noise. `mousedown`
-      is prevented so the click does not blur the textarea first, which would hide this very button
-      before the click lands.
-    -->
-    <button
-      v-if="selected && isFocused"
-      type="submit"
-      class="focusable text-zinc-600 dark:text-zinc-300 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900 flex items-center justify-center px-3 py-2.5 transition-all duration-200 rounded-sm"
-      :title="t('search_route')"
-      :aria-label="t('search_route')"
-      @mousedown.prevent
-      @click="currently_actively_picking = false"
+  <div class="relative flex flex-grow flex-col">
+    <div
+      class="bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 flex flex-row rounded-s-sm border focus-within:outline focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-blue-600 dark:focus-within:outline-blue-300"
     >
-      <MdiIcon :path="mdiMagnify" :size="16" />
-    </button>
-    <ClientOnly>
+      <textarea
+        :id="queryId"
+        v-model="query"
+        cols="1"
+        rows="2"
+        :title="t('input.aria-searchlabel')"
+        aria-autocomplete="both"
+        aria-haspopup="false"
+        autocapitalize="off"
+        autocomplete="off"
+        spellcheck="false"
+        maxlength="2048"
+        :name="queryId"
+        type="text"
+        class="text-zinc-800 dark:text-zinc-100 flex-grow resize-none bg-transparent py-2.5 ps-3 pe-2 text-sm font-semibold placeholder:text-zinc-800 dark:placeholder:text-zinc-100 focus-within:placeholder:text-zinc-500 dark:focus-within:placeholder:text-zinc-400 placeholder:font-normal focus:outline-0"
+        :placeholder="t('input.placeholder-' + queryId)"
+        :aria-label="t('input.aria-searchlabel')"
+        @focus="
+          isFocused = true;
+          currently_actively_picking = true;
+          highlighted = 0;
+        "
+        @blur="isFocused = false"
+        @keydown="onKeyDown"
+      />
       <button
-        v-if="isGeolocationSupported && !geolocationState.mapGeolocationActive"
-        type="button"
-        class="focusable text-zinc-600 dark:text-zinc-300 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900 flex items-center justify-center px-3 py-2.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent rounded-sm text-xs font-medium whitespace-nowrap"
-        :title="t('gps.use_current_location')"
-        :aria-label="t('gps.use_current_location')"
-        @click="useCurrentLocation"
+        v-if="selected && isFocused"
+        type="submit"
+        class="focusable text-zinc-600 dark:text-zinc-300 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900 flex items-center justify-center px-3 py-2.5 transition-all duration-200 rounded-sm"
+        :title="t('search_route')"
+        :aria-label="t('search_route')"
+        @mousedown.prevent
+        @click="currently_actively_picking = false"
       >
-        <MdiIcon
-          :path="mdiCrosshairsGps"
-          :size="16"
-          :class="[
-            'mr-1',
-            {
-              'text-blue-600 dark:text-blue-300 animate-pulse': isSearchingLocation,
-              'text-zinc-600 dark:text-zinc-300': !isSearchingLocation,
-            },
-          ]"
-        />
+        <MdiIcon :path="mdiMagnify" :size="16" />
       </button>
+      <ClientOnly>
+        <button
+          v-if="isGeolocationSupported && !geolocationState.mapGeolocationActive"
+          type="button"
+          class="focusable text-zinc-600 dark:text-zinc-300 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900 flex items-center justify-center px-3 py-2.5 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent rounded-sm text-xs font-medium whitespace-nowrap"
+          :title="t('gps.use_current_location')"
+          :aria-label="t('gps.use_current_location')"
+          @click="useCurrentLocation"
+        >
+          <MdiIcon
+            :path="mdiCrosshairsGps"
+            :size="16"
+            :class="[
+              'mr-1',
+              {
+                'text-blue-600 dark:text-blue-300 animate-pulse': isSearchingLocation,
+                'text-zinc-600 dark:text-zinc-300': !isSearchingLocation,
+              },
+            ]"
+          />
+        </button>
+      </ClientOnly>
+    </div>
+    <ClientOnly>
+      <div
+        v-if="currently_actively_picking && data && query.length !== 0"
+        class="shadow-4xl bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 absolute inset-x-0 top-full z-30 mt-1 flex max-h-[calc(100vh-80px)] flex-col gap-4 overflow-auto rounded border p-3.5 shadow-zinc-700/30 dark:shadow-zinc-200/30"
+      >
+        <Toast v-if="error" id="search-error" level="error">
+          <p class="text-md font-bold">{{ t("error.header") }}</p>
+          <p class="text-sm">
+            {{ t("error.reason") }}:<br />
+            <code
+              class="text-red-900 dark:text-red-50 bg-red-200 mb-1 mt-2 inline-flex max-w-full items-center space-x-2 overflow-auto rounded-md px-4 py-3 text-left font-mono text-xs dark:bg-red-900/20"
+            >
+              {{ error }}
+            </code>
+          </p>
+          <p class="text-sm">{{ t("error.call_to_action") }}</p>
+        </Toast>
+        <ul v-for="s in data.sections" v-cloak :key="s.facet" class="flex flex-col gap-2">
+          <div class="flex items-center">
+            <span class="text-md text-zinc-800 dark:text-zinc-100 me-4 flex-shrink">{{ t(`sections.${s.facet}`) }}</span>
+            <div class="border-zinc-800 dark:border-zinc-100 flex-grow border-t" />
+          </div>
+
+          <template v-for="(e, i) in tagSectionEntries(s)" :key="e.id">
+            <SearchResultContent
+              v-if="expandedFacets.has(s.facet) || i < s.n_visible"
+              :highlighted="e.id === visibleElements[highlighted ?? -1]"
+              :item="e"
+              @mousedown.prevent
+              @click="select(e.id)"
+              @mouseover="highlighted = i"
+            />
+          </template>
+          <li class="-mt-2">
+            <Btn
+              v-if="!expandedFacets.has(s.facet) && s.n_visible < s.entries.length"
+              variant="linkButton"
+              size="sm"
+              @click="expandedFacets = new Set([...expandedFacets, s.facet])"
+            >
+              {{ t("show_hidden", s.entries.length - s.n_visible) }}
+            </Btn>
+            <span class="text-zinc-400 dark:text-zinc-500 text-sm">
+              {{
+                s.estimatedTotalHits > 20 ? t("approx_results", s.estimatedTotalHits) : t("results", s.estimatedTotalHits)
+              }}
+            </span>
+          </li>
+        </ul>
+      </div>
     </ClientOnly>
   </div>
-  <!-- Autocomplete -->
-  <ClientOnly>
-    <div
-      v-if="currently_actively_picking && data && query.length !== 0"
-      class="shadow-4xl bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 absolute top-3 z-30 -ms-4 mt-56 flex max-h-[calc(100vh-80px)] min-w-96 max-w-sm flex-col gap-4 overflow-auto rounded border p-3.5 shadow-zinc-700/30 dark:shadow-zinc-200/30 md:me-3"
-    >
-      <Toast v-if="error" id="search-error" level="error">
-        <p class="text-md font-bold">{{ t("error.header") }}</p>
-        <p class="text-sm">
-          {{ t("error.reason") }}:<br />
-          <code
-            class="text-red-900 dark:text-red-50 bg-red-200 mb-1 mt-2 inline-flex max-w-full items-center space-x-2 overflow-auto rounded-md px-4 py-3 text-left font-mono text-xs dark:bg-red-900/20"
-          >
-            {{ error }}
-          </code>
-        </p>
-        <p class="text-sm">{{ t("error.call_to_action") }}</p>
-      </Toast>
-      <ul v-for="s in data.sections" v-cloak :key="s.facet" class="flex flex-col gap-2">
-        <div class="flex items-center">
-          <span class="text-md text-zinc-800 dark:text-zinc-100 me-4 flex-shrink">{{ t(`sections.${s.facet}`) }}</span>
-          <div class="border-zinc-800 dark:border-zinc-100 flex-grow border-t" />
-        </div>
-
-        <template v-for="(e, i) in tagSectionEntries(s)" :key="e.id">
-          <SearchResultContent
-            v-if="expandedFacets.has(s.facet) || i < s.n_visible"
-            :highlighted="e.id === visibleElements[highlighted ?? -1]"
-            :item="e"
-            @mousedown.prevent
-            @click="select(e.id)"
-            @mouseover="highlighted = i"
-          />
-        </template>
-        <li class="-mt-2">
-          <Btn
-            v-if="!expandedFacets.has(s.facet) && s.n_visible < s.entries.length"
-            variant="linkButton"
-            size="sm"
-            @click="expandedFacets = new Set([...expandedFacets, s.facet])"
-          >
-            {{ t("show_hidden", s.entries.length - s.n_visible) }}
-          </Btn>
-          <span class="text-zinc-400 dark:text-zinc-500 text-sm">
-            {{
-              s.estimatedTotalHits > 20 ? t("approx_results", s.estimatedTotalHits) : t("results", s.estimatedTotalHits)
-            }}
-          </span>
-        </li>
-      </ul>
-    </div>
-  </ClientOnly>
 </template>
 
 <i18n lang="yaml">

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -16,6 +16,11 @@ const route = useRoute();
 const router = useRouter();
 const currently_actively_picking = ref(false);
 const isFocused = ref(false);
+const searchWrapper = ref<HTMLElement | null>(null);
+const { focused: wrapperFocused } = useFocusWithin(searchWrapper);
+watch(wrapperFocused, (focused) => {
+  if (!focused) currently_actively_picking.value = false;
+});
 
 const geolocationState = useSharedGeolocation();
 
@@ -164,7 +169,7 @@ const { data, error } = await useFetch<SearchResponse>(url, {
 </script>
 
 <template>
-  <div class="relative flex flex-grow flex-col">
+  <div ref="searchWrapper" class="relative flex flex-grow flex-col">
     <div
       class="bg-zinc-200 dark:bg-zinc-700 border-zinc-400 dark:border-zinc-500 flex flex-row rounded-s-sm border focus-within:outline focus-within:outline-2 focus-within:outline-offset-1 focus-within:outline-blue-600 dark:focus-within:outline-blue-300"
     >


### PR DESCRIPTION
Anchors each navigate search bar's autocomplete beneath its own field with `inset-x-0 top-full` instead of a fixed `mt-56` drop, so the dropdown tracks whichever of the stacked from/to fields is focused.