### PR TITLE
chore(data): 1 property edit

### DIFF
--- a/data/sources/names.csv
+++ b/data/sources/names.csv
@@ -18,6 +18,7 @@ id,name,short_name,arch_name
 0206.EG.003,Besprechungsraum Studentische Vertretung / SV,,
 0501.05.170B,Café NACHHOELZER,NACHHOELZER,
 0507.01.767,Besprechungsraum,,
+2410,"Heßstrasse 134, Munich Institute of Robotics and Machine Intelligence (MIRMI)",MIRMI,
 2907.01.130,Fachschaft Lehrertum/Lehramt/Educational Sciences,Lehramt,
 0501.05.131,Vorhoelzer-Forum Dachterasse,,
 0503.EG.347,Archiv,,


### PR DESCRIPTION
<sub>Batched edits</sub>

## Additional context:
> MSRM heißt mittlerweile:
Munich Institute of Robotics and Machine Intelligence (MIRMI)

The following property edits were made:
| entry | edit |
| ---   | ---  |
| [`2410`](https://nav.tum.de/view/2410) | name: `Heßstrasse 134, Munich Institute of Robotics and Machine Intelligence (MIRMI)`, short_name: `MIRMI` |
