### PR TITLE
fix(webclient): migrate styleimagemissing to setMissingStyleImageResolver

### DIFF
--- a/webclient/app/composables/useEventMarkers.ts
+++ b/webclient/app/composables/useEventMarkers.ts
@@ -4,7 +4,6 @@ import type {
   GeoJSONFeature,
   Map as MapLibreMap,
   MapSourceDataEvent,
-  MapStyleImageMissingEvent,
   SymbolLayerSpecification,
 } from "maplibre-gl";
 import type { MaybeRefOrGetter, Ref } from "vue";
@@ -19,7 +18,7 @@ function layerIdFor(source: EventSourceId): string {
   return `${source}-symbols`;
 }
 
-// Per-event photos register on demand; see `styleimagemissing`.
+// Per-event photos register on demand via `setMissingStyleImageResolver`.
 const MARKER_LAYOUT = {
   "icon-image": ["concat", "event-", ["to-string", ["id"]]],
   "icon-size": ["interpolate", ["linear"], ["zoom"], 14, 0.6, 16, 1.2, 19, 1.7],
@@ -299,12 +298,14 @@ export function useEventMarkers(
       }
     };
 
-    const onStyleImageMissing = (event: MapStyleImageMissingEvent) => {
-      if (event.id.startsWith("event-")) void ensureImage(event.id);
-    };
+    // `setMissingStyleImageResolver` is awaited by MapLibre, so async image loading now works on
+    // the primary path. When the resolver fires before the tile's features are queryable it returns
+    // without adding the image; the miss is then cached, so `onSourceData` re-drives registration
+    // once the tile settles.
+    target.setMissingStyleImageResolver(async (id) => {
+      if (id.startsWith("event-")) await ensureImage(id);
+    });
 
-    // `styleimagemissing` fires once per id and the miss is cached, so one raised before the tile's
-    // features are queryable would never recover; re-drive registration when a feed's data settles.
     const onSourceData = (event: MapSourceDataEvent) => {
       if (!event.isSourceLoaded || !sources.some((source) => source === event.sourceId)) return;
       for (const source of sources) {
@@ -344,7 +345,6 @@ export function useEventMarkers(
       }
       applyExpiry(target);
       applyVisibility(target);
-      target.on("styleimagemissing", onStyleImageMissing);
       target.on("sourcedata", onSourceData);
     };
     if (target.loaded()) attach();
@@ -352,7 +352,7 @@ export function useEventMarkers(
 
     onCleanup(() => {
       target.off("load", attach);
-      target.off("styleimagemissing", onStyleImageMissing);
+      target.setMissingStyleImageResolver(null);
       target.off("sourcedata", onSourceData);
       for (const source of sources) {
         const layerId = layerIdFor(source);

--- a/webclient/app/composables/useEventMarkers.ts
+++ b/webclient/app/composables/useEventMarkers.ts
@@ -298,10 +298,6 @@ export function useEventMarkers(
       }
     };
 
-    // `setMissingStyleImageResolver` is awaited by MapLibre, so async image loading now works on
-    // the primary path. When the resolver fires before the tile's features are queryable it returns
-    // without adding the image; the miss is then cached, so `onSourceData` re-drives registration
-    // once the tile settles.
     target.setMissingStyleImageResolver(async (id) => {
       if (id.startsWith("event-")) await ensureImage(id);
     });


### PR DESCRIPTION
`styleimagemissing` is now notify-only in MapLibre GL JS 6; use `Map.setMissingStyleImageResolver` (async-capable) for on-demand image supply instead. Closes no issue — this is a required API migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)