### PR TITLE
feat(webclient): clarify foot-leg levels and transitions on /navigate

### DIFF
--- a/webclient/app/components/IndoorMap.vue
+++ b/webclient/app/components/IndoorMap.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { GeoJSONSource } from "maplibre-gl";
+import type { ExpressionSpecification, GeoJSONSource } from "maplibre-gl";
 import { GeolocateControl, Map as MapLibreMap, Marker, NavigationControl } from "maplibre-gl";
 import type { components } from "~/api_types";
 import { FloorControl } from "~/composables/FloorControl";
@@ -10,9 +10,9 @@ import {
   calculateItineraryBounds,
   calculateLegBounds,
   calculateStepBounds,
-  decodeMotisGeometry,
   extractPlatformChangeMarkers,
   getTransitModeStyle,
+  splitLegByLevel,
 } from "~/utils/motis";
 
 type LocationDetailsResponse = components["schemas"]["LocationDetailsResponse"];
@@ -47,6 +47,8 @@ const geolocationState = useSharedGeolocation();
 
 // Motis routing state
 const highlightedLegIndex = ref<number | null>(null);
+// The floor the selector currently shows, so the walk route can emphasise its on-floor part.
+const currentLevel = ref<number | null>(null);
 const zoom = computed<number>(() => zoomForLocationType(props.type));
 
 onMounted(async () => {
@@ -156,6 +158,8 @@ async function initMap(containerId: string): Promise<MapLibreMap> {
     mapInstance.addControl(floors, "top-left");
     // Floors only render from zoom 17, so picking one while zoomed out would show nothing.
     floors.on("level-changed", (event: { level: number | null }) => {
+      currentLevel.value = event.level;
+      applyWalkLevelStyling(event.level);
       if (event.level !== null && mapInstance.getZoom() < 17) {
         mapInstance.easeTo({ zoom: 17, duration: 2000 });
       }
@@ -383,16 +387,17 @@ function drawMotisItinerary(itinerary: ItineraryResponse, isAfterLoaded = false)
   // Clear existing routes
   clearMotisRoutes();
 
-  // Create GeoJSON features for each leg
-  const routeFeatures: SimpleGeoJSONFeature[] = itinerary.legs.map((leg, index) => {
-    const coordinates = decodeMotisGeometry(leg.leg_geometry);
+  // One feature per single-floor run of each leg, so the active floor can be drawn solid while
+  // off-floor runs of the same walk are ghosted (see applyWalkLevelStyling).
+  const routeFeatures: SimpleGeoJSONFeature[] = itinerary.legs.flatMap((leg, index) => {
     const style = getTransitModeStyle(leg.mode, leg.route_color, leg.route_text_color);
-
-    return {
-      type: "Feature",
+    return splitLegByLevel(leg).map((segment) => ({
+      type: "Feature" as const,
       properties: {
         legIndex: index,
         mode: leg.mode,
+        level: segment.level,
+        floorSelectable: segment.floorSelectable,
         color: style.color,
         textColor: style.textColor,
         weight: style.weight,
@@ -405,9 +410,9 @@ function drawMotisItinerary(itinerary: ItineraryResponse, isAfterLoaded = false)
       },
       geometry: {
         type: "LineString",
-        coordinates: coordinates.map(({ lat, lon }) => [lon, lat]),
+        coordinates: segment.coordinates.map(({ lat, lon }) => [lon, lat]),
       },
-    };
+    }));
   });
 
   // Update the routes source
@@ -438,9 +443,34 @@ function drawMotisItinerary(itinerary: ItineraryResponse, isAfterLoaded = false)
     features: platformChangeFeatures,
   });
 
+  // Re-apply floor emphasis to the freshly drawn walk segments.
+  applyWalkLevelStyling(currentLevel.value);
+
   // Fit map to show entire route
   const bounds = calculateItineraryBounds(itinerary);
   fitBounds([bounds.minLon, bounds.maxLon], [bounds.minLat, bounds.maxLat]);
+}
+
+// Emphasise the part of the walk on the shown floor and ghost the rest. Runs on a non-selectable
+// level (outdoors, or a floor the selector can't show) always stay solid; with no floor selected
+// the whole walk is solid. See splitLegByLevel for how legs are cut into per-floor segments.
+function applyWalkLevelStyling(level: number | null) {
+  if (!map.value?.loaded()) return;
+
+  const onShownFloor: ExpressionSpecification =
+    level === null
+      ? ["literal", true]
+      : ["any", ["!", ["get", "floorSelectable"]], ["==", ["get", "level"], level]];
+
+  const walkOpacity: ExpressionSpecification = ["case", onShownFloor, ["get", "opacity"], 0.2];
+  const walkWidth: ExpressionSpecification = ["case", onShownFloor, ["get", "weight"], 2];
+  const highlightOpacity: ExpressionSpecification = ["case", onShownFloor, 0.9, 0.3];
+  const highlightWidth: ExpressionSpecification = ["case", onShownFloor, 8, 3];
+
+  map.value.setPaintProperty("motis-route-walk", "line-opacity", walkOpacity);
+  map.value.setPaintProperty("motis-route-walk", "line-width", walkWidth);
+  map.value.setPaintProperty("motis-route-highlighted", "line-opacity", highlightOpacity);
+  map.value.setPaintProperty("motis-route-highlighted", "line-width", highlightWidth);
 }
 
 /**

--- a/webclient/app/components/MotisTimelineWalkEdge.vue
+++ b/webclient/app/components/MotisTimelineWalkEdge.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { mdiAlert, mdiChevronDown } from "@mdi/js";
+import { mdiAlert, mdiChevronDown, mdiElevator, mdiStairs, mdiSwapVertical } from "@mdi/js";
 import type { components } from "~/api_types";
-import { formatDistance, formatDuration } from "~/utils/motis";
+import { formatDistance, formatDuration, legFloorSpan } from "~/utils/motis";
 
 type MotisLegResponse = components["schemas"]["MotisLegResponse"];
+type DirectionResponse = components["schemas"]["DirectionResponse"];
 
 const props = defineProps<{
   leg: MotisLegResponse;
@@ -13,8 +14,90 @@ const emit = defineEmits<{ toggle: []; selectStep: [stepIndex: number] }>();
 
 const { t } = useI18n({ useScope: "local" });
 
+// Maps each turn to a base-instruction i18n key; vertical moves are narrated separately below.
+const TURN_KEY: Record<DirectionResponse, string> = {
+  depart: "dir_depart",
+  continue: "dir_continue",
+  slightly_left: "dir_bear_left",
+  left: "dir_turn_left",
+  hard_left: "dir_sharp_left",
+  slightly_right: "dir_bear_right",
+  right: "dir_turn_right",
+  hard_right: "dir_sharp_right",
+  uturn_left: "dir_uturn",
+  uturn_right: "dir_uturn",
+  circle_clockwise: "dir_roundabout",
+  circle_counterclockwise: "dir_roundabout",
+  stairs: "dir_continue",
+  elevator: "dir_continue",
+};
+
 const steps = computed(() => props.leg.steps ?? []);
 const hasRestrictedStep = computed(() => steps.value.some((step) => step.access_restriction));
+
+// The floors this walk touches, so the collapsed leg can advertise vertical movement.
+const floorSpan = computed(() => legFloorSpan(props.leg));
+const floorBadge = computed<string | null>(() => {
+  const span = floorSpan.value;
+  if (span.length === 0) return null;
+  return `${formatLevel(span[0] ?? 0)} – ${formatLevel(span[span.length - 1] ?? 0)}`;
+});
+const verticalIcon = computed(() => {
+  if (steps.value.some((step) => step.relative_direction === "elevator")) return mdiElevator;
+  if (steps.value.some((step) => step.relative_direction === "stairs")) return mdiStairs;
+  return mdiSwapVertical;
+});
+
+// Motis reports the level per step (and, inconsistently, within a step) rather than as explicit
+// transitions, so a floor change shows up as the level a step lands on differing from the one
+// before it. We surface the reached level as-is — half-levels and all — without smoothing.
+const levelChanges = computed(() =>
+  steps.value.map((step, index) => {
+    const before = index > 0 ? (steps.value[index - 1]?.to_level ?? 0) : props.leg.from.level;
+    if (step.to_level === before) return null;
+    return { level: step.to_level, up: step.to_level > before };
+  })
+);
+
+// Whether a step heads up or down, so stairs and elevators can point the right way. Prefer a
+// within-step level change, then the change relative to the previous step.
+const verticalDirections = computed<(("up" | "down") | undefined)[]>(() =>
+  steps.value.map((step, index) => {
+    if (step.to_level !== step.from_level) return step.to_level > step.from_level ? "up" : "down";
+    const change = levelChanges.value[index];
+    return change ? (change.up ? "up" : "down") : undefined;
+  })
+);
+
+function formatLevel(level: number): string {
+  return String(level);
+}
+
+// Motis hands us a maneuver enum and (rarely, indoors) a street name, but no instruction text, so
+// we compose one — narrating stairs, elevators, and bare level changes with the floor they reach.
+function stepInstruction(index: number): string {
+  const step = steps.value[index];
+  if (!step) return t("dir_continue");
+  const direction = step.relative_direction;
+  const change = levelChanges.value[index];
+  const vertical = verticalDirections.value[index];
+
+  if (direction === "stairs" || direction === "elevator") {
+    const mode = direction === "stairs" ? "stairs" : "elevator";
+    if (change && vertical)
+      return t(`take_${mode}_${vertical}`, { level: formatLevel(change.level) });
+    return t(`take_${mode}`);
+  }
+  if (change && vertical && (direction === "continue" || direction === "depart")) {
+    return t(`go_${vertical}`, { level: formatLevel(change.level) });
+  }
+
+  const base = t(TURN_KEY[direction]);
+  if (!step.street_name) return base;
+  const connector =
+    direction === "continue" || direction === "depart" ? "on_street" : "onto_street";
+  return t(connector, { maneuver: base, street: step.street_name });
+}
 </script>
 
 <template>
@@ -32,6 +115,14 @@ const hasRestrictedStep = computed(() => steps.value.some((step) => step.access_
       >
         <MotisTransitModeIcon :mode="leg.mode" variant="inherit" class="h-4 w-4 flex-shrink-0" />
         <span v-if="leg.distance">{{ formatDistance(leg.distance) }}</span>
+        <span
+          v-if="floorBadge"
+          :title="t('touches_floors')"
+          class="text-indigo-700 dark:text-indigo-300 flex items-center gap-0.5 text-xs font-medium"
+        >
+          <MdiIcon :path="verticalIcon" :size="14" />
+          {{ floorBadge }}
+        </span>
         <span v-if="hasRestrictedStep" class="text-amber-700 dark:text-amber-300 flex items-center gap-1 text-xs">
           <MdiIcon :path="mdiAlert" :size="14" />
           {{ t("access_restriction_hint") }}
@@ -47,23 +138,20 @@ const hasRestrictedStep = computed(() => steps.value.some((step) => step.access_
       </button>
 
       <Collapsible :open="open">
-        <ol class="mt-1 space-y-2 border-l border-zinc-200 dark:border-zinc-700 pl-3">
+        <ol class="mt-1 space-y-2 pl-1">
           <li
             v-for="(step, s) in steps"
             :key="`step-${s}`"
             class="focusable -mx-2 flex cursor-pointer items-start gap-3 rounded px-2 py-1 hover:bg-zinc-100 dark:hover:bg-zinc-800"
             @click="emit('selectStep', s)"
           >
-            <WalkingDirectionIcon :direction="step.relative_direction" />
+            <WalkingDirectionIcon :direction="step.relative_direction" :vertical="verticalDirections[s]" />
             <div class="min-w-0 flex-grow text-sm">
               <div class="text-zinc-900 dark:text-zinc-50">
-                {{ step.street_name || t("continue") }}
+                {{ stepInstruction(s) }}
               </div>
               <div class="text-zinc-600 dark:text-zinc-300 flex flex-wrap items-center gap-2 text-xs">
                 {{ formatDistance(step.distance) }}
-                <span v-if="step.from_level !== step.to_level" class="text-zinc-500 dark:text-zinc-400">
-                  {{ t(step.to_level > step.from_level ? "level_up" : "level_down", { level: step.to_level }) }}
-                </span>
                 <span v-if="step.elevation_up" class="text-zinc-500 dark:text-zinc-400">↗ {{ step.elevation_up }}m</span>
                 <span v-if="step.elevation_down" class="text-zinc-500 dark:text-zinc-400">↘ {{ step.elevation_down }}m</span>
                 <span v-if="step.toll" class="text-orange-600 dark:text-orange-300">{{ t("toll") }}</span>
@@ -85,16 +173,52 @@ const hasRestrictedStep = computed(() => steps.value.some((step) => step.access_
 
 <i18n lang="yaml">
 de:
-  level_up: hoch auf Ebene {level}
-  level_down: runter auf Ebene {level}
-  continue: Weiter
+  touches_floors: berührte Ebenen
+  dir_depart: Losgehen
+  dir_continue: Weiter
+  dir_bear_left: Leicht links halten
+  dir_turn_left: Links abbiegen
+  dir_sharp_left: Scharf links abbiegen
+  dir_bear_right: Leicht rechts halten
+  dir_turn_right: Rechts abbiegen
+  dir_sharp_right: Scharf rechts abbiegen
+  dir_uturn: Wenden
+  dir_roundabout: In den Kreisverkehr
+  on_street: "{maneuver} auf {street}"
+  onto_street: "{maneuver} auf {street}"
+  take_stairs: Treppe nehmen
+  take_stairs_up: Treppe hoch auf Ebene {level}
+  take_stairs_down: Treppe runter auf Ebene {level}
+  take_elevator: Aufzug nehmen
+  take_elevator_up: Aufzug hoch auf Ebene {level}
+  take_elevator_down: Aufzug runter auf Ebene {level}
+  go_up: Hoch auf Ebene {level}
+  go_down: Runter auf Ebene {level}
   toll: Maut
   access_restriction: Eingeschränkter Zugang
   access_restriction_hint: enthält Zugangsbeschränkungen
 en:
-  level_up: up to level {level}
-  level_down: down to level {level}
-  continue: Continue
+  touches_floors: floors touched
+  dir_depart: Start walking
+  dir_continue: Continue
+  dir_bear_left: Bear left
+  dir_turn_left: Turn left
+  dir_sharp_left: Turn sharply left
+  dir_bear_right: Bear right
+  dir_turn_right: Turn right
+  dir_sharp_right: Turn sharply right
+  dir_uturn: Turn around
+  dir_roundabout: Take the roundabout
+  on_street: "{maneuver} on {street}"
+  onto_street: "{maneuver} onto {street}"
+  take_stairs: Take the stairs
+  take_stairs_up: Take the stairs up to level {level}
+  take_stairs_down: Take the stairs down to level {level}
+  take_elevator: Take the elevator
+  take_elevator_up: Take the elevator up to level {level}
+  take_elevator_down: Take the elevator down to level {level}
+  go_up: Go up to level {level}
+  go_down: Go down to level {level}
   toll: Toll
   access_restriction: Restricted access
   access_restriction_hint: contains access restrictions

--- a/webclient/app/components/MotisTimelineWalkEdge.vue
+++ b/webclient/app/components/MotisTimelineWalkEdge.vue
@@ -40,7 +40,7 @@ const floorSpan = computed(() => legFloorSpan(props.leg));
 const floorBadge = computed<string | null>(() => {
   const span = floorSpan.value;
   if (span.length === 0) return null;
-  return `${formatLevel(span[0] ?? 0)} – ${formatLevel(span[span.length - 1] ?? 0)}`;
+  return `${formatLevel(span[0] ?? 0)} - ${formatLevel(span[span.length - 1] ?? 0)}`;
 });
 const verticalIcon = computed(() => {
   if (steps.value.some((step) => step.relative_direction === "elevator")) return mdiElevator;
@@ -50,7 +50,7 @@ const verticalIcon = computed(() => {
 
 // Motis reports the level per step (and, inconsistently, within a step) rather than as explicit
 // transitions, so a floor change shows up as the level a step lands on differing from the one
-// before it. We surface the reached level as-is — half-levels and all — without smoothing.
+// before it. We surface the reached level as-is - half-levels and all - without smoothing.
 const levelChanges = computed(() =>
   steps.value.map((step, index) => {
     const before = index > 0 ? (steps.value[index - 1]?.to_level ?? 0) : props.leg.from.level;
@@ -74,7 +74,7 @@ function formatLevel(level: number): string {
 }
 
 // Motis hands us a maneuver enum and (rarely, indoors) a street name, but no instruction text, so
-// we compose one — narrating stairs, elevators, and bare level changes with the floor they reach.
+// we compose one - narrating stairs, elevators, and bare level changes with the floor they reach.
 function stepInstruction(index: number): string {
   const step = steps.value[index];
   if (!step) return t("dir_continue");

--- a/webclient/app/components/WalkingDirectionIcon.vue
+++ b/webclient/app/components/WalkingDirectionIcon.vue
@@ -9,12 +9,30 @@ import {
   mdiAxisXRotateClockwise,
   mdiAxisXRotateCounterclockwise,
   mdiElevator,
+  mdiElevatorDown,
+  mdiElevatorUp,
   mdiPlay,
+  mdiStairs,
+  mdiStairsDown,
+  mdiStairsUp,
 } from "@mdi/js";
 import type { components } from "~/api_types";
 
 type DirectionResponse = components["schemas"]["DirectionResponse"];
-defineProps<{ direction: DirectionResponse }>();
+// `vertical` carries the sense of a floor change (derived from the step levels, which the
+// direction enum alone does not encode), so stairs and elevators can point up or down.
+const props = defineProps<{ direction: DirectionResponse; vertical?: "up" | "down" }>();
+
+const stairsIcon = computed(() =>
+  props.vertical === "up" ? mdiStairsUp : props.vertical === "down" ? mdiStairsDown : mdiStairs
+);
+const elevatorIcon = computed(() =>
+  props.vertical === "up"
+    ? mdiElevatorUp
+    : props.vertical === "down"
+      ? mdiElevatorDown
+      : mdiElevator
+);
 </script>
 
 <template>
@@ -44,8 +62,8 @@ defineProps<{ direction: DirectionResponse }>();
     <MdiIcon v-else-if="direction === 'circle_counterclockwise'" :path="mdiAxisXRotateCounterclockwise" :size="16" />
 
     <!-- Vertical movement -->
-    <MdiIcon v-else-if="direction === 'stairs'" :path="mdiArrowUp" :size="16" />
-    <MdiIcon v-else-if="direction === 'elevator'" :path="mdiElevator" :size="16" />
+    <MdiIcon v-else-if="direction === 'stairs'" :path="stairsIcon" :size="16" />
+    <MdiIcon v-else-if="direction === 'elevator'" :path="elevatorIcon" :size="16" />
 
     <!-- Fallback -->
     <span v-else class="text-xs font-bold">{{ (direction as string).slice(0, 2).toUpperCase() }}</span>

--- a/webclient/app/utils/motis.ts
+++ b/webclient/app/utils/motis.ts
@@ -1,5 +1,6 @@
 import { decode } from "@googlemaps/polyline-codec";
 import type { components } from "~/api_types";
+import { SELECTABLE_LEVELS } from "~/composables/mapLayers";
 
 type ItineraryResponse = components["schemas"]["ItineraryResponse"];
 type ModeResponse = components["schemas"]["ModeResponse"];
@@ -157,6 +158,64 @@ export function extractPlatformChangeMarkers(itinerary: ItineraryResponse): Plat
   }
 
   return markers;
+}
+
+// A segment only ghosts with the floor selector when it sits on a floor the selector can
+// represent. Motis reports level 0 for outdoor geometry too, so level 0 always renders solid.
+export function isFloorSelectableLevel(level: number): boolean {
+  return level !== 0 && SELECTABLE_LEVELS.includes(level);
+}
+
+/** A contiguous run of a leg's geometry that stays on a single OSM level. */
+export interface LegLevelSegment {
+  readonly level: number;
+  // Whether this run participates in floor-selector ghosting (see isFloorSelectableLevel).
+  readonly floorSelectable: boolean;
+  readonly coordinates: Coordinate[];
+}
+
+/**
+ * Split a leg's geometry into runs that each stay on one OSM level, so the map can render
+ * the part on the active floor solid and ghost the rest. Self-navigated legs are cut along
+ * their steps' `from_level`; legs without usable step geometry stay a single run.
+ */
+export function splitLegByLevel(leg: MotisLegResponse): LegLevelSegment[] {
+  const steps = leg.steps ?? [];
+  const segments: LegLevelSegment[] = [];
+  for (const step of steps) {
+    const coordinates = decodeMotisGeometry(step.polyline);
+    if (coordinates.length === 0) continue;
+    const level = step.from_level;
+    const last = segments[segments.length - 1];
+    // Steps on the same level draw as one line; the shared vertex would otherwise double up.
+    if (last && last.level === level) last.coordinates.push(...coordinates.slice(1));
+    else segments.push({ level, floorSelectable: isFloorSelectableLevel(level), coordinates });
+  }
+  if (segments.length > 0) return segments;
+
+  const level = leg.from.level;
+  return [
+    {
+      level,
+      floorSelectable: isFloorSelectableLevel(level),
+      coordinates: decodeMotisGeometry(leg.leg_geometry),
+    },
+  ];
+}
+
+/**
+ * The floors a self-navigated leg touches (endpoints and every step), lowest first, or an
+ * empty array when the leg never leaves a single floor. Lets the list flag vertical movement
+ * on a collapsed leg without expanding it.
+ */
+export function legFloorSpan(leg: MotisLegResponse): number[] {
+  const levels = new Set<number>([leg.from.level, leg.to.level]);
+  for (const step of leg.steps ?? []) {
+    levels.add(step.from_level);
+    levels.add(step.to_level);
+  }
+  if (levels.size <= 1) return [];
+  return [...levels].sort((a, b) => a - b);
 }
 
 /**

--- a/webclient/test/motis.test.ts
+++ b/webclient/test/motis.test.ts
@@ -1,7 +1,14 @@
 import { encode } from "@googlemaps/polyline-codec";
 import { describe, expect, it } from "vitest";
 import type { components } from "../app/api_types";
-import { buildItineraryTimeline, calculateStepBounds, delayMinutes } from "../app/utils/motis";
+import {
+  buildItineraryTimeline,
+  calculateStepBounds,
+  delayMinutes,
+  isFloorSelectableLevel,
+  legFloorSpan,
+  splitLegByLevel,
+} from "../app/utils/motis";
 import { floorLevelForSelection } from "../app/utils/motisLevels";
 
 type MotisLegResponse = components["schemas"]["MotisLegResponse"];
@@ -81,6 +88,109 @@ describe("floorLevelForSelection", () => {
     const basementStep = step(-2, -3);
     const leg = walkLeg({ fromLevel: -2, toLevel: -3, steps: [basementStep] });
     expect(floorLevelForSelection(leg, basementStep)).toBeNull();
+  });
+});
+
+describe("isFloorSelectableLevel", () => {
+  it("treats ground level as non-selectable, since Motis reports 0 outdoors too", () => {
+    expect(isFloorSelectableLevel(0)).toBe(false);
+  });
+
+  it("selects levels the floor selector can represent", () => {
+    expect(isFloorSelectableLevel(1)).toBe(true);
+    expect(isFloorSelectableLevel(-1)).toBe(true);
+  });
+
+  it("rejects half-levels and levels outside the selector's range", () => {
+    expect(isFloorSelectableLevel(1.5)).toBe(false);
+    expect(isFloorSelectableLevel(-2)).toBe(false);
+  });
+});
+
+describe("splitLegByLevel", () => {
+  const line = (coords: [number, number][]) => encode(coords, 6);
+
+  it("keeps a step-less leg as one run on its starting level", () => {
+    const leg = walkLeg({ fromLevel: 1, toLevel: 1 });
+    leg.leg_geometry = line([
+      [48.1, 11.6],
+      [48.2, 11.5],
+    ]);
+    const [segment, ...rest] = splitLegByLevel(leg);
+    expect(rest).toHaveLength(0);
+    expect(segment).toMatchObject({ level: 1, floorSelectable: true });
+    expect(segment?.coordinates).toHaveLength(2);
+  });
+
+  it("cuts a leg into one run per level and merges the shared vertex", () => {
+    const leg = walkLeg({
+      fromLevel: 0,
+      toLevel: 1,
+      steps: [
+        step(
+          0,
+          0,
+          line([
+            [48.1, 11.6],
+            [48.11, 11.6],
+          ])
+        ),
+        step(
+          0,
+          1,
+          line([
+            [48.11, 11.6],
+            [48.12, 11.6],
+          ])
+        ),
+        step(
+          1,
+          1,
+          line([
+            [48.12, 11.6],
+            [48.13, 11.6],
+          ])
+        ),
+      ],
+    });
+    const segments = splitLegByLevel(leg);
+    expect(segments.map((s) => s.level)).toEqual([0, 1]);
+    // The transitioning step departs from level 0, so its geometry joins the level-0 run: two
+    // steps merge there (2 + 1 after dropping the shared vertex), leaving the level-1 step alone.
+    expect(segments[0]?.coordinates).toHaveLength(3);
+    expect(segments[1]?.coordinates).toHaveLength(2);
+  });
+
+  it("skips steps whose polyline cannot be decoded", () => {
+    const leg = walkLeg({
+      fromLevel: 1,
+      toLevel: 1,
+      steps: [
+        step(1, 1, ""),
+        step(
+          1,
+          1,
+          line([
+            [48.1, 11.6],
+            [48.2, 11.5],
+          ])
+        ),
+      ],
+    });
+    const segments = splitLegByLevel(leg);
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.coordinates).toHaveLength(2);
+  });
+});
+
+describe("legFloorSpan", () => {
+  it("is empty for a leg that never leaves one floor", () => {
+    expect(legFloorSpan(walkLeg({ fromLevel: 2, toLevel: 2, steps: [step(2, 2)] }))).toEqual([]);
+  });
+
+  it("lists the touched floors low to high", () => {
+    const leg = walkLeg({ fromLevel: 0, toLevel: 2, steps: [step(0, 1), step(1, 2)] });
+    expect(legFloorSpan(leg)).toEqual([0, 1, 2]);
   });
 });
 


### PR DESCRIPTION
Ghost off-floor parts of walking legs on the indoor map and narrate each foot step (turns, stairs/elevators, and the level it reaches) instead of a bare "Continue".

🤖 Generated with [Claude Code](https://claude.com/claude-code)